### PR TITLE
Fix test runs start from 1 and not use the mutant id's.

### DIFF
--- a/core/src/main/scala/stryker4s/run/ProcessMutantRunner.scala
+++ b/core/src/main/scala/stryker4s/run/ProcessMutantRunner.scala
@@ -54,9 +54,8 @@ class ProcessMutantRunner(command: Command, process: ProcessRunner)(implicit con
       mutant <- mutatedFile.mutants
     } yield {
       val result = runMutant(mutant, tmpDir, subPath)
-      val id = mutant.id
-      info(
-        s"Finished mutation run $id/$totalMutants (${((id / totalMutants.toDouble) * 100).round}%)")
+      val id = mutant.id + 1
+      info(s"Finished mutation run $id/$totalMutants (${((id / totalMutants.toDouble) * 100).round}%)")
       result
     }
 
@@ -68,7 +67,7 @@ class ProcessMutantRunner(command: Command, process: ProcessRunner)(implicit con
 
   private[this] def runMutant(mutant: Mutant, workingDir: File, subPath: Path): MutantRunResult = {
     val id = mutant.id
-    info(s"Starting test-run $id...")
+    info(s"Starting test-run ${id + 1}...")
     process(command, workingDir, ("ACTIVE_MUTATION", id.toString)) match {
       case Success(exitCode) if exitCode == 0 => Survived(mutant, subPath)
       case Success(exitCode)                  => Killed(exitCode, mutant, subPath)


### PR DESCRIPTION
The logging for mutations runs began at 0 so we would get awkward scenarios like this:

```
Finished mutation run 15/16 (94%)
Mutation run finished! Took 191 seconds
Total mutants: 16, detected: 16, undetected: 0

```