### PR TITLE
Refactor sbt plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,5 +19,7 @@ lazy val sbtStryker4s = newProject("sbt-stryker4s", "runners/sbt")
   .settings(Settings.sbtPluginSettings)
   .dependsOn(stryker4sCore)
 
-def newProject(projectName: String, dir: String): Project = sbt.Project(projectName, file(dir))
+def newProject(projectName: String, dir: String): Project =
+  sbt
+    .Project(projectName, file(dir))
     .settings(Settings.commonSettings)

--- a/core/src/main/scala/stryker4s/Stryker4s.scala
+++ b/core/src/main/scala/stryker4s/Stryker4s.scala
@@ -9,7 +9,8 @@ import stryker4s.run.report.Reporter
 import stryker4s.run.threshold.{ScoreStatus, ThresholdChecker}
 
 class Stryker4s(fileCollector: SourceCollector, mutator: Mutator, runner: MutantRunner, reporter: Reporter)(
-    implicit config: Config) extends Logging {
+    implicit config: Config)
+    extends Logging {
 
   def run(): ScoreStatus = {
     preRunLogs()
@@ -25,7 +26,8 @@ class Stryker4s(fileCollector: SourceCollector, mutator: Mutator, runner: Mutant
     // to encourage the user to make a decision here.
     if (!jvmMemory2GBOrHigher) {
       warn("The JVM has less than 2GB memory available. We advise increasing this to 4GB when running Stryker4s.")
-      warn("This can be done in sbt by setting an environment variable: SBT_OPTS=\"-XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=4G -Xmx4G\" ")
+      warn(
+        "This can be done in sbt by setting an environment variable: SBT_OPTS=\"-XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=4G -Xmx4G\" ")
       warn("Visit https://github.com/stryker-mutator/stryker4s#memory-usage for more info.")
     }
   }

--- a/core/src/main/scala/stryker4s/Stryker4s.scala
+++ b/core/src/main/scala/stryker4s/Stryker4s.scala
@@ -13,7 +13,7 @@ class Stryker4s(fileCollector: SourceCollector, mutator: Mutator, runner: Mutant
   def run(): ScoreStatus = {
     val filesToMutate = fileCollector.collectFilesToMutate()
     val mutatedFiles = mutator.mutate(filesToMutate)
-    val runResults = runner(mutatedFiles, fileCollector)
+    val runResults = runner(mutatedFiles)
     reporter.report(runResults)
     ThresholdChecker.determineScoreStatus(runResults.mutationScore)
   }

--- a/core/src/main/scala/stryker4s/extension/exception/stryker4sException.scala
+++ b/core/src/main/scala/stryker4s/extension/exception/stryker4sException.scala
@@ -9,6 +9,8 @@ final case class UnableToBuildPatternMatchException() extends Stryker4sException
 
 final case class InitialTestRunFailedException(message: String) extends Stryker4sException(message) with NoStackTrace
 
+final case class MutationRunFailedException(message: String) extends Stryker4sException(message)
+
 final case class InvalidThresholdValueException(message: String) extends Stryker4sException(message)
 
 final case class InvalidExclusionsException(invalid: Iterable[String])

--- a/core/src/main/scala/stryker4s/run/MutantRunner.scala
+++ b/core/src/main/scala/stryker4s/run/MutantRunner.scala
@@ -24,7 +24,6 @@ abstract class MutantRunner(process: ProcessRunner, sourceCollector: SourceColle
     val targetFolder = config.baseDir / "target"
     targetFolder.createDirectoryIfNotExists()
 
-
     File.newTemporaryDirectory("stryker4s-", Option(targetFolder))
   }
 

--- a/core/src/main/scala/stryker4s/run/Stryker4sRunner.scala
+++ b/core/src/main/scala/stryker4s/run/Stryker4sRunner.scala
@@ -4,7 +4,7 @@ import stryker4s.Stryker4s
 import stryker4s.config.{CommandRunner, Config, ConfigReader}
 import stryker4s.mutants.Mutator
 import stryker4s.mutants.applymutants.{MatchBuilder, StatementTransformer}
-import stryker4s.mutants.findmutants.{FileCollector, MutantFinder, MutantMatcher}
+import stryker4s.mutants.findmutants.{FileCollector, MutantFinder, MutantMatcher, SourceCollector}
 import stryker4s.run.process.{Command, ProcessMutantRunner, ProcessRunner}
 import stryker4s.run.report.Reporter
 import stryker4s.run.threshold.ScoreStatus
@@ -22,17 +22,18 @@ class Stryker4sRunner {
      // it is cleaned before it starts.
     PlatformTokenizerCache.megaCache.clear()
 
+    val collector = new FileCollector
     val stryker4s = new Stryker4s(
-      new FileCollector,
+      collector,
       new Mutator(new MutantFinder(new MutantMatcher), new StatementTransformer, new MatchBuilder),
-      resolveRunner(),
+      resolveRunner(collector),
       new Reporter()
     )
     stryker4s.run()
   }
 
-  def resolveRunner()(implicit config: Config): MutantRunner = config.testRunner match {
-    case CommandRunner(command, args) => new ProcessMutantRunner(Command(command, args), ProcessRunner.resolveRunner())
+  def resolveRunner(collector: SourceCollector)(implicit config: Config): MutantRunner = config.testRunner match {
+    case CommandRunner(command, args) => new ProcessMutantRunner(Command(command, args), ProcessRunner.resolveRunner(), collector)
   }
 
 }

--- a/core/src/main/scala/stryker4s/run/Stryker4sRunner.scala
+++ b/core/src/main/scala/stryker4s/run/Stryker4sRunner.scala
@@ -18,8 +18,8 @@ class Stryker4sRunner {
   def run(): ScoreStatus = {
 
     // Scalameta uses a cache file->tokens that exists at a process level
-     // if one file changes between runs (in the same process, eg a single SBT session) could lead to an error, so
-     // it is cleaned before it starts.
+    // if one file changes between runs (in the same process, eg a single SBT session) could lead to an error, so
+    // it is cleaned before it starts.
     PlatformTokenizerCache.megaCache.clear()
 
     val collector = new FileCollector
@@ -33,7 +33,8 @@ class Stryker4sRunner {
   }
 
   def resolveRunner(collector: SourceCollector)(implicit config: Config): MutantRunner = config.testRunner match {
-    case CommandRunner(command, args) => new ProcessMutantRunner(Command(command, args), ProcessRunner.resolveRunner(), collector)
+    case CommandRunner(command, args) =>
+      new ProcessMutantRunner(Command(command, args), ProcessRunner.resolveRunner(), collector)
   }
 
 }

--- a/core/src/main/scala/stryker4s/run/process/ProcessMutantRunner.scala
+++ b/core/src/main/scala/stryker4s/run/process/ProcessMutantRunner.scala
@@ -5,13 +5,14 @@ import java.nio.file.Path
 import better.files.File
 import stryker4s.config.Config
 import stryker4s.model._
+import stryker4s.mutants.findmutants.SourceCollector
 import stryker4s.run.MutantRunner
 
 import scala.concurrent.TimeoutException
 import scala.util.{Failure, Success}
 
-class ProcessMutantRunner(command: Command, processRunner: ProcessRunner)(implicit config: Config)
-    extends MutantRunner(processRunner) {
+class ProcessMutantRunner(command: Command, processRunner: ProcessRunner, sourceCollector: SourceCollector)(implicit config: Config)
+    extends MutantRunner(processRunner, sourceCollector) {
 
   def runMutant(mutant: Mutant, workingDir: File, subPath: Path): MutantRunResult = {
     val id = mutant.id

--- a/core/src/main/scala/stryker4s/run/process/ProcessMutantRunner.scala
+++ b/core/src/main/scala/stryker4s/run/process/ProcessMutantRunner.scala
@@ -11,7 +11,8 @@ import stryker4s.run.MutantRunner
 import scala.concurrent.TimeoutException
 import scala.util.{Failure, Success}
 
-class ProcessMutantRunner(command: Command, processRunner: ProcessRunner, sourceCollector: SourceCollector)(implicit config: Config)
+class ProcessMutantRunner(command: Command, processRunner: ProcessRunner, sourceCollector: SourceCollector)(
+    implicit config: Config)
     extends MutantRunner(processRunner, sourceCollector) {
 
   def runMutant(mutant: Mutant, workingDir: File, subPath: Path): MutantRunResult = {

--- a/core/src/test/scala/stryker4s/Stryker4sTest.scala
+++ b/core/src/test/scala/stryker4s/Stryker4sTest.scala
@@ -53,7 +53,7 @@ class Stryker4sTest extends Stryker4sSuite with LogMatchers {
       implicit val conf: Config = Config()
       val testSourceCollector = new TestSourceCollector(Seq())
       val testProcessRunner = TestProcessRunner()
-      val testMutantRunner = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner)
+      val testMutantRunner = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, testSourceCollector)
       val testReporter = new TestReporter
 
       val sut: Stryker4s =
@@ -76,7 +76,7 @@ class Stryker4sTest extends Stryker4sSuite with LogMatchers {
       implicit val conf: Config = Config()
       val testSourceCollector = new TestSourceCollector(Seq())
       val testProcessRunner = TestProcessRunner()
-      val testMutantRunner = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner)
+      val testMutantRunner = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, testSourceCollector)
       val testReporter = new TestReporter
 
       val sut: Stryker4s =

--- a/core/src/test/scala/stryker4s/Stryker4sTest.scala
+++ b/core/src/test/scala/stryker4s/Stryker4sTest.scala
@@ -6,7 +6,7 @@ import stryker4s.config.Config
 import stryker4s.model.{Killed, Mutant}
 import stryker4s.mutants.Mutator
 import stryker4s.mutants.applymutants.{MatchBuilder, StatementTransformer}
-import stryker4s.mutants.findmutants.{MutantFinder, MutantMatcher}
+import stryker4s.mutants.findmutants.{FileCollector, MutantFinder, MutantMatcher}
 import stryker4s.run.process.{Command, ProcessMutantRunner}
 import stryker4s.run.threshold.SuccessStatus
 import stryker4s.scalatest.FileUtil
@@ -24,7 +24,7 @@ class Stryker4sTest extends Stryker4sSuite {
       val testFiles = Seq(file)
       val testSourceCollector = new TestSourceCollector(testFiles)
       val testProcessRunner = TestProcessRunner(Success(1), Success(1), Success(1), Success(1))
-      val testMutantRunner = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner)
+      val testMutantRunner = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, new FileCollector())
       val testReporter = new TestReporter
 
       val sut = new Stryker4s(

--- a/core/src/test/scala/stryker4s/Stryker4sTest.scala
+++ b/core/src/test/scala/stryker4s/Stryker4sTest.scala
@@ -56,14 +56,14 @@ class Stryker4sTest extends Stryker4sSuite with LogMatchers {
       val testMutantRunner = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner)
       val testReporter = new TestReporter
 
-      val sut: Stryker4s = new Stryker4s(
-        testSourceCollector,
-        new Mutator(new MutantFinder(new MutantMatcher), new StatementTransformer, new MatchBuilder),
-        testMutantRunner,
-        testReporter) {
+      val sut: Stryker4s =
+        new Stryker4s(testSourceCollector,
+                      new Mutator(new MutantFinder(new MutantMatcher), new StatementTransformer, new MatchBuilder),
+                      testMutantRunner,
+                      testReporter) {
 
-        override def jvmMemory2GBOrHigher: Boolean = false
-      }
+          override def jvmMemory2GBOrHigher: Boolean = false
+        }
 
       sut.run()
 
@@ -79,14 +79,14 @@ class Stryker4sTest extends Stryker4sSuite with LogMatchers {
       val testMutantRunner = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner)
       val testReporter = new TestReporter
 
-      val sut: Stryker4s = new Stryker4s(
-        testSourceCollector,
-        new Mutator(new MutantFinder(new MutantMatcher), new StatementTransformer, new MatchBuilder),
-        testMutantRunner,
-        testReporter) {
+      val sut: Stryker4s =
+        new Stryker4s(testSourceCollector,
+                      new Mutator(new MutantFinder(new MutantMatcher), new StatementTransformer, new MatchBuilder),
+                      testMutantRunner,
+                      testReporter) {
 
-        override def jvmMemory2GBOrHigher: Boolean = true
-      }
+          override def jvmMemory2GBOrHigher: Boolean = true
+        }
 
       sut.run()
 

--- a/core/src/test/scala/stryker4s/mutants/findmutants/FileCollectorTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/FileCollectorTest.scala
@@ -215,7 +215,10 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
       "Should copy files out of the target folders when no files config key is found and target repo is not a git repo") {
       implicit val config: Config = Config(baseDir = basePath, files = None)
       val expectedFileList =
-        Seq(basePath / "someFile.scala", basePath / "secondFile.scala", basePath / "otherFile.notScala", basePath / "target.scala")
+        Seq(basePath / "someFile.scala",
+            basePath / "secondFile.scala",
+            basePath / "otherFile.notScala",
+            basePath / "target.scala")
       val gitProcessResult = Failure(new Exception("Exception"))
       when(processRunnerMock(any[Command], any[File])).thenReturn(gitProcessResult)
 
@@ -238,7 +241,7 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
 
       val results = sut.filesToCopy(processRunnerMock)
 
-      results should be (empty)
+      results should be(empty)
     }
 
     describe("log tests") {

--- a/core/src/test/scala/stryker4s/run/process/ProcessMutantRunnerTest.scala
+++ b/core/src/test/scala/stryker4s/run/process/ProcessMutantRunnerTest.scala
@@ -24,14 +24,14 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
   describe("apply") {
     it("should return a Survived mutant on an exitcode 0 process") {
       val testProcessRunner = TestProcessRunner(Success(0))
-      val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner)
+      val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, fileCollectorMock)
       val mutant = Mutant(0, q"4", q"5", EmptyString)
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
       val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant), 0)
 
       when(fileCollectorMock.filesToCopy(testProcessRunner)).thenReturn(List(file))
 
-      val result = sut.apply(Seq(mutatedFile), fileCollectorMock)
+      val result = sut(Seq(mutatedFile))
 
       testProcessRunner.timesCalled.next() should equal(1)
       result.mutationScore shouldBe 00.00
@@ -41,14 +41,14 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
 
     it("should return a Killed mutant on an exitcode 1 process") {
       val testProcessRunner = TestProcessRunner(Success(1))
-      val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner)
+      val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, fileCollectorMock)
       val mutant = Mutant(0, q"4", q"5", EmptyString)
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
       val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant), 0)
 
       when(fileCollectorMock.filesToCopy(testProcessRunner)).thenReturn(List(file))
 
-      val result = sut.apply(Seq(mutatedFile), fileCollectorMock)
+      val result = sut(Seq(mutatedFile))
 
       testProcessRunner.timesCalled.next() should equal(1)
       result.mutationScore shouldBe 100.00
@@ -59,14 +59,14 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
     it("should return a TimedOut mutant on a TimedOut process") {
       val exception = new TimeoutException("Test")
       val testProcessRunner = TestProcessRunner(Failure(exception))
-      val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner)
+      val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, fileCollectorMock)
       val mutant = Mutant(0, q"4", q"5", EmptyString)
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
       val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant), 0)
 
       when(fileCollectorMock.filesToCopy(testProcessRunner)).thenReturn(List(file))
 
