### PR TITLE
Logging tests without race conditions

### DIFF
--- a/core/src/test/scala/stryker4s/config/ConfigReaderTest.scala
+++ b/core/src/test/scala/stryker4s/config/ConfigReaderTest.scala
@@ -93,6 +93,6 @@ class ConfigReaderTest extends Stryker4sSuite with BeforeAndAfterEach {
   }
 
   override def afterEach(): Unit = {
-    TestAppender.reset()
+    TestAppender.reset
   }
 }

--- a/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
@@ -1,13 +1,13 @@
-package stryker4s
+package stryker4s.mutants
 
 import org.scalatest.BeforeAndAfterEach
 import stryker4s.config.Config
-import stryker4s.mutants.Mutator
 import stryker4s.mutants.applymutants.{MatchBuilder, StatementTransformer}
 import stryker4s.mutants.findmutants.{MutantFinder, MutantMatcher}
 import stryker4s.run.MutantRegistry
 import stryker4s.scalatest.{FileUtil, TreeEquality}
 import stryker4s.stubs.TestSourceCollector
+import stryker4s.{Stryker4sSuite, TestAppender}
 
 import scala.meta._
 

--- a/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
@@ -62,6 +62,6 @@ class MutatorTest extends Stryker4sSuite with TreeEquality with BeforeAndAfterEa
   }
 
   override def afterEach(): Unit = {
-    TestAppender.reset()
+    TestAppender.reset
   }
 }

--- a/core/src/test/scala/stryker4s/run/report/ReporterTest.scala
+++ b/core/src/test/scala/stryker4s/run/report/ReporterTest.scala
@@ -25,8 +25,4 @@ class ReporterTest extends Stryker4sSuite with BeforeAndAfterEach with Idiomatic
       verify(reporterMock).report(mutantRunResults)
     }
   }
-
-  override def afterEach(): Unit = {
-    TestAppender.reset()
-  }
 }

--- a/util/src/test/scala/stryker4s/Stryker4sSuite.scala
+++ b/util/src/test/scala/stryker4s/Stryker4sSuite.scala
@@ -3,4 +3,13 @@ package stryker4s
 import org.scalatest.{FunSpec, LoneElement, Matchers, OptionValues}
 import stryker4s.scalatest.LogMatchers
 
-trait Stryker4sSuite extends FunSpec with Matchers with OptionValues with LoneElement with LogMatchers
+trait Stryker4sSuite extends FunSpec with Matchers with OptionValues with LoneElement with LogMatchers {
+
+  /**
+    * The className of the system under test.
+    * Is done by getting the executing test class and stripping off 'test'.
+    *
+    * This is used for logMatchers.
+    */
+  implicit val className: String =  getClass.getCanonicalName.replace("Test", "")
+}

