### PR TITLE
Add names to mutants so we can have it in the html report

### DIFF
--- a/core/src/main/scala/stryker4s/model/Mutant.scala
+++ b/core/src/main/scala/stryker4s/model/Mutant.scala
@@ -2,4 +2,4 @@ package stryker4s.model
 
 import scala.meta.Term
 
-case class Mutant(id: Int, original: Term, mutated: Term)
+case class Mutant(id: Int, original: Term, mutated: Term, mutatorName: String)

--- a/core/src/main/scala/stryker4s/mutants/applymutants/StatementTransformer.scala
+++ b/core/src/main/scala/stryker4s/mutants/applymutants/StatementTransformer.scala
@@ -25,7 +25,8 @@ class StatementTransformer {
 
     val transformedMutants = registered.map { mutant =>
       val newMutated = transformStatement(topStatement, mutant.original, mutant.mutated)
-      Mutant(mutant.id, topStatement, newMutated)
+
+      mutant.copy(original = topStatement, mutated = newMutated)
     }.toList
 
     TransformedMutants(topStatement, transformedMutants)

--- a/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
+++ b/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
@@ -17,7 +17,7 @@ class MutantMatcher {
       matchStringMutators() orElse
       matchMethodMutators()
 
-  def matchBinaryOperators(): PartialFunction[Tree, Seq[Mutant]] = {
+  def matchBinaryOperators(implicit mutatorName: String = "BinaryOperator"): PartialFunction[Tree, Seq[Mutant]] = {
     case GreaterThanEqualTo(orig) => orig ~~> (GreaterThan, LesserThan, EqualTo)
     case GreaterThan(orig)        => orig ~~> (GreaterThanEqualTo, LesserThan, EqualTo)
     case LesserThanEqualTo(orig)  => orig ~~> (LesserThan, GreaterThanEqualTo, EqualTo)
@@ -26,23 +26,23 @@ class MutantMatcher {
     case NotEqualTo(orig)         => orig ~~> EqualTo
   }
 
-  def matchBooleanSubstitutions(): PartialFunction[Tree, Seq[Mutant]] = {
+  def matchBooleanSubstitutions(implicit mutatorName: String = "BooleanSubstitution"): PartialFunction[Tree, Seq[Mutant]] = {
     case True(orig)  => orig ~~> False
     case False(orig) => orig ~~> True
   }
 
-  def matchLogicalOperators(): PartialFunction[Tree, Seq[Mutant]] = {
+  def matchLogicalOperators(implicit mutatorName: String = "LogicalOperator"): PartialFunction[Tree, Seq[Mutant]] = {
     case And(orig) => orig ~~> Or
     case Or(orig)  => orig ~~> And
   }
 
-  def matchStringMutators(): PartialFunction[Tree, Seq[Mutant]] = {
+  def matchStringMutators(implicit mutatorName: String = "StringMutator"): PartialFunction[Tree, Seq[Mutant]] = {
     case EmptyString(orig)         => orig ~~> StrykerWasHereString
     case NonEmptyString(orig)      => orig ~~> EmptyString
     case StringInterpolation(orig) => orig ~~> EmptyStringInterpolation
   }
 
-  def matchMethodMutators(): PartialFunction[Tree, Seq[Mutant]] = {
+  def matchMethodMutators(implicit mutatorName: String = "MethodMutator"): PartialFunction[Tree, Seq[Mutant]] = {
     case Filter(orig)      => orig ~~> FilterNot
     case FilterNot(orig)   => orig ~~> Filter
     case Exists(orig)      => orig ~~> ForAll
@@ -55,9 +55,9 @@ class MutantMatcher {
     case Min(orig)         => orig ~~> Max
   }
 
-  implicit class TermExtensions(original: Term) {
+  implicit class TermExtensions(original: Term)(implicit mutatorName: String) {
     def ~~>(mutated: Term*): Seq[Mutant] = {
-      mutated.map(mutant => Mutant(stream.next(), original, mutant))
+      mutated.map(mutant => Mutant(stream.next(), original, mutant, mutatorName))
     }
   }
 }

--- a/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
+++ b/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
@@ -17,7 +17,7 @@ class MutantMatcher {
       matchStringMutators() orElse
       matchMethodMutators()
 
-  def matchBinaryOperators(implicit mutatorName: String = "BinaryOperator"): PartialFunction[Tree, Seq[Mutant]] = {
+  def matchBinaryOperators(): PartialFunction[Tree, Seq[Mutant]] = {
     case GreaterThanEqualTo(orig) => orig ~~> (GreaterThan, LesserThan, EqualTo)
     case GreaterThan(orig)        => orig ~~> (GreaterThanEqualTo, LesserThan, EqualTo)
     case LesserThanEqualTo(orig)  => orig ~~> (LesserThan, GreaterThanEqualTo, EqualTo)
@@ -26,23 +26,23 @@ class MutantMatcher {
     case NotEqualTo(orig)         => orig ~~> EqualTo
   }
 
-  def matchBooleanSubstitutions(implicit mutatorName: String = "BooleanSubstitution"): PartialFunction[Tree, Seq[Mutant]] = {
+  def matchBooleanSubstitutions(): PartialFunction[Tree, Seq[Mutant]] = {
     case True(orig)  => orig ~~> False
     case False(orig) => orig ~~> True
   }
 
-  def matchLogicalOperators(implicit mutatorName: String = "LogicalOperator"): PartialFunction[Tree, Seq[Mutant]] = {
+  def matchLogicalOperators(): PartialFunction[Tree, Seq[Mutant]] = {
     case And(orig) => orig ~~> Or
     case Or(orig)  => orig ~~> And
   }
 
-  def matchStringMutators(implicit mutatorName: String = "StringMutator"): PartialFunction[Tree, Seq[Mutant]] = {
+  def matchStringMutators(): PartialFunction[Tree, Seq[Mutant]] = {
     case EmptyString(orig)         => orig ~~> StrykerWasHereString
     case NonEmptyString(orig)      => orig ~~> EmptyString
     case StringInterpolation(orig) => orig ~~> EmptyStringInterpolation
   }
 
-  def matchMethodMutators(implicit mutatorName: String = "MethodMutator"): PartialFunction[Tree, Seq[Mutant]] = {
+  def matchMethodMutators(): PartialFunction[Tree, Seq[Mutant]] = {
     case Filter(orig)      => orig ~~> FilterNot
     case FilterNot(orig)   => orig ~~> Filter
     case Exists(orig)      => orig ~~> ForAll
@@ -55,9 +55,9 @@ class MutantMatcher {
     case Min(orig)         => orig ~~> Max
   }
 
-  implicit class TermExtensions(original: Term)(implicit mutatorName: String) {
-    def ~~>(mutated: Term*): Seq[Mutant] = {
-      mutated.map(mutant => Mutant(stream.next(), original, mutant, mutatorName))
+  implicit class TermExtensions(original: Term) {
+    def ~~>(mutated: Mutation[_ <: Term]*): Seq[Mutant] = {
+      mutated.map(mutant => Mutant(stream.next(), original, mutant, mutant.mutationName))
     }
   }
 }

--- a/core/src/test/scala/stryker4s/Stryker4sTest.scala
+++ b/core/src/test/scala/stryker4s/Stryker4sTest.scala
@@ -40,9 +40,9 @@ class Stryker4sTest extends Stryker4sSuite {
 
       val expectedPath = Paths.get("simpleFile.scala")
       reportedResults should matchPattern {
-        case List(Killed(1, Mutant(0, _, _), `expectedPath`),
-                  Killed(1, Mutant(1, _, _), `expectedPath`),
-                  Killed(1, Mutant(2, _, _), `expectedPath`)) =>
+        case List(Killed(1, Mutant(0, _, _, _), `expectedPath`),
+                  Killed(1, Mutant(1, _, _, _), `expectedPath`),
+                  Killed(1, Mutant(2, _, _, _), `expectedPath`)) =>
       }
     }
   }

--- a/core/src/test/scala/stryker4s/mutants/applymutants/MatchBuilderTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/applymutants/MatchBuilderTest.scala
@@ -20,7 +20,7 @@ class MatchBuilderTest extends Stryker4sSuite with TreeEquality {
       val ids = Iterator.from(0)
       val originalStatement = q"x >= 15"
       val mutants = List(q"x > 15", q"x <= 15")
-        .map(Mutant(ids.next(), originalStatement, _))
+        .map(Mutant(ids.next(), originalStatement, _, "testMutant"))
       val sut = new MatchBuilder
 
       // Act
@@ -152,7 +152,7 @@ class MatchBuilderTest extends Stryker4sSuite with TreeEquality {
     val topStatement = source.find(origStatement).value.topStatement()
     val mutant = mutants
       .map(m => topStatement transformOnce { case orig if orig.isEqual(origStatement) => m })
-      .map(m => Mutant(ids.next(), topStatement, m.asInstanceOf[Term]))
+      .map(m => Mutant(ids.next(), topStatement, m.asInstanceOf[Term], "testMutant"))
       .toList
 
     TransformedMutants(topStatement, mutant)

--- a/core/src/test/scala/stryker4s/mutants/applymutants/StatementTransformerTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/applymutants/StatementTransformerTest.scala
@@ -66,7 +66,7 @@ class StatementTransformerTest extends Stryker4sSuite with TreeEquality {
       val originalTopTree = q"val x: Boolean = 15 >= 5"
       val originalTree = originalTopTree.find(q">=").value
       val mutants = List(EqualTo, GreaterThan, LesserThanEqualTo)
-        .map(Mutant(0, originalTree, _))
+        .map(Mutant(0, originalTree, _, "testMutant"))
 
       // Act
       val transformedMutant = sut.transformMutant(originalTree, mutants)
@@ -86,7 +86,7 @@ class StatementTransformerTest extends Stryker4sSuite with TreeEquality {
       val source = "object Foo { def bar: Boolean = 15 >= 4 }".parse[Source].get
       val origTree = source.find(q">=").value
       val mutants = List(EqualTo, GreaterThan, LesserThanEqualTo)
-        .map(Mutant(0, origTree, _))
+        .map(Mutant(0, origTree, _, "testMutant"))
 
       // Act
       val result = sut.transformSource(source, mutants)
@@ -105,11 +105,11 @@ class StatementTransformerTest extends Stryker4sSuite with TreeEquality {
 
     val firstOrigTree = source.find(q">=").value
     val firstMutants: Seq[Mutant] = List(EqualTo, GreaterThan, LesserThanEqualTo)
-      .map(Mutant(0, firstOrigTree, _))
+      .map(Mutant(0, firstOrigTree, _, "testMutant"))
 
     val secOrigTree = source.find(q"<").value
     val secondMutants: Seq[Mutant] = List(LesserThanEqualTo, GreaterThan, EqualTo)
-      .map(Mutant(0, secOrigTree, _))
+      .map(Mutant(0, secOrigTree, _, "testMutant"))
 
     val statements = firstMutants ++ secondMutants
 

--- a/core/src/test/scala/stryker4s/run/process/ProcessMutantRunnerTest.scala
+++ b/core/src/test/scala/stryker4s/run/process/ProcessMutantRunnerTest.scala
@@ -20,7 +20,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite {
     it("should return a Survived mutant on an exitcode 0 process") {
       val testProcessRunner = new TestProcessRunner(Success(0))
       val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner)
-      val mutant = Mutant(0, q"4", q"5")
+      val mutant = createMutant(0, q"4", q"5")
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
       val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant))
 
@@ -35,7 +35,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite {
     it("should return a Killed mutant on an exitcode 1 process") {
       val testProcessRunner = new TestProcessRunner(Success(1))
       val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner)
-      val mutant = Mutant(0, q"4", q"5")
+      val mutant = createMutant(0, q"4", q"5")
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
       val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant))
 
@@ -51,7 +51,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite {
       val exception = new TimeoutException("Test")
       val testProcessRunner = new TestProcessRunner(Failure(exception))
       val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner)
-      val mutant = Mutant(0, q"4", q"5")
+      val mutant = createMutant(0, q"4", q"5")
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
       val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant))
 
@@ -66,8 +66,8 @@ class ProcessMutantRunnerTest extends Stryker4sSuite {
     it("should return a combination of results on multiple runs") {
       val testProcessRunner = new TestProcessRunner(Success(1), Success(1))
       val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner)
-      val mutant = Mutant(0, q"0", q"zero")
-      val secondMutant = Mutant(1, q"1", q"one")
+      val mutant = createMutant(0, q"0", q"zero")
+      val secondMutant = createMutant(1, q"1", q"one")
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
       val mutants = Seq(mutant, secondMutant)
       val mutatedFile = MutatedFile(file, q"def foo = 4", mutants)
@@ -86,9 +86,9 @@ class ProcessMutantRunnerTest extends Stryker4sSuite {
     it("should return a mutationScore of 66.67 when 2 of 3 mutants are killed") {
       val testProcessRunner = new TestProcessRunner(Success(1), Success(1), Success(0))
       val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner)
-      val mutant = Mutant(0, q"0", q"zero")
-      val secondMutant = Mutant(1, q"1", q"one")
-      val thirdMutant = Mutant(2, q"5", q"5")
+      val mutant = createMutant(0, q"0", q"zero")
+      val secondMutant = createMutant(1, q"1", q"one")
+      val thirdMutant = createMutant(2, q"5", q"5")
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
       val mutants = Seq(mutant, secondMutant, thirdMutant)
       val mutatedFile = MutatedFile(file, q"def foo = 4", mutants)
@@ -104,5 +104,9 @@ class ProcessMutantRunnerTest extends Stryker4sSuite {
         Survived(thirdMutant, Paths.get("simpleFile.scala"))
       )
     }
+  }
+
+  private def createMutant(id: Int, original: Term, mutated: Term): Mutant = {
+    Mutant(id, original, mutated,"testMutant")
   }
 }

--- a/util/src/main/scala/stryker4s/extensions/mutationtypes/LogicalOperators.scala
+++ b/util/src/main/scala/stryker4s/extensions/mutationtypes/LogicalOperators.scala
@@ -1,10 +1,10 @@
 package stryker4s.extensions.mutationtypes
 import scala.meta.Term
 
-case object And extends BinaryOperator {
+case object And extends LogicalOperator {
   override val tree: Term.Name = Term.Name("&&")
 }
 
-case object Or extends BinaryOperator {
+case object Or extends LogicalOperator {
   override val tree: Term.Name = Term.Name("||")
 }

--- a/util/src/main/scala/stryker4s/extensions/mutationtypes/MutationTypes.scala
+++ b/util/src/main/scala/stryker4s/extensions/mutationtypes/MutationTypes.scala
@@ -12,18 +12,29 @@ import scala.meta.{Lit, Term, Tree}
   */
 sealed trait Mutation[T <: Tree] {
   val tree: T
+  val mutationName: String
 
   def unapply(arg: T): Option[T] = Some(arg).filter(a => a.isEqual(tree))
 }
 
-trait BinaryOperator extends Mutation[Term.Name]
+trait BinaryOperator extends Mutation[Term.Name] {
+  override val mutationName: String = "BinaryOperator"
+}
 
-trait BooleanSubstitution extends Mutation[Lit.Boolean]
+trait BooleanSubstitution extends Mutation[Lit.Boolean] {
+  override val mutationName: String = "BooleanSubstitution"
+}
 
-trait LogicalOperator extends Mutation[Term.Name]
+trait LogicalOperator extends Mutation[Term.Name] {
+  override val mutationName: String = "LogicalOperator"
+}
 
-trait MethodMutator extends Mutation[Term.Name]
+trait MethodMutator extends Mutation[Term.Name] {
+  override val mutationName: String = "MethodMutator"
+}
 
 /** T &lt;: Term because it can be either a `Lit.String` or `Term.Interpolation`
   */
-trait StringMutator[T <: Term] extends Mutation[T]
+trait StringMutator[T <: Term] extends Mutation[T] {
+  override val mutationName: String = "StringMutator"
+}


### PR DESCRIPTION
In the HTML reporter spec is a field called "mutatorName" so far we were not able to get this field filled. But with this merge request and because of the removal of the useless case classes we are able to do it in a semi-elegant way. 