### PR TITLE
Change git issue template location

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -33,8 +33,8 @@ stryker4s x.x.x
 ```
 
 ### Your Environment
-| software         | version(s)
-| ---------------- | -------  
-| Scala version | 
-| Build tool & version              | 
-| Operating System |
+| software             | version(s) |
+| -------------------- | ---------- |
+| Scala version        |            |
+| Build tool & version |            | 
+| Operating System     |            |


### PR DESCRIPTION
Change the location so it will be automatically picked up when you create an issue. Was annoying me i had to either pick the template or click a small button to get a clean one. Now you can just empty it.