### PR TITLE
Fix logging incorrect percentages when mutants are excluded

### DIFF
--- a/core/src/main/scala/stryker4s/config/Config.scala
+++ b/core/src/main/scala/stryker4s/config/Config.scala
@@ -3,7 +3,6 @@ package stryker4s.config
 import better.files._
 import org.apache.logging.log4j.Level
 import pureconfig.ConfigWriter
-import stryker4s.mutants.Exclusions
 import stryker4s.run.report.{ConsoleReporter, MutantRunReporter}
 
 case class Config(mutate: Seq[String] = Seq("**/main/scala/**/*.scala"),
@@ -12,7 +11,7 @@ case class Config(mutate: Seq[String] = Seq("**/main/scala/**/*.scala"),
                   reporters: List[MutantRunReporter] = List(new ConsoleReporter),
                   logLevel: Level = Level.INFO,
                   files: Option[Seq[String]] = None,
-                  excludedMutations: Exclusions = Exclusions(Set.empty)) {
+                  excludedMutations: Set[String] = Set.empty) {
 
   def toHoconString: String = {
     import stryker4s.config.implicits.ConfigWriterImplicits._

--- a/core/src/main/scala/stryker4s/config/implicits/ConfigReaderImplicits.scala
+++ b/core/src/main/scala/stryker4s/config/implicits/ConfigReaderImplicits.scala
@@ -7,7 +7,6 @@ import org.apache.logging.log4j.Level
 import pureconfig.ConfigReader
 import stryker4s.extensions.exceptions.InvalidExclusionsException
 import stryker4s.extensions.mutationtypes.Mutation
-import stryker4s.mutants.Exclusions
 import stryker4s.run.report.{ConsoleReporter, MutantRunReporter}
 
 trait ConfigReaderImplicits extends Logging {
@@ -26,13 +25,11 @@ trait ConfigReaderImplicits extends Logging {
       case MutantRunReporter.`consoleReporter` => new ConsoleReporter
     })
 
-  private[config] implicit val exclusions: ConfigReader[Exclusions] =
-    ConfigReader[List[String]]
-      .map(errorOnInvalidExclusions)
-      .map(exclusions => Exclusions(exclusions.toSet))
+  private[config] implicit val exclusions: ConfigReader[Set[String]] =
+    ConfigReader[List[String]].map(errorOnInvalidExclusions).map(_.toSet)
 
-  private def errorOnInvalidExclusions(list: List[String]): List[String] = {
-    val (valid, invalid) = list.partition(Mutation.mutations.contains)
+  private def errorOnInvalidExclusions(exclusions: List[String]): List[String] = {
+    val (valid, invalid) = exclusions.partition(Mutation.mutations.contains)
     if (invalid.nonEmpty) throw InvalidExclusionsException(invalid)
 
     valid

--- a/core/src/main/scala/stryker4s/config/implicits/ConfigWriterImplicits.scala
+++ b/core/src/main/scala/stryker4s/config/implicits/ConfigWriterImplicits.scala
@@ -5,7 +5,6 @@ import better.files.File
 import com.typesafe.config.ConfigRenderOptions
 import org.apache.logging.log4j.Level
 import pureconfig.ConfigWriter
-import stryker4s.mutants.Exclusions
 import stryker4s.run.report.{ConsoleReporter, MutantRunReporter}
 
 object ConfigWriterImplicits {
@@ -13,8 +12,7 @@ object ConfigWriterImplicits {
   private[config] implicit val fileWriter: ConfigWriter[File] = ConfigWriter[Path].contramap[File](_.path)
   private[config] implicit val logLevelWriter: ConfigWriter[Level] =
     ConfigWriter[String].contramap[Level](_.toString)
-  private[config] implicit val exclusionsWriter: ConfigWriter[Exclusions] =
-    ConfigWriter[List[String]].contramap(_.exclusions.toList)
+  private[config] implicit val exclusionsWriter: ConfigWriter[Set[String]] = ConfigWriter[Set[String]]
 
   private[config] implicit val reportersWriter: ConfigWriter[List[MutantRunReporter]] = ConfigWriter[List[String]]
     .contramap(mutantRunReporters =>

--- a/core/src/main/scala/stryker4s/config/implicits/ConfigWriterImplicits.scala
+++ b/core/src/main/scala/stryker4s/config/implicits/ConfigWriterImplicits.scala
@@ -12,7 +12,8 @@ object ConfigWriterImplicits {
   private[config] implicit val fileWriter: ConfigWriter[File] = ConfigWriter[Path].contramap[File](_.path)
   private[config] implicit val logLevelWriter: ConfigWriter[Level] =
     ConfigWriter[String].contramap[Level](_.toString)
-  private[config] implicit val exclusionsWriter: ConfigWriter[Set[String]] = ConfigWriter[Set[String]]
+  private[config] implicit val exclusionsWriter: ConfigWriter[Set[String]] =
+    ConfigWriter[List[String]].contramap[Set[String]](_.toList)
 
   private[config] implicit val reportersWriter: ConfigWriter[List[MutantRunReporter]] = ConfigWriter[List[String]]
     .contramap(mutantRunReporters =>

--- a/core/src/main/scala/stryker4s/model/MutatedFile.scala
+++ b/core/src/main/scala/stryker4s/model/MutatedFile.scala
@@ -4,4 +4,4 @@ import better.files.File
 
 import scala.meta.Tree
 
-case class MutatedFile(fileOrigin: File, tree: Tree, mutants: Seq[Mutant], excludedMutants: Seq[Mutant])
+case class MutatedFile(fileOrigin: File, tree: Tree, mutants: Seq[Mutant], excludedMutants: Int)

--- a/core/src/main/scala/stryker4s/model/MutationsInSource.scala
+++ b/core/src/main/scala/stryker4s/model/MutationsInSource.scala
@@ -2,4 +2,4 @@ package stryker4s.model
 
 import scala.meta.Source
 
-case class MutationsInSource(source: Source, mutants: Seq[Mutant], excluded: Seq[Mutant])
+case class MutationsInSource(source: Source, mutants: Seq[Mutant], excluded: Int)

--- a/core/src/main/scala/stryker4s/mutants/Exclusions.scala
+++ b/core/src/main/scala/stryker4s/mutants/Exclusions.scala
@@ -1,10 +1,3 @@
 package stryker4s.mutants
 
-import stryker4s.model.Mutant
-
-case class Exclusions(exclusions: Set[String]) {
-
-  def shouldExclude(mutant: Mutant): Boolean = {
-    exclusions.contains(mutant.mutationType.mutationName)
-  }
-}
+case class Exclusions(exclusions: Set[String]) {}

--- a/core/src/main/scala/stryker4s/mutants/Exclusions.scala
+++ b/core/src/main/scala/stryker4s/mutants/Exclusions.scala
@@ -1,3 +1,0 @@
-package stryker4s.mutants
-
-case class Exclusions(exclusions: Set[String]) {}

--- a/core/src/main/scala/stryker4s/mutants/Mutator.scala
+++ b/core/src/main/scala/stryker4s/mutants/Mutator.scala
@@ -22,7 +22,7 @@ class Mutator(mutantFinder: MutantFinder,
         val interpolatedFix = wrapInterpolations(builtTree)
         MutatedFile(file, interpolatedFix, mutationsInSource.mutants, mutationsInSource.excluded)
       }
-      .filterNot(mutatedFile => mutatedFile.mutants.isEmpty && mutatedFile.excludedMutants.isEmpty)
+      .filterNot(mutatedFile => mutatedFile.mutants.isEmpty && mutatedFile.excludedMutants == 0)
 
     logMutationResult(mutatedFiles, files.size)
 
@@ -46,7 +46,7 @@ class Mutator(mutantFinder: MutantFinder,
   private def logMutationResult(mutatedFiles: Iterable[MutatedFile],
                                 totalAmountOfFiles: Int): Unit = {
     val includedMutants = mutatedFiles.flatMap(_.mutants).size
-    val excludedMutants = mutatedFiles.flatMap(_.excludedMutants).size
+    val excludedMutants = mutatedFiles.map(_.excludedMutants).sum
 
     info(s"Found ${mutatedFiles.size} of $totalAmountOfFiles file(s) to be mutated.")
     info(s"${includedMutants + excludedMutants} Mutant(s) generated.")

--- a/core/src/main/scala/stryker4s/mutants/findmutants/MutantFinder.scala
+++ b/core/src/main/scala/stryker4s/mutants/findmutants/MutantFinder.scala
@@ -16,8 +16,9 @@ class MutantFinder(matcher: MutantMatcher)(implicit config: Config) extends Logg
     MutationsInSource(parsedSource, included, excluded)
   }
 
-  def findMutants(source: Source): (Seq[Mutant], Seq[Mutant]) = {
-    source.collect(matcher.allMatchers()).flatten.partition(m => !config.excludedMutations.shouldExclude(m))
+  def findMutants(source: Source): (Seq[Mutant], Int) = {
+    val (included, excluded) = source.collect(matcher.allMatchers()).flatten.partition(_.isDefined)
+    (included.flatten, excluded.size)
   }
 
   def parseFile(file: File): Source =

--- a/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
+++ b/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
@@ -62,7 +62,7 @@ class MutantMatcher()(implicit config: Config) {
   implicit class TermExtensions(original: Term) {
     def ~~>[T <: Term](mutated: SubstitutionMutation[T]*): Seq[Option[Mutant]] = {
       mutated.map(mutation => {
-        if (config.excludedMutations.exclusions.contains(mutation.mutationName))
+        if (config.excludedMutations.contains(mutation.mutationName))
           None
         else
           Some(Mutant(stream.next, original, mutation.tree, mutation))
@@ -70,7 +70,7 @@ class MutantMatcher()(implicit config: Config) {
     }
 
     def ~~>(mutated: MethodMutator, f: String => Term): Seq[Option[Mutant]] = {
-      if (config.excludedMutations.exclusions.contains(mutated.mutationName))
+      if (config.excludedMutations.contains(mutated.mutationName))
         None :: Nil
       else
         Some(Mutant(stream.next, original, mutated.apply(f), mutated)) :: Nil

--- a/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
+++ b/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
@@ -62,18 +62,21 @@ class MutantMatcher()(implicit config: Config) {
   implicit class TermExtensions(original: Term) {
     def ~~>[T <: Term](mutated: SubstitutionMutation[T]*): Seq[Option[Mutant]] = {
       mutated.map(mutation => {
-        if (config.excludedMutations.contains(mutation.mutationName))
+        if (matchExcluded(mutation))
           None
         else
           Some(Mutant(stream.next, original, mutation.tree, mutation))
       })
     }
-
     def ~~>(mutated: MethodMutator, f: String => Term): Seq[Option[Mutant]] = {
-      if (config.excludedMutations.contains(mutated.mutationName))
+      if (matchExcluded(mutated))
         None :: Nil
       else
         Some(Mutant(stream.next, original, mutated.apply(f), mutated)) :: Nil
+    }
+
+    private def matchExcluded(mutation: Mutation[_]): Boolean = {
+      config.excludedMutations.contains(mutation.mutationName)
     }
   }
 

--- a/core/src/main/scala/stryker4s/run/ProcessMutantRunner.scala
+++ b/core/src/main/scala/stryker4s/run/ProcessMutantRunner.scala
@@ -55,7 +55,7 @@ class ProcessMutantRunner(command: Command, process: ProcessRunner)(implicit con
       id = mutatedFiles.flatMap(_.mutants).toSeq.indexOf(mutant) + 1
     } yield {
       val result = runMutant(mutant, tmpDir, subPath, id)
-      info(s"Finished mutation run (id: ${mutant.id}) $id/$totalMutants (${((id / totalMutants.toDouble) * 100).round}%)")
+      info(s"Finished mutation run (id: $id/$totalMutants (${((id / totalMutants.toDouble) * 100).round}%)")
       result
     }
 

--- a/core/src/main/scala/stryker4s/run/ProcessMutantRunner.scala
+++ b/core/src/main/scala/stryker4s/run/ProcessMutantRunner.scala
@@ -55,7 +55,7 @@ class ProcessMutantRunner(command: Command, process: ProcessRunner)(implicit con
       id = mutatedFiles.flatMap(_.mutants).toSeq.indexOf(mutant) + 1
     } yield {
       val result = runMutant(mutant, tmpDir, subPath, id)
-      info(s"Finished mutation run (id: $id/$totalMutants (${((id / totalMutants.toDouble) * 100).round}%)")
+      info(s"Finished mutation run $id/$totalMutants (${((id / totalMutants.toDouble) * 100).round}%)")
       result
     }
 

--- a/core/src/main/scala/stryker4s/run/ProcessMutantRunner.scala
+++ b/core/src/main/scala/stryker4s/run/ProcessMutantRunner.scala
@@ -57,7 +57,7 @@ class ProcessMutantRunner(command: Command, process: ProcessRunner)(implicit con
     val runResults = mutantsWithPath.zipWithIndex.map{ case ((mutant, subPath), index) =>
       val id = index + 1
       val result = runMutant(mutant, tmpDir, subPath, id)
-      info(s"Finished mutation run id(${mutant.id}) $id/$totalMutants (${((id / totalMutants.toDouble) * 100).round}%)")
+      info(s"Finished mutation run $id/$totalMutants (${((id / totalMutants.toDouble) * 100).round}%)")
       result
     }
 

--- a/core/src/main/scala/stryker4s/run/ProcessMutantRunner.scala
+++ b/core/src/main/scala/stryker4s/run/ProcessMutantRunner.scala
@@ -67,7 +67,7 @@ class ProcessMutantRunner(command: Command, process: ProcessRunner)(implicit con
 
   private[this] def runMutant(mutant: Mutant, workingDir: File, subPath: Path, id: Int): MutantRunResult = {
     info(s"Starting test-run $id...")
-    process(command, workingDir, ("ACTIVE_MUTATION", id.toString)) match {
+    process(command, workingDir, ("ACTIVE_MUTATION", (id - 1).toString)) match {
       case Success(exitCode) if exitCode == 0 => Survived(mutant, subPath)
       case Success(exitCode)                  => Killed(exitCode, mutant, subPath)
       case Failure(exc: TimeoutException)     => TimedOut(exc, mutant, subPath)

--- a/core/src/test/scala/stryker4s/config/ConfigReaderTest.scala
+++ b/core/src/test/scala/stryker4s/config/ConfigReaderTest.scala
@@ -52,7 +52,7 @@ class ConfigReaderTest extends Stryker4sSuite with LogMatchers {
       result.testRunner shouldBe an[CommandRunner]
       result.logLevel shouldBe Level.DEBUG
       result.reporters.head shouldBe an[ConsoleReporter]
-      result.excludedMutations.exclusions shouldBe Set("BooleanSubstitution")
+      result.excludedMutations shouldBe Set("BooleanSubstitution")
     }
 
     it("should return a failure on an invalid exclusion mutator") {

--- a/core/src/test/scala/stryker4s/config/ConfigTest.scala
+++ b/core/src/test/scala/stryker4s/config/ConfigTest.scala
@@ -2,7 +2,6 @@ package stryker4s.config
 
 import better.files.File
 import stryker4s.Stryker4sSuite
-import stryker4s.mutants.Exclusions
 
 class ConfigTest extends Stryker4sSuite {
   describe("toHoconString") {
@@ -35,7 +34,7 @@ class ConfigTest extends Stryker4sSuite {
       val sut = Config(filePaths,
                        File("tmp"),
                        testRunner = CommandRunner("mvn", "clean test"),
-                       excludedMutations = Exclusions(Set("BooleanSubstitution")))
+                       excludedMutations = Set("BooleanSubstitution"))
 
       val result = sut.toHoconString
 

--- a/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
@@ -65,6 +65,24 @@ class MutatorTest extends Stryker4sSuite with TreeEquality with LogMatchers {
       "Found 1 of 1 file(s) to be mutated." shouldBe loggedAsInfo
       "4 Mutant(s) generated" shouldBe loggedAsInfo
     }
+
+    it("should log the amount of excluded mutants") {
+      implicit val conf: Config = Config(excludedMutations = Exclusions(Set("BinaryOperator")))
+      val files = new TestSourceCollector(Seq(FileUtil.getResource("scalaFiles/simpleFile.scala")))
+        .collectFilesToMutate()
+
+      val sut = new Mutator(
+        new MutantFinder(new MutantMatcher),
+        new StatementTransformer,
+        new MatchBuilder
+      )
+
+      sut.mutate(files)
+
+      "Found 1 of 1 file(s) to be mutated." shouldBe loggedAsInfo
+      "4 Mutant(s) generated" shouldBe loggedAsInfo
+      s"Of which 3 Mutant(s) are excluded." shouldBe loggedAsInfo
+    }
   }
 
   describe("string interpolation") {

--- a/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
@@ -67,7 +67,7 @@ class MutatorTest extends Stryker4sSuite with TreeEquality with LogMatchers {
     }
 
     it("should log the amount of excluded mutants") {
-      implicit val conf: Config = Config(excludedMutations = Exclusions(Set("BinaryOperator")))
+      implicit val conf: Config = Config(excludedMutations = Set("BinaryOperator"))
       val files = new TestSourceCollector(Seq(FileUtil.getResource("scalaFiles/simpleFile.scala")))
         .collectFilesToMutate()
 

--- a/core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala
@@ -6,7 +6,6 @@ import better.files.File
 import stryker4s.Stryker4sSuite
 import stryker4s.config.Config
 import stryker4s.extensions.FileExtensions._
-import stryker4s.mutants.Exclusions
 import stryker4s.scalatest.{FileUtil, LogMatchers, TreeEquality}
 
 import scala.meta._
@@ -88,7 +87,7 @@ class MutantFinderTest extends Stryker4sSuite with TreeEquality with LogMatchers
     }
 
     it("should filter out excluded mutants") {
-      val conf: Config = config.copy(excludedMutations = Exclusions(Set("LogicalOperator")))
+      val conf: Config = config.copy(excludedMutations = Set("LogicalOperator"))
       val sut = new MutantFinder(new MutantMatcher()(conf))(conf)
       val source =
         source"""case class Bar(s: String) {

--- a/core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala
@@ -88,13 +88,16 @@ class MutantFinderTest extends Stryker4sSuite with TreeEquality with LogMatchers
     }
 
     it("should filter out excluded mutants") {
-      val sut = new MutantFinder(new MutantMatcher)(config.copy(excludedMutations = Exclusions(Set("LogicalOperator"))))
+      val conf: Config = config.copy(excludedMutations = Exclusions(Set("LogicalOperator")))
+      val sut = new MutantFinder(new MutantMatcher()(conf))(conf)
       val source =
         source"""case class Bar(s: String) {
                     def and(a: Boolean, b: Boolean) = a && b
                   }"""
 
       val result = sut.findMutants(source)._1
+      val excluded = sut.findMutants(source)._2
+      excluded shouldBe 1
       result should have length 0
     }
   }

--- a/core/src/test/scala/stryker4s/run/process/ProcessMutantRunnerTest.scala
+++ b/core/src/test/scala/stryker4s/run/process/ProcessMutantRunnerTest.scala
@@ -14,7 +14,7 @@ import stryker4s.stubs.TestProcessRunner
 
 import scala.concurrent.TimeoutException
 import scala.meta._
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
 class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with LogMatchers {
 
@@ -27,7 +27,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
       val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner)
       val mutant = Mutant(0, q"4", q"5", EmptyString)
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
-      val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant), Seq())
+      val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant), 0)
 
       when(fileCollectorMock.filesToCopy(testProcessRunner)).thenReturn(List(file))
 
@@ -44,7 +44,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
       val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner)
       val mutant = Mutant(0, q"4", q"5", EmptyString)
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
-      val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant), Seq())
+      val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant), 0)
 
       when(fileCollectorMock.filesToCopy(testProcessRunner)).thenReturn(List(file))
 
@@ -62,7 +62,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
       val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner)
       val mutant = Mutant(0, q"4", q"5", EmptyString)
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
-      val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant), Seq())
+      val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant), 0)
 
       when(fileCollectorMock.filesToCopy(testProcessRunner)).thenReturn(List(file))
 
@@ -81,7 +81,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
       val secondMutant = Mutant(1, q"1", q"one", EmptyString)
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
       val mutants = Seq(mutant, secondMutant)
-      val mutatedFile = MutatedFile(file, q"def foo = 4", mutants, Seq())
+      val mutatedFile = MutatedFile(file, q"def foo = 4", mutants, 0)
 
       when(fileCollectorMock.filesToCopy(testProcessRunner)).thenReturn(List(file))
 
@@ -104,7 +104,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
       val thirdMutant = Mutant(2, q"5", q"5", EmptyString)
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
       val mutants = Seq(mutant, secondMutant, thirdMutant)
-      val mutatedFile = MutatedFile(file, q"def foo = 4", mutants, Seq())
+      val mutatedFile = MutatedFile(file, q"def foo = 4", mutants, 0)
 
       when(fileCollectorMock.filesToCopy(testProcessRunner)).thenReturn(List(file))
 
@@ -126,7 +126,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
         val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner)
         val mutant = Mutant(0, q"4", q"5", EmptyString)
         val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
-        val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant), Seq())
+        val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant), 0)
 
         when(fileCollectorMock.filesToCopy(testProcessRunner)).thenReturn(List(file))
 
@@ -142,7 +142,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
         val mutant0 = Mutant(0, q"4", q"5", EmptyString)
         val mutant1 = Mutant(1, q"4", q"5", EmptyString)
         val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
-        val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant0, mutant1), Seq())
+        val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant0, mutant1), 0)
 
         when(fileCollectorMock.filesToCopy(testProcessRunner)).thenReturn(List(file))
 

--- a/util/src/main/scala/stryker4s/extensions/exceptions/InvalidExclusionsException.scala
+++ b/util/src/main/scala/stryker4s/extensions/exceptions/InvalidExclusionsException.scala
@@ -1,7 +1,7 @@
 package stryker4s.extensions.exceptions
 import stryker4s.extensions.mutationtypes.Mutation
 
-case class InvalidExclusionsException(invalid: List[String]) extends Exception{
+case class InvalidExclusionsException(invalid: Iterable[String]) extends Exception{
   override def getMessage: String = {
     s"""Invalid exclusion option(s): '${invalid.mkString(", ")}'
        |Valid exclusions are ${Mutation.mutations.mkString(", ")}."""


### PR DESCRIPTION
Example of the incorrect logging that happened.
```
INFO  Mutator: 146 Mutant(s) generated.
INFO  Mutator: Of which 142 Mutant(s) are excluded.
INFO  ProcessMutantRunner: Starting test-run 26...
INFO  ProcessMutantRunner: Finished mutation run 26/4 (650%)
INFO  ProcessMutantRunner: Starting test-run 31...
INFO  ProcessMutantRunner: Finished mutation run 31/4 (775%)
```