### PR TITLE
Remove unused info from github templates

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,9 +1,3 @@
----
-name: ISSUE_TEMPLATE
-about: Create a report to help us improve
-
----
-
 <!---
 Thanks for filing an issue 😄 ! Before you submit, please read the following:
 
@@ -17,7 +11,7 @@ If you have a feature request, feel free to ignore the template.
 
 <!--- Provide a general summary of the issue in the title above -->
 
-### Stryker config
+### Stryker4s config
 
 <!--- Please place your stryker4s config below. Feel free to change paths in the files and mutate arrays if you cannot share them. -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,3 @@
----
-name: PULL_REQUEST_TEMPLATE
-about: Create a pull request for an awesome new feature or bug fix
----
-
 <!---
 Thanks for your pull request 😄! Please fill in the information below so we can quickly review and merge your PR.
 


### PR DESCRIPTION
This removes the unused info at the top of the GitHub templates. They didn't really add much, and the one in the issue template was formatted wrong so didn't show properly