-      val result = sut.apply(Seq(mutatedFile), fileCollectorMock)
+      val result = sut(Seq(mutatedFile))
 
       testProcessRunner.timesCalled.next() should equal(1)
       result.mutationScore shouldBe 100.00
@@ -76,7 +76,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
 
     it("should return a combination of results on multiple runs") {
       val testProcessRunner = TestProcessRunner(Success(1), Success(1))
-      val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner)
+      val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, fileCollectorMock)
       val mutant = Mutant(0, q"0", q"zero", EmptyString)
       val secondMutant = Mutant(1, q"1", q"one", EmptyString)
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
@@ -85,7 +85,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
 
       when(fileCollectorMock.filesToCopy(testProcessRunner)).thenReturn(List(file))
 
-      val result = sut.apply(Seq(mutatedFile), fileCollectorMock)
+      val result = sut(Seq(mutatedFile))
 
       testProcessRunner.timesCalled.next() should equal(2)
 
@@ -98,7 +98,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
 
     it("should return a mutationScore of 66.67 when 2 of 3 mutants are killed") {
       val testProcessRunner = TestProcessRunner(Success(1), Success(1), Success(0))
-      val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner)
+      val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, fileCollectorMock)
       val mutant = Mutant(0, q"0", q"zero", EmptyString)
       val secondMutant = Mutant(1, q"1", q"one", EmptyString)
       val thirdMutant = Mutant(2, q"5", q"5", EmptyString)
