### PR TITLE
Update scala from 2.12.6 to 2.12.7

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
 
   object versions {
-    val scala212 = "2.12.6"
+    val scala212 = "2.12.7"
     val scala211 = "2.11.12"
     val crossScala = Seq(scala211, scala212)
 


### PR DESCRIPTION
Bringing [up to 10% improvement in compiler performance](https://github.com/scala/scala/releases/tag/v2.12.7). Which is always a nice thing to have