### PR TITLE
Add new mutators

### DIFF
--- a/core/src/main/scala/stryker4s/Stryker4s.scala
+++ b/core/src/main/scala/stryker4s/Stryker4s.scala
@@ -7,9 +7,9 @@ import stryker4s.run.MutantRunner
 import stryker4s.run.report.MutantRunReporter
 
 class Stryker4s(fileCollector: SourceCollector,
-               mutator: Mutator,
-               runner: MutantRunner,
-               reporter: MutantRunReporter)(implicit config: Config) {
+                mutator: Mutator,
+                runner: MutantRunner,
+                reporter: MutantRunReporter)(implicit config: Config) {
 
   def run() = {
     val files = fileCollector.collectFiles()

--- a/core/src/main/scala/stryker4s/model/MutantRunResult.scala
+++ b/core/src/main/scala/stryker4s/model/MutantRunResult.scala
@@ -5,7 +5,9 @@ import java.nio.file.Path
 import scala.concurrent.TimeoutException
 import scala.concurrent.duration.Duration
 
-case class MutantRunResults(results: Iterable[MutantRunResult], mutationScore: Double, duration: Duration)
+case class MutantRunResults(results: Iterable[MutantRunResult],
+                            mutationScore: Double,
+                            duration: Duration)
 
 /** The base result type of a mutant run.
   * Extends Product with Serializable to clean up the type signature, as all subtypes are case classes

--- a/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
+++ b/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
@@ -25,8 +25,16 @@ class MutantMatcher {
   }
 
   def matchMethods(): PartialFunction[Tree, FoundMutant] = {
-    case Filter(orig)    => FoundMutant(orig, FilterNot)
-    case FilterNot(orig) => FoundMutant(orig, Filter)
+    case Filter(orig)      => FoundMutant(orig, FilterNot)
+    case FilterNot(orig)   => FoundMutant(orig, Filter)
+    case Exists(orig)      => FoundMutant(orig, ForAll)
+    case ForAll(orig)      => FoundMutant(orig, Exists)
+    case IsEmpty(orig)     => FoundMutant(orig, NonEmpty)
+    case NonEmpty(orig)    => FoundMutant(orig, IsEmpty)
+    case IndexOf(orig)     => FoundMutant(orig, LastIndexOf)
+    case LastIndexOf(orig) => FoundMutant(orig, IndexOf)
+    case Max(orig)         => FoundMutant(orig, Min)
+    case Min(orig)         => FoundMutant(orig, Max)
   }
 
   def matchLiterals(): PartialFunction[Tree, FoundMutant] = {

--- a/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
+++ b/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
@@ -38,10 +38,11 @@ class MutantMatcher {
   }
 
   def matchLiterals(): PartialFunction[Tree, FoundMutant] = {
-    case True(orig)           => FoundMutant(orig, False)
-    case False(orig)          => FoundMutant(orig, True)
-    case EmptyString(orig)    => FoundMutant(orig, StrykerWasHereString)
-    case NonEmptyString(orig) => FoundMutant(orig, EmptyString)
+    case True(orig)                => FoundMutant(orig, False)
+    case False(orig)               => FoundMutant(orig, True)
+    case EmptyString(orig)         => FoundMutant(orig, StrykerWasHereString)
+    case NonEmptyString(orig)      => FoundMutant(orig, EmptyString)
+    case StringInterpolation(orig) => FoundMutant(orig, EmptyStringInterpolation)
   }
 
 }

--- a/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
+++ b/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
@@ -11,7 +11,7 @@ class MutantMatcher {
   def allMatchers(): PartialFunction[Tree, FoundMutant] =
     matchConditionals() orElse
       matchMethods() orElse
-      matchBooleanSubstitutions()
+      matchLiterals()
 
   def matchConditionals(): PartialFunction[Tree, FoundMutant] = {
     case GreaterThanEqualTo(orig) => FoundMutant(orig, GreaterThan, LesserThan, EqualTo)
@@ -20,6 +20,8 @@ class MutantMatcher {
     case LesserThan(orig)         => FoundMutant(orig, LesserThanEqualTo, GreaterThan, EqualTo)
     case EqualTo(orig)            => FoundMutant(orig, NotEqualTo)
     case NotEqualTo(orig)         => FoundMutant(orig, EqualTo)
+    case And(orig)                => FoundMutant(orig, Or)
+    case Or(orig)                 => FoundMutant(orig, And)
   }
 
   def matchMethods(): PartialFunction[Tree, FoundMutant] = {
@@ -27,7 +29,7 @@ class MutantMatcher {
     case FilterNot(orig) => FoundMutant(orig, Filter)
   }
 
-  def matchBooleanSubstitutions(): PartialFunction[Tree, FoundMutant] = {
+  def matchLiterals(): PartialFunction[Tree, FoundMutant] = {
     case True(orig)  => FoundMutant(orig, False)
     case False(orig) => FoundMutant(orig, True)
   }

--- a/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
+++ b/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
@@ -30,8 +30,10 @@ class MutantMatcher {
   }
 
   def matchLiterals(): PartialFunction[Tree, FoundMutant] = {
-    case True(orig)  => FoundMutant(orig, False)
-    case False(orig) => FoundMutant(orig, True)
+    case True(orig)           => FoundMutant(orig, False)
+    case False(orig)          => FoundMutant(orig, True)
+    case EmptyString(orig)    => FoundMutant(orig, StrykerWasHereString)
+    case NonEmptyString(orig) => FoundMutant(orig, EmptyString)
   }
 
 }

--- a/core/src/main/scala/stryker4s/run/ProcessMutantRunner.scala
+++ b/core/src/main/scala/stryker4s/run/ProcessMutantRunner.scala
@@ -13,7 +13,7 @@ import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
 class ProcessMutantRunner(process: ProcessRunner)(implicit config: Config)
-  extends MutantRunner
+    extends MutantRunner
     with Logging {
 
   override def apply(files: Iterable[MutatedFile]): MutantRunResults = {
@@ -57,12 +57,13 @@ class ProcessMutantRunner(process: ProcessRunner)(implicit config: Config)
     info(s"Starting test-run $id...")
     process("sbt test", workingDir, ("ACTIVE_MUTATION", id.toString)) match {
       case Success(exitCode) if exitCode == 0 => Survived(mutant, subPath)
-      case Success(exitCode) => Killed(exitCode, mutant, subPath)
-      case Failure(exc: TimeoutException) => TimedOut(exc, mutant, subPath)
+      case Success(exitCode)                  => Killed(exitCode, mutant, subPath)
+      case Failure(exc: TimeoutException)     => TimedOut(exc, mutant, subPath)
     }
   }
 
-  private[this] def calculateMutationScore(totalMutants: Double, detectedMutants: Double): Double = {
+  private[this] def calculateMutationScore(totalMutants: Double,
+                                           detectedMutants: Double): Double = {
     val mutationScore = detectedMutants / totalMutants * 100
     BigDecimal(mutationScore).setScale(2, BigDecimal.RoundingMode.HALF_UP).toDouble
   }

--- a/core/src/test/scala/stryker4s/config/ConfigReaderTest.scala
+++ b/core/src/test/scala/stryker4s/config/ConfigReaderTest.scala
@@ -29,8 +29,10 @@ class ConfigReaderTest extends Stryker4sSuite {
 
       val result = ConfigReader.readConfig(confPath)
 
-      val expected = Config(files = Seq("bar/src/main/**/*.scala", "foo/src/main/**/*.scala", "!excluded/file.scala"),
-                            baseDir = File("/tmp/project"))
+      val expected = Config(
+        files = Seq("bar/src/main/**/*.scala", "foo/src/main/**/*.scala", "!excluded/file.scala"),
+        baseDir = File("/tmp/project")
+      )
       result should equal(expected)
     }
   }

