### PR TITLE
Improve log messages when a match can not be build

### DIFF
--- a/core/src/main/scala/stryker4s/mutants/applymutants/MatchBuilder.scala
+++ b/core/src/main/scala/stryker4s/mutants/applymutants/MatchBuilder.scala
@@ -1,13 +1,14 @@
 package stryker4s.mutants.applymutants
 
+import grizzled.slf4j.Logging
 import stryker4s.extensions.TreeExtensions.ImplicitTreeExtensions
 import stryker4s.model.{Mutant, SourceTransformations, TransformedMutants}
 
 import scala.meta.contrib.implicits.Equality.XtensionTreeEquality
-import scala.meta.quasiquotes._
-import scala.meta.{Case, Lit, Pat, Term, Tree}
+import scala.meta.{Case, Lit, Pat, Term, Tree, _}
+import scala.util.{Failure, Success}
 
-class MatchBuilder {
+class MatchBuilder extends Logging {
 
   def buildNewSource(transformedStatements: SourceTransformations): Tree = {
     val source = transformedStatements.source
@@ -20,6 +21,16 @@ class MatchBuilder {
         rest transformOnce {
           case found if found.isEqual(origStatement) && found.pos == origStatement.pos =>
             buildMatch(mutant)
+        } match {
+          case Success(value) => value
+          case Failure(exception) =>
+            error(
+              s"Failed to construct pattern match: original statement [$origStatement] " +
+                s"on line [${origStatement.pos.endLine}] for file [${origStatement.pos.input}].)")
+            error(s"Failed mutation(s) ${mutant.mutantStatements.mkString(",")}.")
+            debug(exception.getMessage)
+
+            throw exception
         }
       }
   }

--- a/core/src/test/scala/stryker4s/mutants/applymutants/MatchBuilderTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/applymutants/MatchBuilderTest.scala
@@ -1,12 +1,13 @@
 package stryker4s.mutants.applymutants
 
-import stryker4s.Stryker4sSuite
+import stryker4s.{Stryker4sSuite, model}
 import stryker4s.extensions.TreeExtensions._
 import stryker4s.model.{Mutant, SourceTransformations, TransformedMutants}
 import stryker4s.scalatest.TreeEquality
 
 import scala.meta._
 import scala.meta.contrib._
+import scala.language.postfixOps
 
 class MatchBuilderTest extends Stryker4sSuite with TreeEquality {
   private val activeMutationExpr: Term.Apply = {
@@ -157,7 +158,7 @@ class MatchBuilderTest extends Stryker4sSuite with TreeEquality {
       implicit ids: Iterator[Int]): TransformedMutants = {
     val topStatement = source.find(origStatement).value.topStatement()
     val mutant = mutants
-      .map(m => topStatement transformOnce { case orig if orig.isEqual(origStatement) => m })
+      .map(m => topStatement transformOnce { case orig if orig.isEqual(origStatement) => m } get )
       .map(m => Mutant(ids.next(), topStatement, m.asInstanceOf[Term]))
       .toList
 

--- a/util/src/main/scala/stryker4s/extensions/TreeExtensions.scala
+++ b/util/src/main/scala/stryker4s/extensions/TreeExtensions.scala
@@ -3,6 +3,7 @@ package stryker4s.extensions
 import scala.annotation.tailrec
 import scala.meta.contrib._
 import scala.meta.{Case, Lit, Term, Transformer, Tree}
+import scala.util.Try
 
 object TreeExtensions {
 
@@ -67,17 +68,17 @@ object TreeExtensions {
       * This causes a StackOverflowError when the transformation that is searched for is also present in the newly transformed tree. <br>
       * This function does not recursively go into the transformed tree
       */
-    def transformOnce(fn: PartialFunction[Tree, Tree]): Tree = {
-      val liftedFn = fn.lift
-      val transformer = new OnceTransformer(liftedFn)
-      transformer(thisTree)
+    def transformOnce(fn: PartialFunction[Tree, Tree]): Try[Tree] = {
+      Try {
+        val liftedFn = fn.lift
+        val transformer = new OnceTransformer(liftedFn)
+        transformer(thisTree)
+      }
     }
 
     private class OnceTransformer(liftedFn: Tree => Option[Tree]) extends Transformer {
       override def apply(tree: Tree): Tree =
         liftedFn(tree).getOrElse(super.apply(tree))
     }
-
   }
-
 }

--- a/util/src/test/scala/stryker4s/extensions/TreeExtensionsTest.scala
+++ b/util/src/test/scala/stryker4s/extensions/TreeExtensionsTest.scala
@@ -279,7 +279,7 @@ class TreeExtensionsTest extends Stryker4sSuite with TreeEquality {
     it("should transform does not recursively transform new subtree") {
       val sut = q"def foo = 5"
 
-      val result = sut.transformOnce({ case q"5" => q"5 + 1" })
+      val result = sut.transformOnce({ case q"5" => q"5 + 1" }).get
 
       result should equal(q"def foo = 5 + 1")
     }
@@ -287,7 +287,7 @@ class TreeExtensionsTest extends Stryker4sSuite with TreeEquality {
     it("should transform both appearances in the tree only once") {
       val sut = q"def foo = 5 + 5"
 
-      val result = sut.transformOnce({ case q"5" => q"(5 * 2)" })
+      val result = sut.transformOnce({ case q"5" => q"(5 * 2)" }).get
 
       result should equal(q"def foo = (5 * 2) + (5 * 2)")
     }
@@ -295,7 +295,7 @@ class TreeExtensionsTest extends Stryker4sSuite with TreeEquality {
     it("should return the same tree if no transformation is applied") {
       val sut = q"def foo = 5"
 
-      val result = sut.transformOnce({ case q"6" => q"6 + 1" })
+      val result = sut.transformOnce({ case q"6" => q"6 + 1" }).get
 
       result should be theSameInstanceAs sut
     }
@@ -303,7 +303,7 @@ class TreeExtensionsTest extends Stryker4sSuite with TreeEquality {
     it("should transform a parsed string and have changed syntax") {
       val sut = "val x: Int = 5".parse[Stat].get
 
-      val result = sut.transformOnce({ case q"5" => q"6" })
+      val result = sut.transformOnce({ case q"5" => q"6" }).get
 
       val expected = q"val x: Int = 6"
       result should equal(expected)


### PR DESCRIPTION
Fixes: #80 

Improved logging statement. 
Unable to test because there are no known statements at the moment that break so the exception was force tested at run time.