### PR TITLE
Improve calculation of mutation score

### DIFF
--- a/core/src/main/scala/stryker4s/run/ProcessMutantRunner.scala
+++ b/core/src/main/scala/stryker4s/run/ProcessMutantRunner.scala
@@ -5,6 +5,7 @@ import java.nio.file.Path
 import better.files.File
 import grizzled.slf4j.Logging
 import stryker4s.config.Config
+import stryker4s.extensions.score.MutationScoreCalculator
 import stryker4s.model._
 import stryker4s.run.process.{Command, ProcessRunner}
 
@@ -14,6 +15,7 @@ import scala.util.{Failure, Success}
 
 class ProcessMutantRunner(command: Command, process: ProcessRunner)(implicit config: Config)
     extends MutantRunner
+    with MutationScoreCalculator
     with Logging {
 
   override def apply(files: Iterable[MutatedFile]): MutantRunResults = {
@@ -59,11 +61,5 @@ class ProcessMutantRunner(command: Command, process: ProcessRunner)(implicit con
       case Success(exitCode)                  => Killed(exitCode, mutant, subPath)
       case Failure(exc: TimeoutException)     => TimedOut(exc, mutant, subPath)
     }
-  }
-
-  private[this] def calculateMutationScore(totalMutants: Double,
-                                           detectedMutants: Double): Double = {
-    val mutationScore = detectedMutants / totalMutants * 100
-    BigDecimal(mutationScore).setScale(2, BigDecimal.RoundingMode.HALF_UP).toDouble
   }
 }

--- a/util/src/main/scala/stryker4s/extensions/score/MutationScoreCalculator.scala
+++ b/util/src/main/scala/stryker4s/extensions/score/MutationScoreCalculator.scala
@@ -1,0 +1,13 @@
+package stryker4s.extensions.score
+
+trait MutationScoreCalculator {
+
+  def calculateMutationScore(totalMutants: Double, detectedMutants: Double): Double = {
+    detectedMutants / totalMutants * 100 match {
+      case mutationScore if mutationScore.isNaN =>
+        0.00
+      case mutationScore =>
+        BigDecimal(mutationScore).setScale(2, BigDecimal.RoundingMode.HALF_UP).toDouble
+    }
+  }
+}

--- a/util/src/test/scala/stryker4s/extensions/score/MutationScoreCalculatorTest.scala
+++ b/util/src/test/scala/stryker4s/extensions/score/MutationScoreCalculatorTest.scala
@@ -31,5 +31,11 @@ class MutationScoreCalculatorTest extends Stryker4sSuite {
 
       mutationScore shouldBe 85.71
     }
+
+    it("Should give a mutation score of 66.67 when 6 of the 9 mutations are killed") {
+      val mutationScore = sut.calculateMutationScore(9, 6)
+
+      mutationScore shouldBe 66.67
+    }
   }
 }

--- a/util/src/test/scala/stryker4s/extensions/score/MutationScoreCalculatorTest.scala
+++ b/util/src/test/scala/stryker4s/extensions/score/MutationScoreCalculatorTest.scala
@@ -1,0 +1,29 @@
+package stryker4s.extensions.score
+import stryker4s.Stryker4sSuite
+
+class MutationScoreCalculatorTest extends Stryker4sSuite {
+
+  case object Sut extends MutationScoreCalculator
+
+  private val sut = Sut
+
+  describe("Calculating the mutation score") {
+    it("Should give a mutation score of 0.0 if no mutants were found") {
+      val mutationScore = sut.calculateMutationScore(0, 0)
+
+      mutationScore shouldBe 0.00
+    }
+
+    it("Should give a mutation score of 100.0 when all mutations are killed") {
+      val mutationScore = sut.calculateMutationScore(100, 100)
+
+      mutationScore shouldBe 100.00
+    }
+
+    it("Should give a mutation score of 85.71 when 12 of the 14 mutations are killed") {
+      val mutationScore = sut.calculateMutationScore(14, 12)
+
+      mutationScore shouldBe 85.71
+    }
+  }
+}

--- a/util/src/test/scala/stryker4s/extensions/score/MutationScoreCalculatorTest.scala
+++ b/util/src/test/scala/stryker4s/extensions/score/MutationScoreCalculatorTest.scala
@@ -8,13 +8,19 @@ class MutationScoreCalculatorTest extends Stryker4sSuite {
   private val sut = Sut
 
   describe("Calculating the mutation score") {
-    it("Should give a mutation score of 0.0 if no mutants were found") {
+    it("Should give a mutation score of 0.00 if no mutants were found") {
       val mutationScore = sut.calculateMutationScore(0, 0)
 
       mutationScore shouldBe 0.00
     }
 
-    it("Should give a mutation score of 100.0 when all mutations are killed") {
+    it("Should give a mutation score of 0.00 if 1 mutant is found and non are detected") {
+      val mutationScore = sut.calculateMutationScore(1, 0)
+
+      mutationScore shouldBe 0.00
+    }
+
+    it("Should give a mutation score of 100.00 when all mutations are killed") {
       val mutationScore = sut.calculateMutationScore(100, 100)
 
       mutationScore shouldBe 100.00


### PR DESCRIPTION
Currently, when the configuration is wrong and you will not find any mutations the mutation score calculation will do a divide by zero. 

Scala's behavior is not a DivideByZeroException by a NaN. This merge request will putt a check if it's a `NaN` and convert that back to a `0.00`