### PR TITLE
Remove debug statement and add relativePath extension method

### DIFF
--- a/core/src/main/scala/stryker4s/extensions/FileExtensions.scala
+++ b/core/src/main/scala/stryker4s/extensions/FileExtensions.scala
@@ -1,0 +1,10 @@
+package stryker4s.extensions
+import java.nio.file.Path
+
+import better.files.File
+import stryker4s.config.Config
+object FileExtensions {
+  implicit class RelativePathExtension(file: File) {
+    def relativePath(implicit config: Config): Path = config.baseDir.relativize(file)
+  }
+}

--- a/core/src/main/scala/stryker4s/mutants/findmutants/MutantFinder.scala
+++ b/core/src/main/scala/stryker4s/mutants/findmutants/MutantFinder.scala
@@ -4,7 +4,7 @@ import better.files.File
 import grizzled.slf4j.Logging
 import stryker4s.config.Config
 import stryker4s.model.{Mutant, MutationsInSource}
-import stryker4s.extensions.FileExtensions._
+
 import scala.meta.Source
 import scala.meta.parsers.{Parsed, XtensionParseInputLike}
 
@@ -22,7 +22,6 @@ class MutantFinder(matcher: MutantMatcher)(implicit config: Config) extends Logg
   def parseFile(file: File): Source =
     file.toJava.parse[Source] match {
       case Parsed.Success(source) =>
-        debug(s"Parsed file '${file.relativePath}'")
         source
       case Parsed.Error(_, msg, ex) =>
         error(s"Error while parsing file '$file', $msg")

--- a/core/src/main/scala/stryker4s/mutants/findmutants/MutantFinder.scala
+++ b/core/src/main/scala/stryker4s/mutants/findmutants/MutantFinder.scala
@@ -4,7 +4,7 @@ import better.files.File
 import grizzled.slf4j.Logging
 import stryker4s.config.Config
 import stryker4s.model.{Mutant, MutationsInSource}
-
+import stryker4s.extensions.FileExtensions._
 import scala.meta.Source
 import scala.meta.parsers.{Parsed, XtensionParseInputLike}
 
@@ -24,7 +24,7 @@ class MutantFinder(matcher: MutantMatcher)(implicit config: Config) extends Logg
       case Parsed.Success(source) =>
         source
       case Parsed.Error(_, msg, ex) =>
-        error(s"Error while parsing file '$file', $msg")
+        error(s"Error while parsing file '${file.relativePath}', $msg")
         throw ex
     }
 }

--- a/core/src/main/scala/stryker4s/mutants/findmutants/MutantFinder.scala
+++ b/core/src/main/scala/stryker4s/mutants/findmutants/MutantFinder.scala
@@ -2,12 +2,13 @@ package stryker4s.mutants.findmutants
 
 import better.files.File
 import grizzled.slf4j.Logging
+import stryker4s.config.Config
 import stryker4s.model.{Mutant, MutationsInSource}
-
+import stryker4s.extensions.FileExtensions._
 import scala.meta.Source
 import scala.meta.parsers.{Parsed, XtensionParseInputLike}
 
