### PR TITLE
Update to Scalameta 4.0.0 (and some other dependencies)

### DIFF
--- a/core/src/main/scala/stryker4s/mutants/findmutants/MutantFinder.scala
+++ b/core/src/main/scala/stryker4s/mutants/findmutants/MutantFinder.scala
@@ -19,13 +19,12 @@ class MutantFinder(matcher: MutantMatcher) extends Logging {
   }
 
   def parseFile(file: File): Source =
-    file.contentAsString
-      .replace("\r\n", "\n")
-      .parse[Source] match {
+    file.toJava.parse[Source] match {
       case Parsed.Success(source) =>
+        debug(s"Parsed file '$file'")
         source
       case Parsed.Error(_, msg, ex) =>
-        error(s"Error while parsing file $file, $msg")
+        error(s"Error while parsing file '$file', $msg")
         throw ex
     }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,10 +7,7 @@ object Dependencies {
     val scala211 = "2.11.12"
     val crossScala = Seq(scala211, scala212)
 
-    /** Use 3.3.1 until a Scalameta bug with transforming a Scalameta Parsed is fixed
-      * See: https://github.com/scalameta/scalameta/issues/1526
-      */
-    val scalameta = "3.3.1"
+    val scalameta = "4.0.0"
     val pureconfig = "0.9.2"
     val scalatest = "3.0.5"
     val mockitoScala = "0.4.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,8 +10,8 @@ object Dependencies {
     val scalameta = "4.0.0"
     val pureconfig = "0.9.2"
     val scalatest = "3.0.5"
-    val mockitoScala = "0.4.2"
-    val betterFiles = "3.5.0"
+    val mockitoScala = "0.4.5"
+    val betterFiles = "3.6.0"
     val logback = "1.2.3"
     val grizzledSlf4j = "1.3.2"
   }


### PR DESCRIPTION
I've updated Scalameta to the new 4.0.0 release. This fixes a couple of issues we had with older versions (namely https://github.com/scalameta/scalameta/issues/1597 and https://github.com/scalameta/scalameta/issues/1526) and allows a small code cleanup. I've also updated some other dependencies while I was there.