### PR TITLE
Change config setting files to mutate

### DIFF
--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -3,12 +3,6 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <layout class="ch.qos.logback.classic.PatternLayout">
-
-            <!-- Produce log output like this -->
-            <!-- 15:05:28.776 grizzled.slf4j.Logger: Setting logging level to INFO. -->
-            <!-- 15:05:32.142 grizzled.slf4j.Logger: Found 16 of 36 file(s) to be mutated. -->
-            <!-- 15:05:32.145 grizzled.slf4j.Logger: 81 Mutant(s) generated -->
-            <!-- 15:05:32.678 grizzled.slf4j.Logger: Starting test-run 0... -->
             <Pattern>
                 %d{HH:mm:ss.SSS} %-5level %logger{0}: %msg%n
             </Pattern>

--- a/core/src/main/scala/stryker4s/Stryker4s.scala
+++ b/core/src/main/scala/stryker4s/Stryker4s.scala
@@ -12,8 +12,8 @@ class Stryker4s(fileCollector: SourceCollector,
                 reporter: Reporter)(implicit config: Config) {
 
   def run(): Unit = {
-    val files = fileCollector.collectFiles()
-    val mutatedFiles = mutator.mutate(files)
+    val filesToMutate = fileCollector.collectFilesToMutate()
+    val mutatedFiles = mutator.mutate(filesToMutate)
     val runResults = runner(mutatedFiles)
     reporter.report(runResults)
   }

--- a/core/src/main/scala/stryker4s/config/Config.scala
+++ b/core/src/main/scala/stryker4s/config/Config.scala
@@ -8,7 +8,7 @@ import com.typesafe.config.ConfigRenderOptions
 import pureconfig.ConfigWriter
 import stryker4s.run.report.{ConsoleReporter, MutantRunReporter}
 
-case class Config(files: Seq[String] = Seq("**/main/scala/**/*.scala"),
+case class Config(mutate: Seq[String] = Seq("**/main/scala/**/*.scala"),
                   baseDir: File = File.currentWorkingDirectory,
                   testRunner: TestRunner = CommandRunner("sbt", "test"),
                   reporters: List[MutantRunReporter] = List(new ConsoleReporter),

--- a/core/src/main/scala/stryker4s/mutants/findmutants/FileCollector.scala
+++ b/core/src/main/scala/stryker4s/mutants/findmutants/FileCollector.scala
@@ -4,24 +4,24 @@ import better.files._
 import stryker4s.config.Config
 
 trait SourceCollector {
-  def collectFiles(): Iterable[File]
+  def collectFilesToMutate(): Iterable[File]
 }
 
 class FileCollector(implicit config: Config) extends SourceCollector {
 
-  override def collectFiles(): Iterable[File] = {
-    filesToMutate.filterNot(file => filesToExclude.contains(file))
+  override def collectFilesToMutate(): Iterable[File] = {
+    filesToMutate.filterNot(file => filesToExcludeFromMutation.contains(file))
   }
 
   private[this] val filesToMutate: Seq[File] = {
-    config.files
+    config.mutate
       .filterNot(file => file.startsWith("!"))
       .flatMap(config.baseDir.glob(_))
       .distinct
   }
 
-  private[this] val filesToExclude: Seq[File] = {
-    config.files
+  private[this] val filesToExcludeFromMutation: Seq[File] = {
+    config.mutate
       .filter(file => file.startsWith("!"))
       .flatMap(file => config.baseDir.glob(file.stripPrefix("!")))
       .distinct

--- a/core/src/test/resources/stryker4sconfs/filled.conf
+++ b/core/src/test/resources/stryker4sconfs/filled.conf
@@ -1,5 +1,5 @@
 stryker4s {
-  files: [
+  mutate: [
     "bar/src/main/**/*.scala",
     "foo/src/main/**/*.scala",
     "!excluded/file.scala"

--- a/core/src/test/resources/stryker4sconfs/wrongReporter.conf
+++ b/core/src/test/resources/stryker4sconfs/wrongReporter.conf
@@ -1,5 +1,5 @@
 stryker4s {
-  files: [
+  mutate: [
     "bar/src/main/**/*.scala",
     "foo/src/main/**/*.scala",
     "!excluded/file.scala"

--- a/core/src/test/scala/stryker4s/config/ConfigReaderTest.scala
+++ b/core/src/test/scala/stryker4s/config/ConfigReaderTest.scala
@@ -16,7 +16,7 @@ class ConfigReaderTest extends Stryker4sSuite with LogMatchers {
       val result = ConfigReader.readConfig(confPath)
 
       result.baseDir shouldBe File.currentWorkingDirectory
-      result.files shouldBe Seq("**/main/scala/**/*.scala")
+      result.mutate shouldBe Seq("**/main/scala/**/*.scala")
       result.testRunner shouldBe an[CommandRunner]
       result.logLevel shouldBe Level.INFO
       result.reporters.head shouldBe an[ConsoleReporter]
@@ -46,7 +46,7 @@ class ConfigReaderTest extends Stryker4sSuite with LogMatchers {
       val result = ConfigReader.readConfig(confPath)
 
       result.baseDir shouldBe File("/tmp/project")
-      result.files shouldBe Seq("bar/src/main/**/*.scala",
+      result.mutate shouldBe Seq("bar/src/main/**/*.scala",
                                 "foo/src/main/**/*.scala",
                                 "!excluded/file.scala")
       result.testRunner shouldBe an[CommandRunner]

--- a/core/src/test/scala/stryker4s/config/ConfigTest.scala
+++ b/core/src/test/scala/stryker4s/config/ConfigTest.scala
@@ -12,10 +12,10 @@ class ConfigTest extends Stryker4sSuite {
 
       val expected =
         s"""base-dir="${File.currentWorkingDirectory.pathAsString.replace("\\", "\\\\")}"
-           |files=[
+           |log-level=INFO
+           |mutate=[
            |    "**/main/scala/**/*.scala"
            |]
-           |log-level=INFO
            |reporters=[
            |    console
            |]
@@ -38,11 +38,11 @@ class ConfigTest extends Stryker4sSuite {
 
       val expected =
         s"""base-dir="${File("tmp").pathAsString.replace("\\", "\\\\")}"
-           |files=[
+           |log-level=INFO
+           |mutate=[
            |    "**/main/scala/**/Foo.scala",
            |    "**/main/scala/**/Bar.scala"
            |]
-           |log-level=INFO
            |reporters=[
            |    console
            |]

--- a/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
@@ -15,7 +15,7 @@ class MutatorTest extends Stryker4sSuite with TreeEquality with LogMatchers {
     it("should return a single Tree with changed pattern match") {
       implicit val conf: Config = Config()
       val files = new TestSourceCollector(Seq(FileUtil.getResource("scalaFiles/simpleFile.scala")))
-        .collectFiles()
+        .collectFilesToMutate()
 
       val sut = new Mutator(
         new MutantFinder(new MutantMatcher),
@@ -44,7 +44,7 @@ class MutatorTest extends Stryker4sSuite with TreeEquality with LogMatchers {
     it("should log the amount of mutants found") {
       implicit val conf: Config = Config()
       val files = new TestSourceCollector(Seq(FileUtil.getResource("scalaFiles/simpleFile.scala")))
-        .collectFiles()
+        .collectFilesToMutate()
 
       val sut = new Mutator(
         new MutantFinder(new MutantMatcher),

--- a/core/src/test/scala/stryker4s/mutants/findmutants/FileCollectorTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/FileCollectorTest.scala
@@ -15,7 +15,7 @@ class FileCollectorTest extends Stryker4sSuite {
         implicit val config: Config = Config(baseDir = emptyDir)
         val sut = new FileCollector()
 
-        val results = sut.collectFiles()
+        val results = sut.collectFilesToMutate()
 
         results should be(empty)
       }
@@ -32,7 +32,7 @@ class FileCollectorTest extends Stryker4sSuite {
         implicit val config: Config = Config(baseDir = filledDirPath)
         val sut = new FileCollector()
 
-        val results = sut.collectFiles()
+        val results = sut.collectFilesToMutate()
 
         results should have size 2
         results should contain only (basePath / "someFile.scala", basePath / "secondFile.scala")
@@ -40,10 +40,10 @@ class FileCollectorTest extends Stryker4sSuite {
 
       it("should find matching files with custom config match pattern") {
         implicit val config: Config =
-          Config(files = Seq("src/**/second*.scala"), baseDir = filledDirPath)
+          Config(mutate = Seq("src/**/second*.scala"), baseDir = filledDirPath)
         val sut = new FileCollector()
 
-        val results = sut.collectFiles()
+        val results = sut.collectFilesToMutate()
         val onlyResult = results.loneElement
 
         onlyResult should equal(basePath / "secondFile.scala")
@@ -51,20 +51,20 @@ class FileCollectorTest extends Stryker4sSuite {
 
       it("should find no matches with a non-matching glob") {
         implicit val config: Config =
-          Config(files = Seq("**/noMatchesToBeFoundHere.scala"), baseDir = filledDirPath)
+          Config(mutate = Seq("**/noMatchesToBeFoundHere.scala"), baseDir = filledDirPath)
         val sut = new FileCollector()
 
-        val results = sut.collectFiles()
+        val results = sut.collectFilesToMutate()
 
         results should be(empty)
       }
 
       it("should match on multiple globs") {
         implicit val config: Config =
-          Config(files = Seq("**/someFile.scala", "**/secondFile.scala"), baseDir = filledDirPath)
+          Config(mutate = Seq("**/someFile.scala", "**/secondFile.scala"), baseDir = filledDirPath)
         val sut = new FileCollector()
 
-        val results = sut.collectFiles()
+        val results = sut.collectFilesToMutate()
 
         results should have size 2
         results should contain only (basePath / "someFile.scala", basePath / "secondFile.scala")
@@ -72,17 +72,17 @@ class FileCollectorTest extends Stryker4sSuite {
 
       it("should only add a glob once even when it matches twice") {
         implicit val config: Config =
-          Config(files = Seq("**/someFile.scala", "**/*.scala"), baseDir = filledDirPath)
+          Config(mutate = Seq("**/someFile.scala", "**/*.scala"), baseDir = filledDirPath)
         val sut = new FileCollector()
 
-        val results = sut.collectFiles()
+        val results = sut.collectFilesToMutate()
 
         results should have size 2
         results should contain only (basePath / "someFile.scala", basePath / "secondFile.scala")
       }
 
       it("should not find a file twice when the patterns match on the same file twice") {
-        implicit val config: Config = Config(files = Seq("**/someFile.scala",
+        implicit val config: Config = Config(mutate = Seq("**/someFile.scala",
                                                          "**/secondFile.scala",
                                                          "!**/*.scala",
                                                          "!**/someFile.scala"),
@@ -90,27 +90,28 @@ class FileCollectorTest extends Stryker4sSuite {
 
         val sut = new FileCollector()
 
-        val results = sut.collectFiles()
+        val results = sut.collectFilesToMutate()
 
         results should be(empty)
       }
 
       it("Should exclude the file specified in the excluded files config") {
         implicit val config: Config = Config(
-          files = Seq("**/someFile.scala", "**/secondFile.scala", "!**/someFile.scala"),
+          mutate = Seq("**/someFile.scala", "**/secondFile.scala", "!**/someFile.scala"),
           baseDir = filledDirPath
         )
 
         val sut = new FileCollector()
 
-        val results = sut.collectFiles()
+        val results = sut.collectFilesToMutate()
 
         results should have size 1
         results should contain only (basePath / "secondFile.scala")
       }
 
       it("Should exclude all files specified in the excluded files config") {
-        implicit val config: Config = Config(files = Seq("**/someFile.scala",
+        implicit val config: Config = Config(
+          mutate = Seq("**/someFile.scala",
                                                          "**/secondFile.scala",
                                                          "!**/someFile.scala",
                                                          "!**/secondFile.scala"),
@@ -118,33 +119,33 @@ class FileCollectorTest extends Stryker4sSuite {
 
         val sut = new FileCollector()
 
-        val results = sut.collectFiles()
+        val results = sut.collectFilesToMutate()
 
         results should be(empty)
       }
 
       it("Should exclude all files based on a wildcard") {
         implicit val config: Config = Config(
-          files = Seq("**/someFile.scala", "**/secondFile.scala", "!**/*.scala"),
+          mutate = Seq("**/someFile.scala", "**/secondFile.scala", "!**/*.scala"),
           baseDir = filledDirPath
         )
 
         val sut = new FileCollector()
 
-        val results = sut.collectFiles()
+        val results = sut.collectFilesToMutate()
 
         results should be(empty)
       }
 
       it("Should not exclude a non existing file") {
         implicit val config: Config = Config(
-          files = Seq("**/someFile.scala", "**/secondFile.scala", "!**/nonExistingFile.scala"),
+          mutate = Seq("**/someFile.scala", "**/secondFile.scala", "!**/nonExistingFile.scala"),
           baseDir = filledDirPath
         )
 
         val sut = new FileCollector()
 
-        val results = sut.collectFiles()
+        val results = sut.collectFilesToMutate()
 
         results should have size 2
         results should contain only (basePath / "someFile.scala", basePath / "secondFile.scala")

--- a/core/src/test/scala/stryker4s/stubs/TestSourceCollector.scala
+++ b/core/src/test/scala/stryker4s/stubs/TestSourceCollector.scala
@@ -4,5 +4,5 @@ import better.files.File
 import stryker4s.mutants.findmutants.SourceCollector
 
 class TestSourceCollector(returns: Iterable[File]) extends SourceCollector {
-  override def collectFiles(): Iterable[File] = returns
+  override def collectFilesToMutate(): Iterable[File] = returns
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -10,11 +10,11 @@ stryker4s {
 
 #### Files to mutate
 
-**Config file:** `files: [ "**/main/scala/**/*.scala" ]`  
+**Config file:** `mutate: [ "**/main/scala/**/*.scala" ]`  
 **Default value:** `[ "**/main/scala/**/*.scala" ]`  
 **Mandatory:** No  
 **Description:**  
-With `files` you configure the subset of files to use for mutation testing. 
+With `mutate` you configure the subset of files to use for mutation testing. 
 Generally speaking, these should be your own source files.  
 The default for this will find files in the common Scala project format. 
 


### PR DESCRIPTION
Changed the config settings `files` to `mutate` this is also reflected in [Stryker config](https://github.com/stryker-mutator/stryker/blob/master/packages/stryker/README.md#configuration)

Also, we need the `files` settings as a backup plan on collecting files to copy over files to the tmp folder.