### PR TITLE
Move interpolation fix to Mutator to fix all interpolated strings

### DIFF
--- a/core/src/test/resources/scalaFiles/simpleFile.scala
+++ b/core/src/test/resources/scalaFiles/simpleFile.scala
@@ -1,3 +1,4 @@
 object Foo {
   def bar = 15 > 14
+  def foobar = s"${bar}foo"
 }

--- a/core/src/test/scala/stryker4s/Stryker4sTest.scala
+++ b/core/src/test/scala/stryker4s/Stryker4sTest.scala
@@ -7,8 +7,8 @@ import stryker4s.model.{Killed, Mutant}
 import stryker4s.mutants.Mutator
 import stryker4s.mutants.applymutants.{MatchBuilder, StatementTransformer}
 import stryker4s.mutants.findmutants.{MutantFinder, MutantMatcher}
-import stryker4s.run.process.Command
 import stryker4s.run.ProcessMutantRunner
+import stryker4s.run.process.Command
 import stryker4s.scalatest.FileUtil
 import stryker4s.stubs.{TestProcessRunner, TestReporter, TestSourceCollector}
 
@@ -22,7 +22,7 @@ class Stryker4sTest extends Stryker4sSuite {
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
       val testFiles = Seq(file)
       val testSourceCollector = new TestSourceCollector(testFiles)
-      val testProcessRunner = new TestProcessRunner(Success(1), Success(1), Success(1))
+      val testProcessRunner = new TestProcessRunner(Success(1), Success(1), Success(1), Success(1))
       val testMutantRunner = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner)
       val testReporter = new TestReporter
 
@@ -42,7 +42,8 @@ class Stryker4sTest extends Stryker4sSuite {
       reportedResults should matchPattern {
         case List(Killed(1, Mutant(0, _, _, _), `expectedPath`),
                   Killed(1, Mutant(1, _, _, _), `expectedPath`),
-                  Killed(1, Mutant(2, _, _, _), `expectedPath`)) =>
+                  Killed(1, Mutant(2, _, _, _), `expectedPath`),
+                  Killed(1, Mutant(3, _, _, _), `expectedPath`)) =>
       }
     }
   }

--- a/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
@@ -36,6 +36,14 @@ class MutatorTest extends Stryker4sSuite with TreeEquality with LogMatchers {
                        |    case _ =>
                        |      15 > 14
                        |  }
+                       |  def foobar = sys.env.get("ACTIVE_MUTATION") match {
+                       |    case Some("3") =>
+                       |      s""
+                       |    case _ =>
+                       |      s"${{
+                       |        bar
+                       |      }}foo"
+                       |  }
                        |}""".stripMargin.parse[Source].get
       result.loneElement.tree should equal(expected)
     }
@@ -55,7 +63,23 @@ class MutatorTest extends Stryker4sSuite with TreeEquality with LogMatchers {
       sut.mutate(files)
 
       "Found 1 of 1 file(s) to be mutated." shouldBe loggedAsInfo
-      "3 Mutant(s) generated" shouldBe loggedAsInfo
+      "4 Mutant(s) generated" shouldBe loggedAsInfo
+    }
+  }
+
+  describe("string interpolation") {
+
+    it("checks if the Scalameta workaround is still needed") {
+      // If this test fails, the bug mentioned above is fixed, and the workaround can be removed
+      val interpolated =
+        Term.Interpolate(q"s",
+          List(Lit.String("interpolate this"), Lit.String("bar")),
+          List(q"foo"))
+
+      // We expect that after the fix the interpolate string will look as followed.
+      // interpolated.syntax should equal("""s"interpolate this${foo}bar"""")
+
+      interpolated.syntax should equal("""s"interpolate this$foobar"""")
     }
   }
 }

--- a/util/src/main/scala/stryker4s/extensions/mutationtypes/StringMutators.scala
+++ b/util/src/main/scala/stryker4s/extensions/mutationtypes/StringMutators.scala
@@ -31,17 +31,8 @@ case object StringInterpolation {
   import scala.meta.contrib.implicits.Equality._
 
   def unapply(arg: Term.Interpolate): Option[Term.Interpolate] =
-    Some(arg).filter(_.prefix.isEqual(Term.Name("s"))) map wrapInterpolatedVariableInBlock
+    Some(arg).filter(_.prefix.isEqual(Term.Name("s")))
 
-  /** Wrap a `Term.Name` args of a `Term.Interpolate` args in a `Term.Block` to work around a bug in Scalameta: https://github.com/scalameta/scalameta/issues/1792
-    */
-  private def wrapInterpolatedVariableInBlock(interpolation: Term.Interpolate): Term.Interpolate = {
-    val Term.Interpolate(prefix, parts, args) = interpolation
-    Term.Interpolate(prefix, parts, args.map {
-      case t: Term.Name => Term.Block(List(t))
-      case other        => other
-    })
-  }
 }
 
 private object ParentIsInterpolatedString {


### PR DESCRIPTION
This fix changes all interpolated strings to wrap Term.Block statements around it, instead of just around mutated ones. See also #102.  Turns out simple unit tests aren't everything after all. I've added a interpolated test case to the `MutatorTest`, which closer tests the actual result. 