### PR TITLE
Fix git ls-files bug with non-existent files

### DIFF
--- a/core/src/main/scala/stryker4s/mutants/findmutants/FileCollector.scala
+++ b/core/src/main/scala/stryker4s/mutants/findmutants/FileCollector.scala
@@ -43,6 +43,7 @@ class FileCollector(implicit config: Config) extends SourceCollector with Loggin
       listFilesBasedOnGit(processRunner) getOrElse
       listAllFiles())
       .filterNot(isInTargetDirectory)
+      .filter(_.exists)
   }
 
   /**

--- a/core/src/test/resources/fileTests/filledDir/src/main/scala/package/target.scala
+++ b/core/src/test/resources/fileTests/filledDir/src/main/scala/package/target.scala
@@ -1,0 +1,3 @@
+trait Target
+
+case class Foo() extends Target

--- a/core/src/test/scala/stryker4s/mutants/findmutants/FileCollectorTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/FileCollectorTest.scala
@@ -163,21 +163,6 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
         results should contain only (basePath / "someFile.scala", basePath / "secondFile.scala")
       }
     }
-
-    it("should filter out files that don't exist") {
-      val processRunnerMock: ProcessRunner = mock[ProcessRunner]
-      implicit val config: Config = Config(baseDir = filledDirPath)
-      val filePath = "src/main/scala/package/doesnotexist.scala"
-      val gitProcessResult = Try(Seq(filePath))
-      when(processRunnerMock(Command("git ls-files", "--others --exclude-standard --cached"), config.baseDir))
-        .thenReturn(gitProcessResult)
-
-      val sut = new FileCollector()
-
-      val results = sut.collectFilesToMutate(processRunnerMock)
-
-      results should be (empty)
-    }
   }
 
   describe("Collect files to copy over to tmp folder") {

--- a/core/src/test/scala/stryker4s/mutants/findmutants/FileCollectorTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/FileCollectorTest.scala
@@ -40,8 +40,8 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
 
         val results = sut.collectFilesToMutate()
 
-        results should have size 2
-        results should contain only (basePath / "someFile.scala", basePath / "secondFile.scala")
+        results should have size 3
+        results should contain only (basePath / "someFile.scala", basePath / "secondFile.scala", basePath / "target.scala")
       }
 
       it("should find matching files with custom config match pattern") {
@@ -83,8 +83,8 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
 
         val results = sut.collectFilesToMutate()
 
-        results should have size 2
-        results should contain only (basePath / "someFile.scala", basePath / "secondFile.scala")
+        results should have size 3
+        results should contain only (basePath / "someFile.scala", basePath / "secondFile.scala", basePath / "target.scala")
       }
 
       it("should not find a file twice when the patterns match on the same file twice") {
@@ -145,8 +145,8 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
 
         val results = sut.collectFilesToMutate()
 
-        results should have size 2
-        results should contain only (basePath / "someFile.scala", basePath / "secondFile.scala")
+        results should have size 3
+        results should contain only (basePath / "someFile.scala", basePath / "secondFile.scala", basePath / "target.scala")
       }
 
       it("Should not exclude a non existing file") {
@@ -163,6 +163,21 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
         results should contain only (basePath / "someFile.scala", basePath / "secondFile.scala")
       }
     }
+
+    it("should filter out files that don't exist") {
+      val processRunnerMock: ProcessRunner = mock[ProcessRunner]
+      implicit val config: Config = Config(baseDir = filledDirPath)
+      val filePath = "src/main/scala/package/doesnotexist.scala"
+      val gitProcessResult = Try(Seq(filePath))
+      when(processRunnerMock(Command("git ls-files", "--others --exclude-standard --cached"), config.baseDir))
+        .thenReturn(gitProcessResult)
+
+      val sut = new FileCollector()
+
+      val results = sut.collectFilesToMutate(processRunnerMock)
+
+      results should be (empty)
+    }
   }
 
   describe("Collect files to copy over to tmp folder") {
@@ -171,7 +186,7 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
 
     it("Should execute git process to collect files") {
       implicit val config: Config = Config(baseDir = filledDirPath)
-      val filePath = "Config.scala"
+      val filePath = "src/main/scala/package/someFile.scala"
       val expectedFileList = Seq(config.baseDir / filePath)
       val gitProcessResult = Try(Seq(filePath))
       when(processRunnerMock(Command("git ls-files", "--others --exclude-standard --cached"), config.baseDir))
@@ -186,7 +201,7 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
 
     it("Should copy over files with target in their name") {
       implicit val config: Config = Config(baseDir = filledDirPath)
-      val filePath = "Target.scala"
+      val filePath = "src/main/scala/package/target.scala"
       val expectedFileList = Seq(config.baseDir / filePath)
       val gitProcessResult = Try(Seq(filePath))
       when(processRunnerMock(Command("git ls-files", "--others --exclude-standard --cached"), config.baseDir))
@@ -202,7 +217,7 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
     it("Should copy the files from the files config key") {
       implicit val config: Config =
         Config(baseDir = filledDirPath, files = Some(Seq("**/main/scala/**/*.scala")))
-      val expectedFileList = Seq(basePath / "someFile.scala", basePath / "secondFile.scala")
+      val expectedFileList = Seq(basePath / "someFile.scala", basePath / "secondFile.scala", basePath / "target.scala")
 
       val sut = new FileCollector()
 
@@ -215,7 +230,7 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
       "Should copy files out of the target folders when no files config key is found and target repo is not a git repo") {
       implicit val config: Config = Config(baseDir = basePath, files = None)
       val expectedFileList =
-        Seq(basePath / "someFile.scala", basePath / "secondFile.scala", basePath / "otherFile.notScala")
+        Seq(basePath / "someFile.scala", basePath / "secondFile.scala", basePath / "otherFile.notScala", basePath / "target.scala")
       val gitProcessResult = Failure(new Exception("Exception"))
       when(processRunnerMock(any[Command], any[File])).thenReturn(gitProcessResult)
 
@@ -223,8 +238,22 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
 
       val results = sut.filesToCopy(processRunnerMock)
 
-      results should have size 3
+      results should have size 4
       results should contain theSameElementsAs expectedFileList
+    }
+
+    it("should filter out files that don't exist") {
+      implicit val config: Config = Config(baseDir = filledDirPath)
+      val filePath = "src/main/scala/package/doesnotexist.scala"
+      val gitProcessResult = Try(Seq(filePath))
+      when(processRunnerMock(Command("git ls-files", "--others --exclude-standard --cached"), config.baseDir))
+        .thenReturn(gitProcessResult)
+
+      val sut = new FileCollector()
+
+      val results = sut.filesToCopy(processRunnerMock)
+
+      results should be (empty)
     }
 
     describe("log tests") {


### PR DESCRIPTION
### Fixes #133 

#### What it does

Fixes the bug with a file that is deleted, but not yet staged by git causing a `FileNotFoundException`.

#### How it works

Files that don't exist are now filtered out by the FileCollector