### PR TITLE
Automated release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,27 @@ language: scala
 scala:
   - 2.12.8
 
-jdk:
-  - oraclejdk8
-  - openjdk11
-  - openjdk-ea
+stages:
+  - name: test
+  - name: release
+    if: (branch = master AND type = push) OR (tag IS present)
+
+jobs:
+  include:
+    - stage: test
+      script: sbt clean coverage test coverageReport
+      jdk:
+        - oraclejdk8
+        - openjdk11
+        - openjdk-ea
+    # run ci-release only if previous stages passed
+    - stage: release
+      script: sbt ci-release
+      jdk: openjdk11
 
 matrix:
   allow_failures:
     - jdk: openjdk-ea # Allow build failures for pre-release JDK
-
-script:
-  - sbt clean coverage test coverageReport
 
 before_cache:
   # Cleanup the cached directories to avoid unnecessary cache updates
@@ -25,3 +35,7 @@ cache:
   directories:
     - $HOME/.ivy2/cache
     - $HOME/.sbt
+
+before_install:
+  # Ensure that git tags are always fetched so that sbt-dynver can pick up the correct version
+  - git fetch --tags

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,17 @@ sudo: false
 
 language: scala
 
+jdk:
+  - oraclejdk8
+  - oraclejdk11
+  - openjdk8
+  - openjdk11
+  - openjdk-ea
+
+matrix:
+  allow_failures:
+    - jdk: openjdk-ea # Allow build failures for pre-release JDK
+
 # These directories are cached to S3 at the end of the build
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,16 @@
-# Use container-based infrastructure
-sudo: false
-
 language: scala
+
+scala:
+  - 2.12.8
 
 jdk:
   - oraclejdk8
-  - oraclejdk11
-  - openjdk8
   - openjdk11
   - openjdk-ea
 
 matrix:
   allow_failures:
     - jdk: openjdk-ea # Allow build failures for pre-release JDK
-
-# These directories are cached to S3 at the end of the build
-cache:
-  directories:
-    - $HOME/.ivy2/cache
-    - $HOME/.sbt
-
-scala:
-   - 2.12.8
 
 script:
   - sbt clean coverage test coverageReport
@@ -30,3 +19,9 @@ before_cache:
   # Cleanup the cached directories to avoid unnecessary cache updates
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
   - find $HOME/.sbt        -name "*.lock"               -print -delete
+
+cache:
+  # These directories are cached to S3 at the end of the build
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ stages:
 
 jobs:
   include:
-    # Default stage is test
-    - script: sbt clean coverage test coverageReport
+    # Default stage test is already added
     # run ci-release only if previous stages passed
     - stage: release
       script: sbt ci-release
@@ -25,6 +24,8 @@ jobs:
 matrix:
   allow_failures:
     - jdk: openjdk-ea # Allow build failures for pre-release JDK
+
+script: sbt clean coverage test coverageReport
 
 before_cache:
   # Cleanup the cached directories to avoid unnecessary cache updates

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ stages:
 
 jobs:
   include:
-    - stage: test
-      script: sbt clean coverage test coverageReport
+    # Default stage is test
+    - script: sbt clean coverage test coverageReport
     # run ci-release only if previous stages passed
     - stage: release
       script: sbt ci-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ language: scala
 scala:
   - 2.12.8
 
+jdk:
+  - oraclejdk8
+  - openjdk11
+  - openjdk-ea
+
 stages:
   - name: test
   - name: release
@@ -12,10 +17,6 @@ jobs:
   include:
     - stage: test
       script: sbt clean coverage test coverageReport
-      jdk:
-        - oraclejdk8
-        - openjdk11
-        - openjdk-ea
     # run ci-release only if previous stages passed
     - stage: release
       script: sbt ci-release

--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ Mutation testing can be very taxing on your computer's resources. After all, you
 
 Multi-module projects are not yet fully supported. However, there is a workaround you can use while we work on a better solution. Set the base-directory to the correct directory of the submodule with the [`base-dir` configuration setting](docs/CONFIGURATION.md#base-dir). Then you can run `sbt "project yourSubmoduleNameHere" stryker` to set the active project and run Stryker4s.
 
+## Pre-release versions
+
+We also publish SNAPSHOT versions of each commit on master. To use a pre-release, add the following setting to your `build.sbt`:
+
+```scala
+resolvers += Resolver.sonatypeRepo("snapshots")
+```
+
+Then replace the Stryker4s version with this version: [![Sonatype Nexus (Snapshots)](https://img.shields.io/nexus/s/https/oss.sonatype.org/io.stryker-mutator/stryker4s-core_2.12.svg)](https://oss.sonatype.org/content/repositories/snapshots/io/stryker-mutator/)
+
 ## Configuration
 
 See [CONFIGURATION.md](docs/CONFIGURATION.md) for setting up your `stryker4s.conf` file (optional).

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,10 @@ lazy val stryker4sCore = newProject("stryker4s-core", "core")
   .settings(Settings.coreSettings)
 
 lazy val stryker4sCommandRunner = newProject("stryker4s-command-runner", "runners/command-runner")
-  .settings(Settings.commandRunnerSettings)
+  .settings(
+    Settings.commandRunnerSettings,
+    mainClass in (Compile, run) := Some("stryker4s.run.Stryker4sCommandRunner")
+  )
   .dependsOn(stryker4sCore)
 
 lazy val sbtStryker4s = newProject("sbt-stryker4s", "runners/sbt")
@@ -19,5 +22,7 @@ lazy val sbtStryker4s = newProject("sbt-stryker4s", "runners/sbt")
   .settings(Settings.sbtPluginSettings)
   .dependsOn(stryker4sCore)
 
-def newProject(projectName: String, dir: String): Project = sbt.Project(projectName, file(dir))
+def newProject(projectName: String, dir: String): Project =
+  sbt
+    .Project(projectName, file(dir))
     .settings(Settings.commonSettings)

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -61,8 +61,6 @@ object Settings {
   )
 
   lazy val buildInfo: Seq[Def.Setting[_]] = Seq(
-    name := "stryker4s",
-    version := "0.1.0",
     description := "Stryker4s, the mutation testing framework for Scala.",
     organization := "io.stryker-mutator",
     organizationHomepage := Some(url("https://stryker-mutator.io/")),
@@ -73,6 +71,6 @@ object Settings {
     developers := List(
       Developer("legopiraat", "Legopiraat", "", url("https://github.com/legopiraat")),
       Developer("hugo-vrijswijk", "Hugo", "", url("https://github.com/hugo-vrijswijk"))
-    ),
+    )
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,5 +2,4 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
 
 // Deployment plugins
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.2.2")

--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -1,5 +1,0 @@
-import xerial.sbt.Sonatype._
-
-publishMavenStyle := true
-
-sonatypeProjectHosting := Some(GitHubHosting("strykermutator-npa", "stryker4s", "strykermutator-npa@github.com"))


### PR DESCRIPTION
### Fixes #118 

As there were a couple changes in the Travis.yml with #129, I've used that as a base. That PR should be merged before this one, to get a better diff.

#### What it does

Uses the sbt-ci-release plugin for automated releases from Travis. Every commit on master is now built and uploaded as a snapshot, and tags are built to releases.

#### How it works

Using the sbt-ci-release plugin, I've added another stage to the Travis build. After `Test` is successful, `Release` will start and build, sign and upload a release.