### PR TITLE
Travis multiple jdk versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,17 @@ sudo: false
 
 language: scala
 
+jdk:
+  - oraclejdk8
+  - oraclejdk11
+  - openjdk8
+  - openjdk11
+  - openjdk-ea
+
+matrix:
+  allow_failures:
+    - jdk: openjdk-ea # Allow build failures for pre-release JDK
+
 # These directories are cached to S3 at the end of the build
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ scala:
 jdk:
   - oraclejdk8
   - openjdk11
-  - openjdk-ea
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,16 @@
-# Use container-based infrastructure
-sudo: false
-
 language: scala
+
+scala:
+  - 2.12.8
 
 jdk:
   - oraclejdk8
-  - oraclejdk11
-  - openjdk8
   - openjdk11
   - openjdk-ea
 
 matrix:
   allow_failures:
     - jdk: openjdk-ea # Allow build failures for pre-release JDK
-
-# These directories are cached to S3 at the end of the build
-cache:
-  directories:
-    - $HOME/.ivy2/cache
-    - $HOME/.sbt
-
-scala:
-   - 2.12.8
 
 script:
   - sbt clean coverage test coverageReport
@@ -30,3 +19,9 @@ before_cache:
   # Cleanup the cached directories to avoid unnecessary cache updates
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
   - find $HOME/.sbt        -name "*.lock"               -print -delete
+
+cache:
+  # These directories are cached to S3 at the end of the build
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ jdk:
   - oraclejdk8
   - openjdk11
 
-matrix:
-  allow_failures:
-    - jdk: openjdk-ea # Allow build failures for pre-release JDK
-
 script:
   - sbt clean coverage test coverageReport
 


### PR DESCRIPTION
REOPEN:

I've added multiple JDK versions to Travis. As now we only test against 1 version on Travis. This should hopefully prevent any problems with different JDK's. As we only use Scala libraries, we probably won't have many problems, but it's still good to test.

I've also added a pre-release version, for us to keep an eye on any problems future JDKs might cause.