@@ -108,7 +108,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
 
       when(fileCollectorMock.filesToCopy(testProcessRunner)).thenReturn(List(file))
 
-      val result = sut.apply(Seq(mutatedFile), fileCollectorMock)
+      val result = sut(Seq(mutatedFile))
 
       testProcessRunner.timesCalled.next() should equal(3)
 
@@ -122,24 +122,24 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
 
     it("should throw an exception when the initial test run fails") {
       val testProcessRunner = TestProcessRunner.failInitialTestRun()
-      val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner)
+      val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, fileCollectorMock)
 
       when(fileCollectorMock.filesToCopy(testProcessRunner)).thenReturn(List.empty)
 
-      a[InitialTestRunFailedException] shouldBe thrownBy(sut.apply(Seq.empty, fileCollectorMock))
+      a[InitialTestRunFailedException] shouldBe thrownBy(sut(Seq.empty))
     }
 
     describe("Log tests") {
       it("Should log that test run 1 is started and finished when mutant id is 0") {
         val testProcessRunner = TestProcessRunner(Success(0))
-        val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner)
+        val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, fileCollectorMock)
         val mutant = Mutant(0, q"4", q"5", EmptyString)
         val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
         val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant), 0)
 
         when(fileCollectorMock.filesToCopy(testProcessRunner)).thenReturn(List(file))
 
