### PR TITLE
Fix matching on function names and add tests

### DIFF
--- a/core/src/test/scala/stryker4s/mutants/findmutants/MutantMatcherTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/MutantMatcherTest.scala
@@ -21,11 +21,15 @@ class MutantMatcherTest extends Stryker4sSuite with TreeEquality {
     expectedTerms.foreach(expectedTerm => expectMutations(found, original, expectedTerm))
   }
 
-  def expectMutations(actualMutants: Seq[Mutant], original: Term, expectedMutations: Term*): Unit = {
+  def expectMutations(actualMutants: Seq[Mutant],
+                      original: Term,
+                      expectedMutations: Term*): Unit = {
     expectedMutations.foreach(expectedMutation => {
       val actualMutant = actualMutants
-        .find(mutant => mutant.mutated.isEqual(expectedMutation) &&
-          mutant.original.isEqual(original))
+        .find(
+          mutant =>
+            mutant.mutated.isEqual(expectedMutation) &&
+              mutant.original.isEqual(original))
         .getOrElse(fail("mutant not found"))
 
       actualMutant.original should equal(original)
@@ -351,4 +355,37 @@ class MutantMatcherTest extends Stryker4sSuite with TreeEquality {
     }
   }
 
+  describe("no function name matching") {
+    it("should not match a function with a mutator name") {
+      val tree = q"def isEmpty = foo"
+
+      val result = tree collect sut.allMatchers()
+
+      result should be(empty)
+    }
+
+    it("should not match on a case class with a mutator name") {
+      val tree = q"case class indexOf(foo: String)"
+
+      val result = tree collect sut.allMatchers()
+
+      result should be(empty)
+    }
+
+    it("should not match on a variable with a mutator name") {
+      val tree = q"val min = 5"
+
+      val result = tree collect sut.allMatchers()
+
+      result should be(empty)
+    }
+
+    it("should match a function with a single expression") {
+      val tree = q"def isEmpty = exists"
+
+      val result = (tree collect sut.allMatchers()).flatten
+
+      result.map(_.original) should not contain q"isEmpty"
+    }
+  }
 }

--- a/util/src/main/scala/stryker4s/extensions/mutationtypes/MutationTypes.scala
+++ b/util/src/main/scala/stryker4s/extensions/mutationtypes/MutationTypes.scala
@@ -13,7 +13,13 @@ import scala.meta.{Lit, Term, Tree}
 sealed trait Mutation[T <: Tree] {
   val tree: T
 
-  def unapply(arg: T): Option[T] = Some(arg).filter(a => a.isEqual(tree))
+  def unapply(arg: T): Option[T] =
+    Some(arg)
+      .filter(_.isEqual(tree))
+      .filterNot(_ match { // Do not match on function definitions
+        case name: Term.Name => name.isDefinition
+        case _               => false
+      })
 }
 
 trait BinaryOperator extends Mutation[Term.Name]

--- a/util/src/main/scala/stryker4s/extensions/mutationtypes/MutationTypes.scala
+++ b/util/src/main/scala/stryker4s/extensions/mutationtypes/MutationTypes.scala
@@ -16,10 +16,10 @@ sealed trait Mutation[T <: Tree] {
   def unapply(arg: T): Option[T] =
     Some(arg)
       .filter(_.isEqual(tree))
-      .filterNot(_ match { // Do not match on function definitions
+      .filterNot {
         case name: Term.Name => name.isDefinition
         case _               => false
-      })
+      }
 }
 
 trait BinaryOperator extends Mutation[Term.Name]


### PR DESCRIPTION
Fixes #65 

Adds a matching condition on a Mutation. If it's a Term.Name, check if the tree is a definition or not (it shouldn't be)