-class MutantFinder(matcher: MutantMatcher) extends Logging {
+class MutantFinder(matcher: MutantMatcher)(implicit config: Config) extends Logging {
 
   def mutantsInFile(filePath: File): MutationsInSource = {
     val parsedSource = parseFile(filePath)
@@ -21,7 +22,7 @@ class MutantFinder(matcher: MutantMatcher) extends Logging {
   def parseFile(file: File): Source =
     file.toJava.parse[Source] match {
       case Parsed.Success(source) =>
-        debug(s"Parsed file '$file'")
+        debug(s"Parsed file '${file.relativePath}'")
         source
       case Parsed.Error(_, msg, ex) =>
         error(s"Error while parsing file '$file', $msg")

--- a/core/src/main/scala/stryker4s/run/ProcessMutantRunner.scala
+++ b/core/src/main/scala/stryker4s/run/ProcessMutantRunner.scala
@@ -5,6 +5,7 @@ import java.nio.file.Path
 import better.files.File
 import grizzled.slf4j.Logging
 import stryker4s.config.Config
+import stryker4s.extensions.FileExtensions._
 import stryker4s.model._
 import stryker4s.run.process.{Command, ProcessRunner}
 
@@ -26,7 +27,7 @@ class ProcessMutantRunner(command: Command, process: ProcessRunner)(implicit con
     // Overwrite files to mutated files
     files foreach {
       case MutatedFile(file, tree, _) =>
-        val subPath = config.baseDir.relativize(file)
+        val subPath = file.relativePath
         val filePath = tmpDir / subPath.toString
         filePath.overwrite(tree.syntax)
     }
@@ -35,7 +36,7 @@ class ProcessMutantRunner(command: Command, process: ProcessRunner)(implicit con
 
     val runResults = for {
       mutatedFile <- files
-      subPath = config.baseDir.relativize(mutatedFile.fileOrigin)
+      subPath = mutatedFile.fileOrigin.relativePath
       mutant <- mutatedFile.mutants
     } yield {
       val result = runMutant(mutant, tmpDir, subPath)

--- a/core/src/test/scala/stryker4s/extensions/FileExtensionsTest.scala
+++ b/core/src/test/scala/stryker4s/extensions/FileExtensionsTest.scala
@@ -1,0 +1,32 @@
+package stryker4s.extensions
+import java.nio.file.Paths
+
+import better.files._
+import stryker4s.Stryker4sSuite
+import stryker4s.config.Config
+import stryker4s.extensions.FileExtensions._
+
+class FileExtensionsTest extends Stryker4sSuite {
+  describe("relativePath") {
+    implicit val config: Config = Config()
+
+    it("should return the relative path on a file inside the base-dir") {
+      val expectedRelativePath =
+        Paths.get("util/src/test/scala/stryker4s/extensions/FileExtensions.scala")
+      val sut = File.currentWorkingDirectory / expectedRelativePath.toString
+
+      val result = sut.relativePath
+
+      result should equal(expectedRelativePath)
+    }
+
+    it("should return just the file name when a file is in the base-dir") {
+      val expectedRelativePath = Paths.get("build.sbt")
+      val sut = File.currentWorkingDirectory / expectedRelativePath.toString
+
+      val result = sut.relativePath
+
+      result should equal(expectedRelativePath)
+    }
+  }
+}

--- a/core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala
@@ -4,14 +4,18 @@ import java.nio.file.NoSuchFileException
 
 import better.files.File
 import stryker4s.Stryker4sSuite
+import stryker4s.config.Config
 import stryker4s.scalatest.{FileUtil, LogMatchers, TreeEquality}
-
+import stryker4s.extensions.FileExtensions._
 import scala.meta._
 import scala.meta.parsers.ParseException
 
 class MutantFinderTest extends Stryker4sSuite with TreeEquality with LogMatchers {
 
+  private implicit val config: Config = Config()
+
   private val exampleClassFile = FileUtil.getResource("scalaFiles/ExampleClass.scala")
+
   describe("parseFile") {
     it("should parse an existing file") {
       val sut = new MutantFinder(new MutantMatcher)
@@ -104,11 +108,12 @@ class MutantFinderTest extends Stryker4sSuite with TreeEquality with LogMatchers
   describe("logging") {
     it("should debug log a parsed file") {
       val sut = new MutantFinder(new MutantMatcher)
-      val file = exampleClassFile
+      val file = File.currentWorkingDirectory / "core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala"
 
       sut.parseFile(file)
 
-      s"Parsed file '$exampleClassFile'" should be(loggedAsDebug)
+      val relativePath = file.relativePath
+      s"Parsed file '$relativePath'" should be(loggedAsDebug)
     }
 
     it("should error log an unfound file") {

--- a/core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala
@@ -112,7 +112,7 @@ class MutantFinderTest extends Stryker4sSuite with TreeEquality with LogMatchers
 
       a[ParseException] should be thrownBy sut.parseFile(noFile)
 
-      s"Error while parsing file '$noFile', expected class or object definition" should be(
+      s"Error while parsing file '${noFile.relativePath}', expected class or object definition" should be(
         loggedAsError)
     }
   }

--- a/core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala
@@ -106,16 +106,6 @@ class MutantFinderTest extends Stryker4sSuite with TreeEquality with LogMatchers
   }
 
   describe("logging") {
-    it("should debug log a parsed file") {
-      val sut = new MutantFinder(new MutantMatcher)
-      val file = File.currentWorkingDirectory / "core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala"
-
-      sut.parseFile(file)
-
-      val relativePath = file.relativePath
-      s"Parsed file '$relativePath'" should be(loggedAsDebug)
-    }
-
     it("should error log an unfound file") {
       val sut = new MutantFinder(new MutantMatcher)
       val noFile = FileUtil.getResource("scalaFiles/nonParseableFile.notScala")


### PR DESCRIPTION
I've removed the `Parsed file: ...` debug log as it was causing a lot of random test failures, and didn't add much. Any error during parsing should already log the causing file.. 

I've also added a .relativePath extension method on `File` for ease of use