### PR TITLE
Add Better code badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build status](https://img.shields.io/travis/stryker-mutator/stryker4s/master.svg)](https://travis-ci.org/stryker-mutator/stryker4s)
 [![Gitter](https://badges.gitter.im/stryker-mutator/stryker.svg)](https://gitter.im/stryker-mutator/stryker4s?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![BCH compliance](https://bettercodehub.com/edge/badge/stryker-mutator/stryker4s?branch=master)](https://bettercodehub.com/)
 
 # Stryker4s
 


### PR DESCRIPTION
I've added `stryker4s` to the `bettercodehub` so we can get some general static code analysis. It should be triggered when a new branch is build/merged i think. If not we can look for a replacement that does so. 

Alternative could be `Codecov` for example