### PR TITLE
Fix sbt so it can be run from the root

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,14 +2,12 @@ lazy val root = (project withId "stryker4s" in file("."))
   .settings(
     name := "stryker4s",
     crossScalaVersions := Dependencies.versions.crossScala,
+    mainClass in (Compile, run) := Some("stryker4s.run.Stryker4sRunner")
   )
   .aggregate(stryker4sCore, stryker4sUtil)
-  .dependsOn(stryker4sCore) // So `sbt run` can be used in root project
+  .dependsOn(stryker4sCore)
 
 lazy val stryker4sCore = (project withId "stryker4s-core" in file("core"))
-  .settings(
-    mainClass := Some("stryker4s.run.Stryker4sRunner")
-  )
   .settings(Settings.commonSettings)
   .dependsOn(stryker4sUtil)
   .dependsOn(stryker4sUtil % "test -> test")


### PR DESCRIPTION
As reported on Gitter it was not possible to run `sbt run` from the root of the project.

This will make it possible to run `sbt run` from the root of the project.