--- a/util/src/test/scala/stryker4s/TestAppender.scala
+++ b/util/src/test/scala/stryker4s/TestAppender.scala
@@ -4,15 +4,16 @@ import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.AppenderBase
 
 import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
 
 object TestAppender {
-  val events: mutable.MutableList[ILoggingEvent] = mutable.MutableList.empty
+  val events: mutable.ListBuffer[ILoggingEvent] = ListBuffer.empty
 
   /**
-    * Remove all previous logged events.
+    * Remove all previous logged events for a specific class.
     */
-  def reset(): Unit = {
-    events.clear()
+  def reset(implicit loggerClassName: String): Unit = {
+    events --= events.filterNot(event => event.getLoggerName.contains(loggerClassName))
   }
 }
 

--- a/util/src/test/scala/stryker4s/TestAppender.scala
+++ b/util/src/test/scala/stryker4s/TestAppender.scala
@@ -20,8 +20,6 @@ object TestAppender {
 class TestAppender extends AppenderBase[ILoggingEvent] {
 
   override def append(eventObject: ILoggingEvent): Unit = {
-    eventObject.getLoggerName
-
     TestAppender.events += eventObject
   }
 }

--- a/util/src/test/scala/stryker4s/TestAppender.scala
+++ b/util/src/test/scala/stryker4s/TestAppender.scala
@@ -19,6 +19,8 @@ object TestAppender {
 class TestAppender extends AppenderBase[ILoggingEvent] {
 
   override def append(eventObject: ILoggingEvent): Unit = {
+    eventObject.getLoggerName
+
     TestAppender.events += eventObject
   }
 }

--- a/util/src/test/scala/stryker4s/TestAppender.scala
+++ b/util/src/test/scala/stryker4s/TestAppender.scala
@@ -13,7 +13,7 @@ object TestAppender {
     * Remove all previous logged events for a specific class.
     */
   def reset(implicit loggerClassName: String): Unit = {
-    events --= events.filterNot(event => event.getLoggerName.contains(loggerClassName))
+    events --= events.filter(event => event.getLoggerName.contains(loggerClassName))
   }
 }
 

--- a/util/src/test/scala/stryker4s/scalatest/LogMatchers.scala
+++ b/util/src/test/scala/stryker4s/scalatest/LogMatchers.scala
@@ -6,9 +6,8 @@ import org.scalatest.matchers.{BeMatcher, MatchResult}
 import stryker4s.TestAppender
 
 trait LogMatchers {
-  outer =>
 
-  class LogMatcherWithLevel[A](expectedLogLevel: Level) extends BeMatcher[String] {
+  class LogMatcherWithLevel[A](expectedLogLevel: Level)(implicit loggerClassName: String) extends BeMatcher[String] {
     def apply(expectedLogMessage: String): MatchResult = {
         getLoggingEventWithLogMessage(expectedLogMessage) match {
           case None =>
@@ -30,26 +29,18 @@ trait LogMatchers {
     }
   }
 
-  def loggedAsDebug = new LogMatcherWithLevel(Level.DEBUG)
-  def loggedAsInfo = new LogMatcherWithLevel(Level.INFO)
-  def loggedAsWarning = new LogMatcherWithLevel(Level.WARN)
-  def loggedAsError = new LogMatcherWithLevel(Level.ERROR)
+  def loggedAsDebug(implicit loggerClassName: String) = new LogMatcherWithLevel(Level.DEBUG)
+  def loggedAsInfo(implicit loggerClassName: String) = new LogMatcherWithLevel(Level.INFO)
+  def loggedAsWarning(implicit loggerClassName: String) = new LogMatcherWithLevel(Level.WARN)
+  def loggedAsError(implicit loggerClassName: String) = new LogMatcherWithLevel(Level.ERROR)
 
   private[this] def validateLogLevel(actualLogLevel: Level, expectedLogLevel: Level): Boolean = {
     expectedLogLevel.equals(actualLogLevel)
   }
 
-  private[this] def getLoggingEventWithLogMessage(expectedLogMessage: String): Option[ILoggingEvent] = {
+  private[this] def getLoggingEventWithLogMessage(expectedLogMessage: String)(implicit loggerClassName: String): Option[ILoggingEvent] = {
     TestAppender.events
-      .filter(logEvent => logEvent.getLoggerName.contains(getClassName))
+      .filter(logEvent => logEvent.getLoggerName.contains(loggerClassName))
       .find(_.getFormattedMessage.contains(expectedLogMessage))
-  }
-
-  /**
-    * Gets the class name of the system under test.
-    * Is done by getting the executing test class and stripping off 'test'.
-    */
-  private[this] def getClassName: String = {
-    outer.getClass.getCanonicalName.replace("Test", "")
   }
 }

--- a/util/src/test/scala/stryker4s/scalatest/LogMatchers.scala
+++ b/util/src/test/scala/stryker4s/scalatest/LogMatchers.scala
@@ -7,25 +7,26 @@ import stryker4s.TestAppender
 
 trait LogMatchers {
 
-  class LogMatcherWithLevel[A](expectedLogLevel: Level)(implicit loggerClassName: String) extends BeMatcher[String] {
+  class LogMatcherWithLevel(expectedLogLevel: Level)(implicit loggerClassName: String)
+      extends BeMatcher[String] {
     def apply(expectedLogMessage: String): MatchResult = {
-        getLoggingEventWithLogMessage(expectedLogMessage) match {
-          case None =>
-            MatchResult(
-              matches = false,
-              s"Log message $expectedLogMessage wasn't logged at any level.",
-              s"Log message $expectedLogMessage was logged as $expectedLogLevel."
-            )
-          case Some(loggingEvent) =>
-            val result = validateLogLevel(loggingEvent.getLevel, expectedLogLevel)
+      getLoggingEventWithLogMessage(expectedLogMessage) match {
+        case None =>
+          MatchResult(
+            matches = false,
+            s"Log message $expectedLogMessage wasn't logged at any level.",
+            s"Log message $expectedLogMessage was logged as $expectedLogLevel."
+          )
+        case Some(loggingEvent) =>
+          val result = validateLogLevel(loggingEvent.getLevel, expectedLogLevel)
 
-            MatchResult(
-              result,
-              s"Log message $expectedLogMessage was logged but not on correct log level, " +
-                s"expected [$expectedLogLevel] actual [${loggingEvent.getLevel}].",
-              s"Log message $expectedLogMessage was logged as $expectedLogLevel."
-            )
-        }
+          MatchResult(
+            result,
+            s"Log message $expectedLogMessage was logged but not on correct log level, " +
+              s"expected [$expectedLogLevel] actual [${loggingEvent.getLevel}].",
+            s"Log message $expectedLogMessage was logged as $expectedLogLevel."
+          )
+      }
     }
   }
 
@@ -38,7 +39,8 @@ trait LogMatchers {
     expectedLogLevel.equals(actualLogLevel)
   }
 
-  private[this] def getLoggingEventWithLogMessage(expectedLogMessage: String)(implicit loggerClassName: String): Option[ILoggingEvent] = {
+  private[this] def getLoggingEventWithLogMessage(expectedLogMessage: String)
+                                                 (implicit loggerClassName: String): Option[ILoggingEvent] = {
     TestAppender.events
       .filter(logEvent => logEvent.getLoggerName.contains(loggerClassName))
       .find(_.getFormattedMessage.contains(expectedLogMessage))


### PR DESCRIPTION
I rewrote the logMatcher + appender so it's safe to use.

Basically how it works is by adding a class name so the reset function only removes log events for that specific class under test. because of the AfterEach which is used to reset this is perfectly safe. 

Also altered the log matchers to include the class name so if 2 different classes would log the same line the matchers would still match correctly. This is also done by including the class name.

One warning: It does require a 1:1 mapping of the package structure for the tests. But this is a good practice to do anyway.

this will fix #44 