-        sut.apply(Seq(mutatedFile), fileCollectorMock)
+        sut(Seq(mutatedFile))
 
         "Starting test-run 1..." shouldBe loggedAsInfo
         "Finished mutation run 1/1 (100%)" shouldBe loggedAsInfo
@@ -147,7 +147,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
 
       it("Should log multiple test runs") {
         val testProcessRunner = TestProcessRunner(Success(0), Success(0))
-        val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner)
+        val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, fileCollectorMock)
         val mutant0 = Mutant(0, q"4", q"5", EmptyString)
         val mutant1 = Mutant(1, q"4", q"5", EmptyString)
         val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
@@ -155,7 +155,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
 
         when(fileCollectorMock.filesToCopy(testProcessRunner)).thenReturn(List(file))
 
-        sut.apply(Seq(mutatedFile), fileCollectorMock)
+        sut(Seq(mutatedFile))
 
         "Starting test-run 1..." shouldBe loggedAsInfo
         "Finished mutation run 1/2 (50%)" shouldBe loggedAsInfo
@@ -165,11 +165,11 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
 
       it("should properly log the initial test run") {
         val testProcessRunner = TestProcessRunner()
-        val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner)
+        val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, fileCollectorMock)
 
         when(fileCollectorMock.filesToCopy(testProcessRunner)).thenReturn(List.empty)
 