--- a/core/src/test/scala/stryker4s/mutants/applymutants/MatchBuilderTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/applymutants/MatchBuilderTest.scala
@@ -6,6 +6,7 @@ import stryker4s.model.{Mutant, SourceTransformations, TransformedMutants}
 import stryker4s.scalatest.TreeEquality
 
 import scala.meta._
+import scala.meta.contrib._
 
 class MatchBuilderTest extends Stryker4sSuite with TreeEquality {
   private val activeMutationExpr: Term.Apply = {
@@ -36,13 +37,12 @@ class MatchBuilderTest extends Stryker4sSuite with TreeEquality {
   describe("buildNewSource") {
     it("should build a new tree with a case match in place of the 15 > 14 statement") {
       // Arrange
-      val ids = Iterator.from(0)
+      implicit val ids: Iterator[Int] = Iterator.from(0)
       val source = "class Foo { def bar: Boolean = 15 > 14 }".parse[Source].get
-      val origStatement = source.find(q">").value.topStatement()
-      val mutants = List(q"15 < 14", q"15 == 14")
-        .map(Mutant(ids.next(), origStatement, _))
+
+      val transformed = toTransformed(source, q">", q"<", q"==")
       val transStatements =
-        SourceTransformations(source, List(TransformedMutants(origStatement, mutants)))
+        SourceTransformations(source, List(transformed))
       val sut = new MatchBuilder
 
       // Act
@@ -65,21 +65,12 @@ class MatchBuilderTest extends Stryker4sSuite with TreeEquality {
 
     it("should build a tree with multiple cases out of multiple transformedStatements") {
       // Arrange
-      val ids = Iterator.from(0)
+      implicit val ids: Iterator[Int] = Iterator.from(0)
       val source = "class Foo { def bar: Boolean = 15 > 14 && 14 >= 13 }".parse[Source].get
+      val firstTrans = toTransformed(source, q">", q"<", q"==")
+      val secondTrans = toTransformed(source, q">=", q">", q"==")
 
-      val firstOrig = source.find(q">").value.topStatement()
-      val firstMutants = List(q"15 < 14", q"15 == 14")
-        .map(Mutant(ids.next(), firstOrig, _))
-      val firstTrans = TransformedMutants(firstOrig, firstMutants)
-
-      val secondOrig = source.find(q">=").value.topStatement()
-      val secondMutants = List(q"14 > 13", q"14 == 13")
-        .map(Mutant(ids.next(), firstOrig, _))
-      val secondTrans = TransformedMutants(secondOrig, secondMutants)
-
-      val transformedStatements =
-        SourceTransformations(source, List(firstTrans, secondTrans))
+      val transformedStatements = SourceTransformations(source, List(firstTrans, secondTrans))
       val sut = new MatchBuilder
 
       // Act
@@ -106,6 +97,45 @@ class MatchBuilderTest extends Stryker4sSuite with TreeEquality {
           |}""".stripMargin.parse[Source].get
       result should equal(expected)
     }
+
+    it("should build a new tree out of a single statement with 3 mutants") {
+      // Arrange
+      implicit val ids: Iterator[Int] = Iterator.from(0)
+      val source = """class Foo { def foo = "foo" == "" }""".parse[Source].get
+
+      val firstTransformed = toTransformed(source, Lit.String("foo"), Lit.String(""))
+      val secondTransformed = toTransformed(source, q"==", q"!=")
+      val thirdTransformed = toTransformed(source, Lit.String(""), Lit.String("Stryker was here!"))
+
+      val transformedStatements =
+        SourceTransformations(source, List(firstTransformed, secondTransformed, thirdTransformed))
+      val sut = new MatchBuilder
+
+      // Act
+      val result = sut.buildNewSource(transformedStatements)
+
+      // Assert
+      val expected =
+        """class Foo {
+          |  def foo = sys.env.get("ACTIVE_MUTATION") match {
+          |    case Some("0") =>
+          |      "" == ""
+          |    case _ =>
+          |      sys.env.get("ACTIVE_MUTATION") match {
+          |        case Some("1") =>
+          |          "foo" != ""
+          |        case _ =>
+          |          sys.env.get("ACTIVE_MUTATION") match {
+          |            case Some("2") =>
+          |              "foo" == "Stryker was here!"
+          |            case _ =>
+          |              "foo" == ""
+          |          }
+          |      }
+          |  }
+          |}""".stripMargin.parse[Source].get
+      result should equal(expected)
+    }
   }
 
   /** Little helper method to get a Some(*string*) AST out of an Int
@@ -115,4 +145,16 @@ class MatchBuilderTest extends Stryker4sSuite with TreeEquality {
     p"Some($stringTerm)"
   }
 
+  /** Helper method to create a [[stryker4s.model.TransformedMutants]] out of a statement and it's mutants
+    */
+  private def toTransformed(source: Source, origStatement: Term, mutants: Term*)(
+      implicit ids: Iterator[Int]): TransformedMutants = {
+    val topStatement = source.find(origStatement).value.topStatement()
+    val mutant = mutants
+      .map(m => topStatement transformOnce { case orig if orig.isEqual(origStatement) => m })
+      .map(m => Mutant(ids.next(), topStatement, m.asInstanceOf[Term]))
+      .toList
+
+    TransformedMutants(topStatement, mutant)
+  }
 }

--- a/core/src/test/scala/stryker4s/mutants/findmutants/FileCollectorTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/FileCollectorTest.scala
@@ -35,7 +35,7 @@ class FileCollectorTest extends Stryker4sSuite {
         val results = sut.collectFiles()
 
         results should have size 2
-        results should contain only(basePath / "someFile.scala", basePath / "secondFile.scala")
+        results should contain only (basePath / "someFile.scala", basePath / "secondFile.scala")
       }
 
       it("should find matching files with custom config match pattern") {
@@ -67,7 +67,7 @@ class FileCollectorTest extends Stryker4sSuite {
         val results = sut.collectFiles()
 
         results should have size 2
-        results should contain only(basePath / "someFile.scala", basePath / "secondFile.scala")
+        results should contain only (basePath / "someFile.scala", basePath / "secondFile.scala")
       }
 
       it("should only add a glob once even when it matches twice") {
@@ -78,13 +78,15 @@ class FileCollectorTest extends Stryker4sSuite {
         val results = sut.collectFiles()
 
         results should have size 2
-        results should contain only(basePath / "someFile.scala", basePath / "secondFile.scala")
+        results should contain only (basePath / "someFile.scala", basePath / "secondFile.scala")
       }
 
       it("should not find a file twice when the patterns match on the same file twice") {
-        implicit val config: Config = Config(
-          files = Seq("**/someFile.scala", "**/secondFile.scala", "!**/*.scala", "!**/someFile.scala"),
-          baseDir = filledDirPath)
+        implicit val config: Config = Config(files = Seq("**/someFile.scala",
+                                                         "**/secondFile.scala",
+                                                         "!**/*.scala",
+                                                         "!**/someFile.scala"),
+                                             baseDir = filledDirPath)
 
         val sut = new FileCollector()
 
@@ -96,7 +98,8 @@ class FileCollectorTest extends Stryker4sSuite {
       it("Should exclude the file specified in the excluded files config") {
         implicit val config: Config = Config(
           files = Seq("**/someFile.scala", "**/secondFile.scala", "!**/someFile.scala"),
-          baseDir = filledDirPath)
+          baseDir = filledDirPath
+        )
 
         val sut = new FileCollector()
 
@@ -107,9 +110,11 @@ class FileCollectorTest extends Stryker4sSuite {
       }
 
       it("Should exclude all files specified in the excluded files config") {
-        implicit val config: Config = Config(
-          files = Seq("**/someFile.scala", "**/secondFile.scala", "!**/someFile.scala", "!**/secondFile.scala"),
-          baseDir = filledDirPath)
+        implicit val config: Config = Config(files = Seq("**/someFile.scala",
+                                                         "**/secondFile.scala",
+                                                         "!**/someFile.scala",
+                                                         "!**/secondFile.scala"),
+                                             baseDir = filledDirPath)
 
         val sut = new FileCollector()
 
@@ -121,7 +126,8 @@ class FileCollectorTest extends Stryker4sSuite {
       it("Should exclude all files based on a wildcard") {
         implicit val config: Config = Config(
           files = Seq("**/someFile.scala", "**/secondFile.scala", "!**/*.scala"),
-          baseDir = filledDirPath)
+          baseDir = filledDirPath
+        )
 
         val sut = new FileCollector()
 
@@ -133,14 +139,15 @@ class FileCollectorTest extends Stryker4sSuite {
       it("Should not exclude a non existing file") {
         implicit val config: Config = Config(
           files = Seq("**/someFile.scala", "**/secondFile.scala", "!**/nonExistingFile.scala"),
-          baseDir = filledDirPath)
+          baseDir = filledDirPath
+        )
 
         val sut = new FileCollector()
 
         val results = sut.collectFiles()
 
         results should have size 2
-        results should contain only(basePath / "someFile.scala", basePath / "secondFile.scala")
+        results should contain only (basePath / "someFile.scala", basePath / "secondFile.scala")
       }
     }
   }

--- a/core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala
@@ -71,11 +71,16 @@ class MutantFinderTest extends Stryker4sSuite with TreeEquality {
 
       val result = sut.findMutants(source)
 
-      val head = result.loneElement
+      val head = result.head
       head.originalStatement should equal(q"==")
-      val loneMutant = head.mutants.loneElement
-      loneMutant.original should equal(q"==")
-      loneMutant.mutated should equal(q"!=")
+      val firstMutant = head.mutants.loneElement
+      firstMutant.original should equal(q"==")
+      firstMutant.mutated should equal(q"!=")
+
+      val secondMutant = result(1).mutants.loneElement
+      result(1).originalStatement should equal(Lit.String("foobar"))
+      secondMutant.original should equal(Lit.String("foobar"))
+      secondMutant.mutated should equal(Lit.String(""))
     }
   }
 
@@ -87,11 +92,17 @@ class MutantFinderTest extends Stryker4sSuite with TreeEquality {
       val result = sut.mutantsInFile(file)
 
       result.source.children should not be empty
-      val head = result.mutants.loneElement
-      head.originalStatement should equal(q"==")
-      val loneMutant = head.mutants.loneElement
-      loneMutant.original should equal(q"==")
-      loneMutant.mutated should equal(q"!=")
+      val firstMutant = result.mutants.head
+      firstMutant.originalStatement should equal(q"==")
+      val firstLoneElement = firstMutant.mutants.loneElement
+      firstLoneElement.original should equal(q"==")
+      firstLoneElement.mutated should equal(q"!=")
+
+      val secondMutant = result.mutants(1).mutants.loneElement
+      result.mutants(1).originalStatement should equal(Lit.String("Hugo"))
+      secondMutant.original should equal(Lit.String("Hugo"))
+      secondMutant.mutated should equal(Lit.String(""))
+
     }
 
   }

--- a/core/src/test/scala/stryker4s/mutants/findmutants/MutantMatcherTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/MutantMatcherTest.scala
@@ -186,7 +186,7 @@ class MutantMatcherTest extends Stryker4sSuite with TreeEquality {
     }
   }
 
-  describe("booleanSubstitutions matcher") {
+  describe("literals matcher") {
     it("should match false to true") {
       checkMatch(
         sut.matchLiterals(),
@@ -202,6 +202,24 @@ class MutantMatcherTest extends Stryker4sSuite with TreeEquality {
         q"def foo = true",
         True,
         False
+      )
+    }
+
+    it("should match foo to NonEmptyString") {
+      checkMatch(
+        sut.matchLiterals(),
+        q"""def foo: String = "bar"""",
+        Lit.String("bar"),
+        EmptyString
+      )
+    }
+
+    it("should match empty string to StrykerWasHere") {
+      checkMatch(
+        sut.matchLiterals(),
+        q"""def foo = "" """,
+        EmptyString,
+        StrykerWasHereString
       )
     }
   }

--- a/core/src/test/scala/stryker4s/mutants/findmutants/MutantMatcherTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/MutantMatcherTest.scala
@@ -184,6 +184,78 @@ class MutantMatcherTest extends Stryker4sSuite with TreeEquality {
         Filter
       )
     }
+
+    it("should match exists to forAll") {
+      checkMatch(
+        sut.matchMethods(),
+        q"def foo = List(1, 2, 3).exists(_ % 2 == 0)",
+        Exists,
+        ForAll
+      )
+    }
+
+    it("should match forAll to exists") {
+      checkMatch(
+        sut.matchMethods(),
+        q"def foo = List(1, 2, 3).forAll(_ % 2 == 0)",
+        ForAll,
+        Exists
+      )
+    }
+
+    it("should match isEmpty to nonEmpty") {
+      checkMatch(
+        sut.matchMethods(),
+        q"def foo = List(1, 2, 3).isEmpty",
+        IsEmpty,
+        NonEmpty
+      )
+    }
+
+    it("should match nonEmpty to isEmpty") {
+      checkMatch(
+        sut.matchMethods(),
+        q"def foo = List(1, 2, 3).nonEmpty",
+        NonEmpty,
+        IsEmpty
+      )
+    }
+
+    it("should match indexOf to lastIndexOf") {
+      checkMatch(
+        sut.matchMethods(),
+        q"def foo = List(1, 2, 3).indexOf(2)",
+        IndexOf,
+        LastIndexOf
+      )
+    }
+
+    it("should match lastIndexOf to indexOf") {
+      checkMatch(
+        sut.matchMethods(),
+        q"def foo = List(1, 2, 3).lastIndexOf(2)",
+        LastIndexOf,
+        IndexOf
+      )
+    }
+
+    it("should match max to min") {
+      checkMatch(
+        sut.matchMethods(),
+        q"def foo = List(1, 2, 3).max",
+        Max,
+        Min
+      )
+    }
+
+    it("should match min to max") {
+      checkMatch(
+        sut.matchMethods(),
+        q"def foo = List(1, 2, 3).min",
+        Min,
+        Max
+      )
+    }
   }
 
   describe("literals matcher") {
@@ -224,13 +296,14 @@ class MutantMatcherTest extends Stryker4sSuite with TreeEquality {
     }
 
     it("should not match on interpolated strings") {
-      val interpolated = Term.Interpolate(q"s", List(Lit.String("interpolate "), Lit.String("")), List(q"foo"))
+      val interpolated =
+        Term.Interpolate(q"s", List(Lit.String("interpolate "), Lit.String("")), List(q"foo"))
       val tree = q"""def foo = $interpolated """
 
       val result = tree collect sut.allMatchers()
 
       interpolated.syntax should equal("""s"interpolate $foo"""")
-      result should be (empty)
+      result should be(empty)
     }
   }
 

--- a/core/src/test/scala/stryker4s/mutants/findmutants/MutantMatcherTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/MutantMatcherTest.scala
@@ -222,6 +222,16 @@ class MutantMatcherTest extends Stryker4sSuite with TreeEquality {
         StrykerWasHereString
       )
     }
+
+    it("should not match on interpolated strings") {
+      val interpolated = Term.Interpolate(q"s", List(Lit.String("interpolate "), Lit.String("")), List(q"foo"))
+      val tree = q"""def foo = $interpolated """
+
+      val result = tree collect sut.allMatchers()
+
+      interpolated.syntax should equal("""s"interpolate $foo"""")
+      result should be (empty)
+    }
   }
 
 }

--- a/core/src/test/scala/stryker4s/mutants/findmutants/MutantMatcherTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/MutantMatcherTest.scala
@@ -28,11 +28,13 @@ class MutantMatcherTest extends Stryker4sSuite with TreeEquality {
 
       val found = tree collect sut.allMatchers()
 
-      found should have length 2
+      found should have length 3
       found.head.originalTree should equal(q">")
       found.head.mutations should contain only (q">=", q"<", q"==")
-      found(1).originalTree should equal(q"<")
-      found(1).mutations should contain only (q"<=", q">", q"==")
+      found(1).originalTree should equal(q"&&")
+      found(1).mutations should contain only q"||"
+      found(2).originalTree should equal(q"<")
+      found(2).mutations should contain only (q"<=", q">", q"==")
     }
 
     it("should match a method") {
@@ -52,11 +54,13 @@ class MutantMatcherTest extends Stryker4sSuite with TreeEquality {
 
       val found = tree collect sut.allMatchers()
 
-      found should have length 2
+      found should have length 3
       found.head.originalTree should equal(q"false")
       found.head.mutations should contain only q"true"
-      found(1).originalTree should equal(q">")
-      found(1).mutations should contain allOf (q">=", q"<", q"==")
+      found(1).originalTree should equal(q"&&")
+      found(1).mutations should contain only q"||"
+      found(2).originalTree should equal(q">")
+      found(2).mutations should contain allOf (q">=", q"<", q"==")
     }
 
     it("should match the default case of a constructor argument") {
@@ -142,6 +146,24 @@ class MutantMatcherTest extends Stryker4sSuite with TreeEquality {
         EqualTo
       )
     }
+
+    it("should match && to ||") {
+      checkMatch(
+        sut.matchConditionals(),
+        q"def foo = a && b",
+        And,
+        Or
+      )
+    }
+
+    it("should match || to &&") {
+      checkMatch(
+        sut.matchConditionals(),
+        q"def foo = a || b",
+        Or,
+        And
+      )
+    }
   }
 
   describe("matchMethods matcher") {
@@ -167,7 +189,7 @@ class MutantMatcherTest extends Stryker4sSuite with TreeEquality {
   describe("booleanSubstitutions matcher") {
     it("should match false to true") {
       checkMatch(
-        sut.matchBooleanSubstitutions(),
+        sut.matchLiterals(),
         q"def foo = false",
         False,
         True
@@ -176,7 +198,7 @@ class MutantMatcherTest extends Stryker4sSuite with TreeEquality {
 
     it("should match true to false") {
       checkMatch(
-        sut.matchBooleanSubstitutions(),
+        sut.matchLiterals(),
         q"def foo = true",
         True,
         False

--- a/docs/MUTATORS.md
+++ b/docs/MUTATORS.md
@@ -14,6 +14,8 @@ An always up-to-date reference is also available in the [MutantMatcher source](.
 | `<` | `<=`, `>`, `==` |
 | `==` | `!=` |
 | `!=` | `==` |
+| `&&` | `||` |
+| `||` | `&&` |
 
 ## Methods
 
@@ -22,7 +24,7 @@ An always up-to-date reference is also available in the [MutantMatcher source](.
 | `a.filter(b)` | `a.filterNot(b)` |
 | `a.filterNot(b)` | `a.filter(b)` |
 
-## Boolean substitutions
+## Literal substitutions
 
 | Original | Mutated |
 | --- | --- |

--- a/docs/MUTATORS.md
+++ b/docs/MUTATORS.md
@@ -30,3 +30,5 @@ An always up-to-date reference is also available in the [MutantMatcher source](.
 | --- | --- |
 | `true` | `false` |
 | `false` | `true` |
+| `"foo"` (non-empty string) | `""` (empty string) |
+| `""` (empty string) | `"Stryker was here!"` |

--- a/docs/MUTATORS.md
+++ b/docs/MUTATORS.md
@@ -23,6 +23,14 @@ An always up-to-date reference is also available in the [MutantMatcher source](.
 | --- | --- |
 | `a.filter(b)` | `a.filterNot(b)` |
 | `a.filterNot(b)` | `a.filter(b)` |
+| `a.exists(b)` | `a.forAll(b)` |
+| `a.forAll(b)` | `a.exists(b)` |
+| `a.isEmpty` | `a.nonEmpty` |
+| `a.nonEmpty` | `a.isEmpty` |
+| `a.indexOf` | `a.lastIndexOf(b)` |
+| `a.lastIndexOf(b)` | `a.indexOf(b)` |
+| `a.max` | `a.min` |
+| `a.min` | `a.max` |
 
 ## Literal substitutions
 

--- a/docs/MUTATORS.md
+++ b/docs/MUTATORS.md
@@ -23,14 +23,16 @@ An always up-to-date reference is also available in the [MutantMatcher source](.
 | --- | --- |
 | `a.filter(b)` | `a.filterNot(b)` |
 | `a.filterNot(b)` | `a.filter(b)` |
-| `a.exists(b)` | `a.forAll(b)` |
+| `a.exists(b)` | `a.forAll(b)` <sup>1</sup>|
 | `a.forAll(b)` | `a.exists(b)` |
 | `a.isEmpty` | `a.nonEmpty` |
 | `a.nonEmpty` | `a.isEmpty` |
-| `a.indexOf` | `a.lastIndexOf(b)` |
+| `a.indexOf` | `a.lastIndexOf(b)` <sup>1</sup> |
 | `a.lastIndexOf(b)` | `a.indexOf(b)` |
 | `a.max` | `a.min` |
 | `a.min` | `a.max` |
+
+<sup>1: This can cause some false positives with unique lists, such as sets</sup>
 
 ## Literal substitutions
 

--- a/docs/MUTATORS.md
+++ b/docs/MUTATORS.md
@@ -42,3 +42,5 @@ An always up-to-date reference is also available in the [MutantMatcher source](.
 | `false` | `true` |
 | `"foo"` (non-empty string) | `""` (empty string) |
 | `""` (empty string) | `"Stryker was here!"` |
+| `s"foo ${bar}"` (string interpolation) | `s""` <sup>2</sup> |
+<sup>2: Only works with string interpolation and not others (like [Scalameta quasiquotes](https://scalameta.org/tutorial/#q%22Quasiquotes%22))to avoid compile errors</sup>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,6 +6,7 @@ object Dependencies {
     val scala212 = "2.12.6"
     val scala211 = "2.11.12"
     val crossScala = Seq(scala211, scala212)
+
     /** Use 3.3.1 until a Scalameta bug with transforming a Scalameta Parsed is fixed
       * See: https://github.com/scalameta/scalameta/issues/1526
       */

--- a/util/src/main/scala/stryker4s/extensions/TreeExtensions.scala
+++ b/util/src/main/scala/stryker4s/extensions/TreeExtensions.scala
@@ -21,9 +21,15 @@ object TreeExtensions {
       *
       */
     private object PartialStatement {
+
+      /**
+        * @return A Some of the parent if the given term is a partial statement,
+        *         else a None if the given term is a full statement
+        */
       def unapply(term: Term): Option[Term] = term.parent match {
         case Some(parent: Term.Apply)                             => Some(parent)
         case Some(parent: Term.Select)                            => Some(parent)
+        case Some(parent: Term.ApplyType)                         => Some(parent)
         case Some(_: Term.ApplyInfix) if term.is[Term.ApplyInfix] => None
         case Some(parent: Term.ApplyInfix)                        => Some(parent)
         case _                                                    => None

--- a/util/src/main/scala/stryker4s/extensions/mutationtypes/LiteralMutationTypes.scala
+++ b/util/src/main/scala/stryker4s/extensions/mutationtypes/LiteralMutationTypes.scala
@@ -9,3 +9,17 @@ case object True extends LiteralMutation[Lit.Boolean] {
 case object False extends LiteralMutation[Lit.Boolean] {
   override val tree: Lit.Boolean = Lit.Boolean(false)
 }
+
+case object EmptyString extends LiteralMutation[Lit.String] {
+  override val tree: Lit.String = Lit.String("")
+}
+
+case object StrykerWasHereString extends LiteralMutation[Lit.String] {
+  override val tree: Lit.String = Lit.String("Stryker was here!")
+}
+
+/** Not a mutation, just an extractor for pattern matching
+  */
+case object NonEmptyString {
+  def unapply(arg: Lit.String): Option[Lit.String] = Some(arg).filter(_.value.nonEmpty)
+}

--- a/util/src/main/scala/stryker4s/extensions/mutationtypes/LiteralMutationTypes.scala
+++ b/util/src/main/scala/stryker4s/extensions/mutationtypes/LiteralMutationTypes.scala
@@ -1,6 +1,6 @@
 package stryker4s.extensions.mutationtypes
 
-import scala.meta.Lit
+import scala.meta.{Lit, Term}
 
 case object True extends LiteralMutation[Lit.Boolean] {
   override val tree: Lit.Boolean = Lit.Boolean(true)
@@ -12,6 +12,9 @@ case object False extends LiteralMutation[Lit.Boolean] {
 
 case object EmptyString extends LiteralMutation[Lit.String] {
   override val tree: Lit.String = Lit.String("")
+
+  override def unapply(arg: Lit.String): Option[Lit.String] =
+    super.unapply(arg).filterNot(ParentIsInterpolatedString(_))
 }
 
 case object StrykerWasHereString extends LiteralMutation[Lit.String] {
@@ -21,5 +24,14 @@ case object StrykerWasHereString extends LiteralMutation[Lit.String] {
 /** Not a mutation, just an extractor for pattern matching
   */
 case object NonEmptyString {
-  def unapply(arg: Lit.String): Option[Lit.String] = Some(arg).filter(_.value.nonEmpty)
+  def unapply(arg: Lit.String): Option[Lit.String] =
+    Some(arg).filter(_.value.nonEmpty).filterNot(ParentIsInterpolatedString(_))
+}
+
+object ParentIsInterpolatedString {
+  def apply(arg: Lit.String): Boolean = arg.parent match {
+    // Do not mutate interpolated strings
+    case Some(_: Term.Interpolate) => true
+    case _                         => false
+  }
 }

--- a/util/src/main/scala/stryker4s/extensions/mutationtypes/TermNameMutationTypes.scala
+++ b/util/src/main/scala/stryker4s/extensions/mutationtypes/TermNameMutationTypes.scala
@@ -1,6 +1,6 @@
 package stryker4s.extensions.mutationtypes
 
-import scala.meta.Term
+import scala.meta.{Term, Tree}
 
 case object GreaterThan extends TermNameMutation {
   override val tree: Term.Name = Term.Name(">")
@@ -40,4 +40,36 @@ case object Filter extends TermNameMutation {
 
 case object FilterNot extends TermNameMutation {
   override val tree: Term.Name = Term.Name("filterNot")
+}
+
+case object Exists extends TermNameMutation {
+  override val tree: Term.Name = Term.Name("exists")
+}
+
+case object ForAll extends TermNameMutation {
+  override val tree: Term.Name = Term.Name("forAll")
+}
+
+case object IsEmpty extends TermNameMutation {
+  override val tree: Term.Name = Term.Name("isEmpty")
+}
+
+case object NonEmpty extends TermNameMutation {
+  override val tree: Term.Name = Term.Name("nonEmpty")
+}
+
+case object IndexOf extends TermNameMutation {
+  override val tree: Term.Name = Term.Name("indexOf")
+}
+
+case object LastIndexOf extends TermNameMutation {
+  override val tree: Term.Name = Term.Name("lastIndexOf")
+}
+
+case object Max extends TermNameMutation {
+  override val tree: Term.Name = Term.Name("max")
+}
+
+case object Min extends TermNameMutation {
+  override val tree: Term.Name = Term.Name("min")
 }

--- a/util/src/main/scala/stryker4s/extensions/mutationtypes/TermNameMutationTypes.scala
+++ b/util/src/main/scala/stryker4s/extensions/mutationtypes/TermNameMutationTypes.scala
@@ -26,6 +26,14 @@ case object NotEqualTo extends TermNameMutation {
   override val tree: Term.Name = Term.Name("!=")
 }
 
+case object And extends TermNameMutation {
+  override val tree: Term.Name = Term.Name("&&")
+}
+
+case object Or extends TermNameMutation {
+  override val tree: Term.Name = Term.Name("||")
+}
+
 case object Filter extends TermNameMutation {
   override val tree: Term.Name = Term.Name("filter")
 }

--- a/util/src/test/scala/stryker4s/extensions/TreeExtensionsTest.scala
+++ b/util/src/test/scala/stryker4s/extensions/TreeExtensionsTest.scala
@@ -155,6 +155,33 @@ class TreeExtensionsTest extends Stryker4sSuite with TreeEquality {
 
       result should equal(q"new Bar(4).filter(_ >= 3)")
     }
+
+    it("should include entire statement with && statement") {
+      val tree = q"def foo = a == b && b == c"
+      val subTree = tree.find(q"&&").value
+
+      val result = subTree.topStatement()
+
+      result should equal(q"a == b && b == c")
+    }
+
+    it("should include entire statement when && is not symmetrical on left") {
+      val tree = q"def foo = a && b == c"
+      val subTree = tree.find(q"&&").value
+
+      val result = subTree.topStatement()
+
+      result should equal(q"a && b == c")
+    }
+
+    it("should include entire statement when && is not symmetrical on right") {
+      val tree = q"def foo = a == b && c"
+      val subTree = tree.find(q"&&").value
+
+      val result = subTree.topStatement()
+
+      result should equal(q"a == b && c")
+    }
   }
 
   describe("find") {

--- a/util/src/test/scala/stryker4s/extensions/TreeExtensionsTest.scala
+++ b/util/src/test/scala/stryker4s/extensions/TreeExtensionsTest.scala
@@ -182,6 +182,15 @@ class TreeExtensionsTest extends Stryker4sSuite with TreeEquality {
 
       result should equal(q"a == b && c")
     }
+
+    it("should include generic type") {
+      val tree = q"def foo = a.parse[Source]"
+      val subTree = tree.find(q"parse").value
+
+      val result = subTree.topStatement()
+
+      result should equal(q"a.parse[Source]")
+    }
   }
 
   describe("find") {

--- a/util/src/test/scala/stryker4s/extensions/mutationtypes/MutationTypesTest.scala
+++ b/util/src/test/scala/stryker4s/extensions/mutationtypes/MutationTypesTest.scala
@@ -2,6 +2,7 @@ package stryker4s.extensions.mutationtypes
 
 import stryker4s.Stryker4sSuite
 import stryker4s.extensions.ImplicitMutationConversion.mutationToTree
+import stryker4s.extensions.TreeExtensions.ImplicitTreeExtensions
 import stryker4s.scalatest.TreeEquality
 
 import scala.meta._
@@ -46,6 +47,38 @@ class MutationTypesTest extends Stryker4sSuite with TreeEquality {
 
     it("filterNot to FilterNot") {
       q"filterNot" should matchPattern { case FilterNot(_) => }
+    }
+
+    it("exists to Exists") {
+      q"exists" should matchPattern { case Exists(_) => }
+    }
+
+    it("forAll to ForAll") {
+      q"forAll" should matchPattern { case ForAll(_) => }
+    }
+
+    it("isEmpty to IsEmpty") {
+      q"isEmpty" should matchPattern { case IsEmpty(_) => }
+    }
+
+    it("nonEmpty to NonEmpty") {
+      q"nonEmpty" should matchPattern { case NonEmpty(_) => }
+    }
+
+    it("indexOf to IndexOf") {
+      q"indexOf" should matchPattern { case IndexOf(_) => }
+    }
+
+    it("lastIndexOf to LastIndexOf") {
+      q"lastIndexOf" should matchPattern { case LastIndexOf(_) => }
+    }
+
+    it("max to Max") {
+      q"max" should matchPattern { case Max(_) => }
+    }
+
+    it("min to Min") {
+      q"min" should matchPattern { case Min(_) => }
     }
 
     it("should not match a different pattern") {

--- a/util/src/test/scala/stryker4s/extensions/mutationtypes/MutationTypesTest.scala
+++ b/util/src/test/scala/stryker4s/extensions/mutationtypes/MutationTypesTest.scala
@@ -7,7 +7,7 @@ import stryker4s.scalatest.TreeEquality
 import scala.meta._
 
 class MutationTypesTest extends Stryker4sSuite with TreeEquality {
-  describe("match") {
+  describe("match TermNameMutation") {
     it("> to GreaterThan") {
       q">" should matchPattern { case GreaterThan(_) => }
     }
@@ -48,14 +48,6 @@ class MutationTypesTest extends Stryker4sSuite with TreeEquality {
       q"filterNot" should matchPattern { case FilterNot(_) => }
     }
 
-    it("false to False") {
-      q"false" should matchPattern { case False(_) => }
-    }
-
-    it("true to True") {
-      q"true" should matchPattern { case True(_) => }
-    }
-
     it("should not match a different pattern") {
       q"filter" should not matchPattern { case FilterNot(_) => }
     }
@@ -68,6 +60,24 @@ class MutationTypesTest extends Stryker4sSuite with TreeEquality {
       }
 
       result should be theSameInstanceAs tree
+    }
+  }
+
+  describe("match LiteralMutation") {
+    it("false to False") {
+      q"false" should matchPattern { case False(_) => }
+    }
+
+    it("true to True") {
+      q"true" should matchPattern { case True(_) => }
+    }
+
+    it("foo string to NonEmptyString") {
+      q""""foo"""" should matchPattern { case NonEmptyString(_) => }
+    }
+
+    it("empty string to EmptyString") {
+      Lit.String("") should matchPattern { case EmptyString(_) => }
     }
   }
 
@@ -88,5 +98,4 @@ class MutationTypesTest extends Stryker4sSuite with TreeEquality {
 
     case class WrappedTree(term: Tree)
   }
-
 }

--- a/util/src/test/scala/stryker4s/extensions/mutationtypes/MutationTypesTest.scala
+++ b/util/src/test/scala/stryker4s/extensions/mutationtypes/MutationTypesTest.scala
@@ -32,6 +32,14 @@ class MutationTypesTest extends Stryker4sSuite with TreeEquality {
       q"!=" should matchPattern { case NotEqualTo(_) => }
     }
 
+    it("&& to And") {
+      q"&&" should matchPattern { case And(_) => }
+    }
+
+    it("|| to Or") {
+      q"||" should matchPattern { case Or(_) => }
+    }
+
     it("filter to Filter") {
       q"filter" should matchPattern { case Filter(_) => }
     }

--- a/util/src/test/scala/stryker4s/extensions/mutationtypes/MutationTypesTest.scala
+++ b/util/src/test/scala/stryker4s/extensions/mutationtypes/MutationTypesTest.scala
@@ -2,7 +2,6 @@ package stryker4s.extensions.mutationtypes
 
 import stryker4s.Stryker4sSuite
 import stryker4s.extensions.ImplicitMutationConversion.mutationToTree
-import stryker4s.extensions.TreeExtensions.ImplicitTreeExtensions
 import stryker4s.scalatest.TreeEquality
 
 import scala.meta._
@@ -111,6 +110,18 @@ class MutationTypesTest extends Stryker4sSuite with TreeEquality {
 
     it("empty string to EmptyString") {
       Lit.String("") should matchPattern { case EmptyString(_) => }
+    }
+
+    it("string interpolation to StringInterpolation") {
+      Term.Interpolate(q"s", List(Lit.String("foo "), Lit.String("")), List(q"foo")) should matchPattern {
+        case StringInterpolation(_) =>
+      }
+    }
+
+    it("q interpolation should not match StringInterpolation") {
+      Term.Interpolate(q"q", List(Lit.String("foo "), Lit.String("")), List(q"foo")) should not matchPattern {
+        case StringInterpolation(_) =>
+      }
     }
   }
 


### PR DESCRIPTION
I've added 12 new mutators and updated the documentation to reflect it. The new mutators are mostly function mutators. This takes the number of found mutants when running stryker4s on stryker4s from 10 to 62. It puts our new own mutation score at 77%.

There are probably still a lot of other mutators we can/should add. Can be discussed in #11.

I also did a short experiment with changing `Some(a)` to `None` and `option.getOrElse(a)` to `option.get`. 

The first caused compile errors in some areas, due to the type of the Option no longer being known. We might have to look into this again once we have compile error rollback.

With the second I ran into some troubles with having to replacing a function that has arguments to a function with no arguments. It sounds simple, I know. But we might have to investigate again later.