### PR TITLE
Update mockito-scala version

### DIFF
--- a/core/src/test/scala/stryker4s/mutants/findmutants/FileCollectorTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/FileCollectorTest.scala
@@ -1,8 +1,7 @@
 package stryker4s.mutants.findmutants
 
 import better.files.File
-import org.mockito.ArgumentMatchers._
-import org.mockito.MockitoSugar
+import org.mockito.integrations.scalatest.MockitoFixture
 import stryker4s.Stryker4sSuite
 import stryker4s.config.Config
 import stryker4s.run.process.{Command, ProcessRunner}
@@ -10,7 +9,7 @@ import stryker4s.scalatest.{FileUtil, LogMatchers}
 
 import scala.util.{Failure, Try}
 
-class FileCollectorTest extends Stryker4sSuite with MockitoSugar with LogMatchers {
+class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatchers {
 
   private val filledDirPath: File = FileUtil.getResource("fileTests/filledDir")
   private val basePath: File = filledDirPath / "src/main/scala/package"

--- a/core/src/test/scala/stryker4s/run/process/ProcessMutantRunnerTest.scala
+++ b/core/src/test/scala/stryker4s/run/process/ProcessMutantRunnerTest.scala
@@ -2,8 +2,7 @@ package stryker4s.run.process
 
 import java.nio.file.Paths
 
-import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.mockito.integrations.scalatest.MockitoFixture
 import stryker4s.Stryker4sSuite
 import stryker4s.config.Config
 import stryker4s.model._
@@ -16,7 +15,7 @@ import scala.concurrent.TimeoutException
 import scala.meta._
 import scala.util.{Failure, Success}
 
-class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoSugar with LogMatchers {
+class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with LogMatchers {
 
   private implicit val config: Config = Config(baseDir = FileUtil.getResource("scalaFiles"))
   private val fileCollectorMock: SourceCollector = mock[SourceCollector]

--- a/core/src/test/scala/stryker4s/run/report/ReporterTest.scala
+++ b/core/src/test/scala/stryker4s/run/report/ReporterTest.scala
@@ -1,7 +1,6 @@
 package stryker4s.run.report
 
-import org.mockito.IdiomaticMockito
-import org.mockito.MockitoSugar._
+import org.mockito.integrations.scalatest.MockitoFixture
 import stryker4s.Stryker4sSuite
 import stryker4s.config.Config
 import stryker4s.model.MutantRunResults
@@ -9,7 +8,7 @@ import stryker4s.model.MutantRunResults
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class ReporterTest extends Stryker4sSuite with IdiomaticMockito {
+class ReporterTest extends Stryker4sSuite with MockitoFixture {
 
   describe("reporter") {
     it("should log that the console reporter is used when a non existing reporter is configured") {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
     val scalameta = "4.0.0"
     val pureconfig = "0.9.2"
     val scalatest = "3.0.5"
-    val mockitoScala = "0.4.5"
+    val mockitoScala = "1.0.1"
     val betterFiles = "3.6.0"
     val log4j = "2.11.1"
     val grizzledSlf4j = "1.3.2"


### PR DESCRIPTION
I've updated the mockito-scala version and changed some of the usages and imports to `MockitoFixture`, which gives all the needed imports as well as giving each test it's own mock context