-        sut.apply(Seq.empty, fileCollectorMock)
+        sut(Seq.empty)
 
         "Starting initial test run..." shouldBe loggedAsInfo
         "Initial test run succeeded! Testing mutants..." shouldBe loggedAsInfo

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -1,6 +1,6 @@
 import sbt.Keys._
 import sbt.ScriptedPlugin.autoImport.{scriptedBufferLog, scriptedLaunchOpts}
-import sbt.{Def, _}
+import sbt._
 import scoverage.ScoverageKeys._
 import xerial.sbt.Sonatype.autoImport.sonatypePublishTo
 
@@ -21,7 +21,7 @@ object Settings {
 
   lazy val commonSettings: Seq[Setting[_]] = Seq(
     publishTo := sonatypePublishTo.value,
-    Test / parallelExecution := false, // For logging tests
+    Test / parallelExecution := false // For logging tests
   )
 
   lazy val coreSettings: Seq[Setting[_]] = Seq(

--- a/runners/sbt/src/main/scala/stryker4s/sbt/SbtMutantRunner.scala
+++ b/runners/sbt/src/main/scala/stryker4s/sbt/SbtMutantRunner.scala
@@ -56,13 +56,13 @@ class SbtMutantRunner(state: State, processRunner: ProcessRunner, sourceCollecto
     javaOptions in Test += s"-DACTIVE_MUTATION=${String.valueOf(mutation)}"
 
   private def tmpDirFor(conf: Configuration): Def.Initialize[JFile] = {
-    val sourceDef = pathOf(scalaSource, conf)
-    val baseDef = pathOf(baseDirectory, conf)
+    val sourceDirDef = (scalaSource in conf)(_.absolutePath)
+    val baseDirDef = (baseDirectory in conf)(_.absolutePath)
 
-    (sourceDef zipWith baseDef)(_ diff _)(tmpDir.toJava / _)
+    sourceDirDef.zipWith(baseDirDef) { (sourceDir, baseDir) =>
+      val relativePath = sourceDir diff baseDir
+
+      tmpDir.toJava / relativePath
+    }
   }
-
-  private def pathOf(key: SettingKey[JFile], conf: sbt.Configuration): Def.Initialize[String] =
-    (key in conf)(_.absolutePath)
-
 }

--- a/runners/sbt/src/main/scala/stryker4s/sbt/SbtMutantRunner.scala
+++ b/runners/sbt/src/main/scala/stryker4s/sbt/SbtMutantRunner.scala
@@ -1,73 +1,68 @@
 package stryker4s.sbt
+import java.io.{File => JFile}
 import java.nio.file.Path
 
 import better.files.File
-import sbt._
 import sbt.Keys._
+import sbt._
 import stryker4s.config.Config
-import stryker4s.extension.exception.InitialTestRunFailedException
+import stryker4s.extension.exception.{InitialTestRunFailedException, MutationRunFailedException, Stryker4sException}
 import stryker4s.model._
+import stryker4s.mutants.findmutants.SourceCollector
 import stryker4s.run.MutantRunner
 import stryker4s.run.process.ProcessRunner
 
-class SbtMutantRunner(state: State, processRunner: ProcessRunner)(implicit config: Config)
-    extends MutantRunner(processRunner) {
+class SbtMutantRunner(state: State, processRunner: ProcessRunner, sourceCollector: SourceCollector)(
+    implicit config: Config)
+    extends MutantRunner(processRunner, sourceCollector) {
 
-  val extracted: Extracted = Project.extract(state)
+  private val settings: Seq[Def.Setting[_]] = Seq(
+    fork in Test := true,
+    scalaSource in Compile := tmpDirFor(Compile).value,
+    scalaSource in Test := tmpDirFor(Test).value,
+  )
 
-  override def runInitialTest(workingDir: File): Boolean = {
-    val newState = extracted.appendWithoutSession(settings(workingDir), state)
-    Project.runTask(test in Test, newState) match {
-      case None =>
-        throw InitialTestRunFailedException(
-          s"Unable to execute initial test run. Sbt is unable to find the task 'test'.")
-      case Some((_, Value(_))) => true
-      case Some((_, Inc(_)))   => false
-    }
-  }
+  private val extracted = Project.extract(state)
+
+  private val newState = extracted.appendWithoutSession(settings, state)
+
+  override def runInitialTest(workingDir: File): Boolean = runTests(
+    newState,
+    InitialTestRunFailedException(s"Unable to execute initial test run. Sbt is unable to find the task 'test'."),
+    onSuccess = true,
+    onFailed = false
+  )
 
   override def runMutant(mutant: Mutant, workingDir: File, subPath: Path): MutantRunResult = {
-    val newState = extracted.appendWithoutSession(settings(workingDir) ++ mutationSetting(mutant.id), state)
-
-    Project.runTask(test in Test, newState) match {
-      case None =>
-        throw new RuntimeException(s"An unexpected error occurred while running mutation ${mutant.id}")
-      case Some((_, Value(_))) => Survived(mutant, subPath)
-      case Some((_, Inc(_)))   => Killed(mutant, subPath)
-    }
-  }
-
-  private[this] def settings(tmpDir: File): Seq[Def.Setting[_]] = {
-    val mainPath = {
-      extracted
-        .get(Compile / scalaSource)
-        .absolutePath
-        .diff(
-          extracted.get(Compile / baseDirectory).absolutePath
-        )
-    }
-
-    val testPath = {
-      extracted
-        .get(Test / scalaSource)
-        .absolutePath
-        .diff(
-          extracted.get(Test / baseDirectory).absolutePath
-        )
-    }
-
-    Seq(
-      fork in Test := true,
-      scalaSource in Compile := tmpDir.toJava / mainPath,
-      scalaSource in Test := tmpDir.toJava / testPath
-    )
-
-  }
-
-  private[this] def mutationSetting(mutation: Int): Seq[Def.Setting[_]] = {
-    Seq(
-      // Set active mutation
-      javaOptions in Test += s"-DACTIVE_MUTATION=${String.valueOf(mutation)}"
+    val mutationState = extracted.appendWithSession(settings :+ mutationSetting(mutant.id), newState)
+    runTests(
+      mutationState,
+      MutationRunFailedException(s"An unexpected error occurred while running mutation ${mutant.id}"),
+      Survived(mutant, subPath),
+      Killed(mutant, subPath)
     )
   }
+
+  /** Runs tests with the giving state, calls the corresponding parameter on each result
+    */
+  private def runTests[T](state: State, onError: => Stryker4sException, onSuccess: => T, onFailed: => T): T =
+    Project.runTask(test in Test, state) match {
+      case None                => throw onError
+      case Some((_, Value(_))) => onSuccess
+      case Some((_, Inc(_)))   => onFailed
+    }
+
+  private def mutationSetting(mutation: Int): Def.Setting[_] =
+    javaOptions in Test += s"-DACTIVE_MUTATION=${String.valueOf(mutation)}"
+
+  private def tmpDirFor(conf: Configuration): Def.Initialize[JFile] = {
+    val sourceDef = pathOf(scalaSource, conf)
+    val baseDef = pathOf(baseDirectory, conf)
+
+    (sourceDef zipWith baseDef)(_ diff _)(tmpDir.toJava / _)
+  }
+
+  private def pathOf(key: SettingKey[JFile], conf: sbt.Configuration): Def.Initialize[String] =
+    (key in conf)(_.absolutePath)
+
 }

--- a/runners/sbt/src/main/scala/stryker4s/sbt/Stryker4sPlugin.scala
+++ b/runners/sbt/src/main/scala/stryker4s/sbt/Stryker4sPlugin.scala
@@ -1,8 +1,8 @@
 package stryker4s.sbt
 
 import sbt.Keys._
-import sbt.plugins._
 import sbt._
+import sbt.plugins._
 import stryker4s.run.threshold.ErrorStatus
 
 /**
@@ -20,18 +20,14 @@ object Stryker4sPlugin extends AutoPlugin {
   )
 
   def stryker: Command = Command.command("stryker") { currentState =>
-    // Force compile
-    Project.runTask(compile in Compile, currentState) match {
-      case None                => throw new RuntimeException(s"An unexpected error occurred while running Stryker")
-      case Some((newState, _)) =>
-        // Run Stryker
-        val result = new Stryker4sSbtRunner(newState).run()
+    // Run Stryker
+    val result = new Stryker4sSbtRunner(currentState).run()
 
-        result match {
-          case ErrorStatus => newState.fail
-          case _           => newState
-        }
+    result match {
+      case ErrorStatus => currentState.fail
+      case _           => currentState
     }
+
   }
 
   override lazy val projectSettings: Seq[Def.Setting[_]] = strykerDefaultSettings

--- a/runners/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
+++ b/runners/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
@@ -2,6 +2,7 @@ package stryker4s.sbt
 
 import sbt._
 import stryker4s.config.Config
+import stryker4s.mutants.findmutants.SourceCollector
 import stryker4s.run.process.ProcessRunner
 import stryker4s.run.{MutantRunner, Stryker4sRunner}
 
@@ -12,7 +13,7 @@ import stryker4s.run.{MutantRunner, Stryker4sRunner}
   */
 class Stryker4sSbtRunner(state: State) extends Stryker4sRunner {
 
-  override def resolveRunner()(implicit config: Config): MutantRunner =
-    new SbtMutantRunner(state, ProcessRunner.resolveRunner())
+  override def resolveRunner(collector: SourceCollector)(implicit config: Config): MutantRunner =
+    new SbtMutantRunner(state, ProcessRunner.resolveRunner(), collector)
 
 }


### PR DESCRIPTION
I've refactored the sbt plugin a little bit. The `SbtMutantRunner` is little cleaned up, and I've refactored the main settings (everything but the active mutation) to only be calculated once. Unfortunately, they are still applied for each mutation, instead of once, which would be a far larger performance improvement. I've spent some time trying to get that to work, but couldn't (yet).

I've also changed the main `stryker` command to be a `Task`, instead of a `Command`, as recommended by the [sbt documentation](https://www.scala-sbt.org/1.0/docs/Plugins-Best-Practices.html#Use+settings+and+tasks.+Avoid+commands.)