### PR TITLE
Validate html reporter output with json schema

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 lazy val root = (project withId "stryker4s" in file("."))
   .settings(
     name := "stryker4s",
-    crossScalaVersions := Dependencies.versions.crossScala,
+    crossScalaVersions := Dependencies.versions.crossScala
   )
   .aggregate(stryker4sCore, stryker4sUtil)
   .dependsOn(stryker4sCore) // So `sbt run` can be used in root project
@@ -15,4 +15,5 @@ lazy val stryker4sCore = (project withId "stryker4s-core" in file("core"))
   .dependsOn(stryker4sUtil % "test -> test")
 
 lazy val stryker4sUtil = (project withId "stryker4s-util" in file("util"))
-  .settings(Settings.commonSettings)
+  .settings(Settings.commonSettings,
+            resolvers += "jitpack.io" at "https://jitpack.io")

--- a/core/src/test/scala/stryker4s/run/report/HtmlReporterTest.scala
+++ b/core/src/test/scala/stryker4s/run/report/HtmlReporterTest.scala
@@ -1,0 +1,83 @@
+package stryker4s.run.report
+
+import grizzled.slf4j.Logging
+import org.everit.json.schema.ValidationException
+import org.json.JSONObject
+import org.scalactic.Fail
+import stryker4s.{MutationTestingElementsJsonSchema, Stryker4sSuite}
+
+import scala.util.{Failure, Success, Try}
+
+class HtmlReporterTest extends Stryker4sSuite with Logging {
+
+  /**
+  * Test report should be replaced by the html reporter output but this isn't available yet.
+    */
+  private[this] val testReport: String =
+    """
+      |{  
+      |    "name": "src",
+      |    "path":  "/usr/full/path/to/src",
+      |    "totals": {
+      |       "choose": 8,
+      |       "custom": 1,
+      |       "columns": 1,
+      |       "here": 0,
+      |       "like": 2,
+      |       "mutation score": 80
+      |    },
+      |    "health": "ok",
+      |    "childResults": [
+      |        { 
+      |            "name": "src/Example.cs",
+      |            "path":  "/usr/full/path/to/src/Example.cs",
+      |            "totals": {
+      |               "detected": 1,
+      |               "undetected": 2,
+      |               "valid": 3,
+      |               "invalid": 1
+      |             },  
+      |            "health": "danger",
+      |            "language": "cs",
+      |            "source": "using System; using.....",
+      |            "mutants": [{
+      |                 "id": "321321", 
+      |                 "mutatorName": "BinaryMutator",
+      |                 "replacement": "-",
+      |                 "span": [21,22], 
+      |                 "status": "Killed"
+      |            }]
+      |        }    
+      |    ]
+      |}
+    """.stripMargin
+
+  describe("html reporter output validation") {
+    it("should validate to the `mutation-testing-elements` json schema.") {
+      MutationTestingElementsJsonSchema.mutationTestingElementsJsonSchema match {
+        case Some(schema) =>
+          Try(schema.validate(new JSONObject(testReport))) match {
+            case Success(_)         => succeed
+            case Failure(exception) => fail(exception.getMessage)
+          }
+        case None =>
+          Fail("Schema could not be retrieved")
+      }
+    }
+
+    it("should fail when an empty json string is provided because not all required elements are available.") {
+      MutationTestingElementsJsonSchema.mutationTestingElementsJsonSchema match {
+        case Some(schema) =>
+          Try(schema.validate(new JSONObject("{}"))) match {
+            case Success(_)         => fail("Should fail because input was not correct")
+            case Failure(exception) =>
+              val validationException = exception.asInstanceOf[ValidationException]
+
+              validationException.getAllMessages should  contain ("#: required key [name] not found")
+          }
+        case None =>
+          Fail("Schema could not be retrieved")
+      }
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,6 +13,8 @@ object Dependencies {
     val scalameta = "3.3.1"
     val pureconfig = "0.9.2"
     val scalatest = "3.0.5"
+    val sttp = "1.3.0"
+    val jsonSchemaValidator = "1.9.1"
     val betterFiles = "3.5.0"
     val logback = "1.2.3"
     val grizzledSlf4j = "1.3.2"
@@ -20,6 +22,8 @@ object Dependencies {
 
   object test {
     val scalatest = "org.scalatest" %% "scalatest" % versions.scalatest % Test
+    val sttp = "com.softwaremill.sttp" %% "core" % versions.sttp % Test
+    val jsonSchemaValidator = "com.github.everit-org.json-schema" % "org.everit.json.schema" % versions.jsonSchemaValidator % Test
   }
 
   val pureconfig = "com.github.pureconfig" %% "pureconfig" % versions.pureconfig

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -21,6 +21,8 @@ object Settings {
     scalacOptions ++= scalacOpts,
     libraryDependencies ++= Seq(
       Dependencies.test.scalatest,
+      Dependencies.test.sttp,
+      Dependencies.test.jsonSchemaValidator,
       Dependencies.pureconfig,
       Dependencies.scalameta,
       Dependencies.scalametaContrib,

--- a/util/src/test/scala/stryker4s/MutationTestingElementsJsonSchema.scala
+++ b/util/src/test/scala/stryker4s/MutationTestingElementsJsonSchema.scala
@@ -1,0 +1,39 @@
+package stryker4s
+
+import com.softwaremill.sttp._
+import grizzled.slf4j.Logging
+import org.everit.json.schema.Schema
+import org.everit.json.schema.loader.SchemaLoader
+import org.json.JSONObject
+
+object MutationTestingElementsJsonSchema extends Logging {
+
+  private[this] implicit val backend: SttpBackend[Id, Nothing] = HttpURLConnectionBackend()
+  private[this] val schemaUri: Uri =
+    uri"https://unpkg.com/mutation-testing-elements@latest/mutation-testing-report-schema.json"
+
+  /**
+    * Retrieve json schema from unpkg so we can validate our html reporter output to the json schema.
+    */
+  def mutationTestingElementsJsonSchema: Option[Schema] = {
+    val request = sttp.get(schemaUri).response(asString)
+    val response = request.send()
+
+    response.body match {
+      case Right(responseBody) => toJsonSchema(responseBody)
+      case Left(failure) =>
+        error(s"Could not retrieve json schema reason: $failure")
+        None
+    }
+  }
+
+  private[this] def toJsonSchema(responseBody: String): Option[Schema] = {
+    Option(
+      SchemaLoader
+        .builder()
+        .schemaJson(new JSONObject(responseBody))
+        .build()
+        .load()
+        .build())
+  }
+}


### PR DESCRIPTION
Plumming so we will be able to retrieve the json schema from unpkg and a json validator that will validate the output of the html reporter against the schema. This is for now a static json this should be improved when the html reporter is being implemented.

Fixes: #51 