### PR TITLE
Test against multiple JDK's on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,17 @@ sudo: false
 
 language: scala
 
+jdk:
+  - oraclejdk8
+  - oraclejdk11
+  - openjdk8
+  - openjdk11
+  - openjdk-ea
+
+matrix:
+  allow_failures:
+    - jdk: openjdk-ea # Allow build failures for pre-release JDK
+
 # These directories are cached to S3 at the end of the build
 cache:
   directories:


### PR DESCRIPTION
I've added multiple JDK versions to Travis. As now we only test against 1 version on Travis. This should hopefully prevent any problems with different JDK's. As we only use Scala libraries, we probably won't have many problems, but it's still good to test.

I've also added a pre-release version, for us to keep an eye on any problems future JDKs might cause.