### PR TITLE
Refactor all logging test code into LogMatcher

### DIFF
--- a/core/src/test/scala/stryker4s/config/ConfigReaderTest.scala
+++ b/core/src/test/scala/stryker4s/config/ConfigReaderTest.scala
@@ -2,13 +2,12 @@ package stryker4s.config
 
 import better.files.File
 import ch.qos.logback.classic.Level
-import org.scalatest.BeforeAndAfterEach
 import pureconfig.error.{ConfigReaderException, ConvertFailure}
+import stryker4s.Stryker4sSuite
 import stryker4s.run.report.ConsoleReporter
-import stryker4s.scalatest.FileUtil
-import stryker4s.{Stryker4sSuite, TestAppender}
+import stryker4s.scalatest.{FileUtil, LogMatchers}
 
-class ConfigReaderTest extends Stryker4sSuite with BeforeAndAfterEach {
+class ConfigReaderTest extends Stryker4sSuite with LogMatchers {
 
   describe("loadConfig") {
     it("should load default config with a nonexistent conf file") {
@@ -47,7 +46,9 @@ class ConfigReaderTest extends Stryker4sSuite with BeforeAndAfterEach {
       val result = ConfigReader.readConfig(confPath)
 
       result.baseDir shouldBe File("/tmp/project")
-      result.files shouldBe Seq("bar/src/main/**/*.scala", "foo/src/main/**/*.scala", "!excluded/file.scala")
+      result.files shouldBe Seq("bar/src/main/**/*.scala",
+                                "foo/src/main/**/*.scala",
+                                "!excluded/file.scala")
       result.testRunner shouldBe an[CommandRunner]
       result.logLevel shouldBe Level.DEBUG
       result.reporters.head shouldBe an[ConsoleReporter]
@@ -84,9 +85,5 @@ class ConfigReaderTest extends Stryker4sSuite with BeforeAndAfterEach {
       "Using default config instead..." shouldBe loggedAsWarning
       s"Config used: ${sut.toHoconString}" shouldBe loggedAsInfo
     }
-  }
-
-  override def afterEach(): Unit = {
-    TestAppender.reset
   }
 }

--- a/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
@@ -1,16 +1,15 @@
 package stryker4s.mutants
 
-import org.scalatest.BeforeAndAfterEach
+import stryker4s.Stryker4sSuite
 import stryker4s.config.Config
 import stryker4s.mutants.applymutants.{MatchBuilder, StatementTransformer}
 import stryker4s.mutants.findmutants.{MutantFinder, MutantMatcher}
-import stryker4s.scalatest.{FileUtil, TreeEquality}
+import stryker4s.scalatest.{FileUtil, LogMatchers, TreeEquality}
 import stryker4s.stubs.TestSourceCollector
-import stryker4s.{Stryker4sSuite, TestAppender}
 
 import scala.meta._
 
-class MutatorTest extends Stryker4sSuite with TreeEquality with BeforeAndAfterEach {
+class MutatorTest extends Stryker4sSuite with TreeEquality with LogMatchers {
 
   describe("run") {
     it("should return a single Tree with changed pattern match") {
@@ -58,9 +57,5 @@ class MutatorTest extends Stryker4sSuite with TreeEquality with BeforeAndAfterEa
       "Found 1 of 1 file(s) to be mutated." shouldBe loggedAsInfo
       "3 Mutant(s) generated" shouldBe loggedAsInfo
     }
-  }
-
-  override def afterEach(): Unit = {
-    TestAppender.reset
   }
 }

--- a/core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala
@@ -3,18 +3,13 @@ package stryker4s.mutants.findmutants
 import java.nio.file.NoSuchFileException
 
 import better.files.File
-import org.scalatest.BeforeAndAfterEach
+import stryker4s.Stryker4sSuite
 import stryker4s.scalatest.{FileUtil, LogMatchers, TreeEquality}
-import stryker4s.{Stryker4sSuite, TestAppender}
 
 import scala.meta._
 import scala.meta.parsers.ParseException
 
-class MutantFinderTest
-    extends Stryker4sSuite
-    with TreeEquality
-    with LogMatchers
-    with BeforeAndAfterEach {
+class MutantFinderTest extends Stryker4sSuite with TreeEquality with LogMatchers {
 
   private val exampleClassFile = FileUtil.getResource("scalaFiles/ExampleClass.scala")
   describe("parseFile") {
@@ -125,9 +120,5 @@ class MutantFinderTest
       s"Error while parsing file '$noFile', expected class or object definition" should be(
         loggedAsError)
     }
-  }
-
-  override def afterEach(): Unit = {
-    TestAppender.reset
   }
 }

--- a/core/src/test/scala/stryker4s/run/report/ReporterTest.scala
+++ b/core/src/test/scala/stryker4s/run/report/ReporterTest.scala
@@ -2,15 +2,14 @@ package stryker4s.run.report
 
 import org.mockito.IdiomaticMockito
 import org.mockito.MockitoSugar._
-import org.scalatest.BeforeAndAfterEach
+import stryker4s.Stryker4sSuite
 import stryker4s.config.Config
 import stryker4s.model.MutantRunResults
-import stryker4s.{Stryker4sSuite, TestAppender}
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class ReporterTest extends Stryker4sSuite with BeforeAndAfterEach with IdiomaticMockito {
+class ReporterTest extends Stryker4sSuite with IdiomaticMockito {
 
   describe("reporter") {
     it("should log that the console reporter is used when a non existing reporter is configured") {

--- a/util/src/test/scala/stryker4s/Stryker4sSuite.scala
+++ b/util/src/test/scala/stryker4s/Stryker4sSuite.scala
@@ -1,6 +1,10 @@
 package stryker4s
 
-import org.scalatest.{FunSpec, LoneElement, Matchers, OptionValues}
-import stryker4s.scalatest.LogMatchers
+import org.scalatest._
 
-trait Stryker4sSuite extends FunSpec with Matchers with OptionValues with LoneElement
+trait Stryker4sSuite
+    extends FunSpec
+    with Matchers
+    with OptionValues
+    with LoneElement
+    with BeforeAndAfterEach

--- a/util/src/test/scala/stryker4s/Stryker4sSuite.scala
+++ b/util/src/test/scala/stryker4s/Stryker4sSuite.scala
@@ -3,13 +3,4 @@ package stryker4s
 import org.scalatest.{FunSpec, LoneElement, Matchers, OptionValues}
 import stryker4s.scalatest.LogMatchers
 
-trait Stryker4sSuite extends FunSpec with Matchers with OptionValues with LoneElement with LogMatchers {
-
-  /**
-    * The className of the system under test.
-    * Is done by getting the executing test class and stripping off 'test'.
-    *
-    * This is used for logMatchers.
-    */
-  implicit val className: String =  getClass.getCanonicalName.replace("Test", "")
-}
+trait Stryker4sSuite extends FunSpec with Matchers with OptionValues with LoneElement

--- a/util/src/test/scala/stryker4s/scalatest/LogMatchers.scala
+++ b/util/src/test/scala/stryker4s/scalatest/LogMatchers.scala
@@ -2,11 +2,10 @@ package stryker4s.scalatest
 
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.spi.ILoggingEvent
-import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.{BeMatcher, MatchResult}
 import stryker4s.{Stryker4sSuite, TestAppender}
 
-trait LogMatchers extends BeforeAndAfterEach {
+trait LogMatchers {
   // Causes a compile error if LogMatchers is used without Stryker4sSuite
   this: Stryker4sSuite =>
 
@@ -21,9 +20,9 @@ trait LogMatchers extends BeforeAndAfterEach {
     * The className of the system under test.
     * Is done by getting the executing test class and stripping off 'test'.
     */
-  implicit val className: String = getClass.getCanonicalName.replace("Test", "")
+  private implicit val className: String = getClass.getCanonicalName.replace("Test", "")
 
-  class LogMatcherWithLevel(expectedLogLevel: Level)(implicit loggerClassName: String)
+  protected class LogMatcherWithLevel(expectedLogLevel: Level)(implicit loggerClassName: String)
       extends BeMatcher[String] {
     def apply(expectedLogMessage: String): MatchResult = {
       getLoggingEventWithLogMessage(expectedLogMessage) match {

--- a/util/src/test/scala/stryker4s/scalatest/LogMatchers.scala
+++ b/util/src/test/scala/stryker4s/scalatest/LogMatchers.scala
@@ -2,10 +2,26 @@ package stryker4s.scalatest
 
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.spi.ILoggingEvent
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.{BeMatcher, MatchResult}
-import stryker4s.TestAppender
+import stryker4s.{Stryker4sSuite, TestAppender}
 
-trait LogMatchers {
+trait LogMatchers extends BeforeAndAfterEach {
+  // Causes a compile error if LogMatchers is used without Stryker4sSuite
+  this: Stryker4sSuite =>
+
+  def loggedAsDebug = new LogMatcherWithLevel(Level.DEBUG)
+  def loggedAsInfo = new LogMatcherWithLevel(Level.INFO)
+  def loggedAsWarning = new LogMatcherWithLevel(Level.WARN)
+  def loggedAsError = new LogMatcherWithLevel(Level.ERROR)
+
+  override def afterEach(): Unit = TestAppender.reset
+
+  /**
+    * The className of the system under test.
+    * Is done by getting the executing test class and stripping off 'test'.
+    */
+  implicit val className: String = getClass.getCanonicalName.replace("Test", "")
 
   class LogMatcherWithLevel(expectedLogLevel: Level)(implicit loggerClassName: String)
       extends BeMatcher[String] {
@@ -28,21 +44,15 @@ trait LogMatchers {
           )
       }
     }
-  }
 
-  def loggedAsDebug(implicit loggerClassName: String) = new LogMatcherWithLevel(Level.DEBUG)
-  def loggedAsInfo(implicit loggerClassName: String) = new LogMatcherWithLevel(Level.INFO)
-  def loggedAsWarning(implicit loggerClassName: String) = new LogMatcherWithLevel(Level.WARN)
-  def loggedAsError(implicit loggerClassName: String) = new LogMatcherWithLevel(Level.ERROR)
+    private def validateLogLevel(actualLogLevel: Level, expectedLogLevel: Level): Boolean = {
+      expectedLogLevel.equals(actualLogLevel)
+    }
 
-  private[this] def validateLogLevel(actualLogLevel: Level, expectedLogLevel: Level): Boolean = {
-    expectedLogLevel.equals(actualLogLevel)
-  }
-
-  private[this] def getLoggingEventWithLogMessage(expectedLogMessage: String)
-                                                 (implicit loggerClassName: String): Option[ILoggingEvent] = {
-    TestAppender.events
-      .filter(logEvent => logEvent.getLoggerName.contains(loggerClassName))
-      .find(_.getFormattedMessage.contains(expectedLogMessage))
+    private def getLoggingEventWithLogMessage(expectedLogMessage: String): Option[ILoggingEvent] = {
+      TestAppender.events
+        .filter(logEvent => logEvent.getLoggerName.contains(loggerClassName))
+        .find(_.getFormattedMessage.contains(expectedLogMessage))
+    }
   }
 }


### PR DESCRIPTION
Refactors the logging test code into `LogMatcher`. This way, tests only have to extend `LogMatcher` to test logs, instead of also having to extend `BeforeAndAfterEach`. Tests now also don't have to call the `afterEach` to reset logs, but this is done automatically when extending `LogMatcher`. Also, because the implicit className is no longer in `Stryker4sSuite`, compile times are theoretically a little faster.