### PR TITLE
Log a warning when 0 mutants are found

### DIFF
--- a/core/src/main/scala/stryker4s/mutants/Mutator.scala
+++ b/core/src/main/scala/stryker4s/mutants/Mutator.scala
@@ -51,10 +51,9 @@ class Mutator(mutantFinder: MutantFinder, transformer: StatementTransformer, mat
     if (excludedMutants > 0) {
       info(s"Of which $excludedMutants Mutant(s) are excluded.")
     }
-    if (totalMutants == 0) {
-      warn("It's a mutant-free world, nothing to test.")
-      warn("This is likely an issue with configuration.")
-      warn("Please check your configuration and try again.")
+    if (includedMutants == 0) {
+      info("It's a mutant-free world, nothing to test.")
+      info("If this is not intended, please check your configuration and try again.")
     }
   }
 

--- a/core/src/main/scala/stryker4s/mutants/Mutator.scala
+++ b/core/src/main/scala/stryker4s/mutants/Mutator.scala
@@ -44,11 +44,16 @@ class Mutator(mutantFinder: MutantFinder, transformer: StatementTransformer, mat
   private def logMutationResult(mutatedFiles: Iterable[MutatedFile], totalAmountOfFiles: Int): Unit = {
     val includedMutants = mutatedFiles.flatMap(_.mutants).size
     val excludedMutants = mutatedFiles.map(_.excludedMutants).sum
+    val totalMutants = includedMutants + excludedMutants
 
     info(s"Found ${mutatedFiles.size} of $totalAmountOfFiles file(s) to be mutated.")
-    info(s"${includedMutants + excludedMutants} Mutant(s) generated.")
+    info(s"$totalMutants Mutant(s) generated.")
     if (excludedMutants > 0) {
       info(s"Of which $excludedMutants Mutant(s) are excluded.")
+    }
+    if (includedMutants == 0) {
+      warn("0 mutants are found. This is likely an issue with configuration.")
+      warn("Please check your configuration and try again.")
     }
   }
 

--- a/core/src/main/scala/stryker4s/mutants/Mutator.scala
+++ b/core/src/main/scala/stryker4s/mutants/Mutator.scala
@@ -47,19 +47,26 @@ class Mutator(mutantFinder: MutantFinder, transformer: StatementTransformer, mat
     val totalMutants = includedMutants + excludedMutants
 
     info(s"Found ${mutatedFiles.size} of $totalAmountOfFiles file(s) to be mutated.")
-    info(s"$totalMutants Mutant(s) generated.")
-    if (excludedMutants > 0) {
-      info(s"Of which $excludedMutants Mutant(s) are excluded.")
-    }
-    if (includedMutants == 0) {
-      info("It's a mutant-free world, nothing to test.")
+    info(s"$totalMutants Mutant(s) generated.${if (excludedMutants > 0)
+      s" Of which $excludedMutants Mutant(s) are excluded."}")
+
+    if (totalAmountOfFiles == 0) {
+      warn(s"No files marked to be mutated. ${dryRunText("mutate")}")
+    } else if (includedMutants == 0 && excludedMutants > 0) {
+      warn(s"All found mutations are excluded. ${dryRunText("excluded-mutations")}")
+    } else if (totalMutants == 0) {
+      info("Files to be mutated are found, but no mutations were found in those files.")
       info("If this is not intended, please check your configuration and try again.")
     }
+
+    def dryRunText(configProperty: String): String =
+      s"""Stryker4s will perform a dry-run without actually mutating anything.
+         |You can configure the `$configProperty` property in your configuration""".stripMargin
   }
 
   /** Wrap a `Term.Name` args of a `Term.Interpolate` args in a `Term.Block` to work around a bug in Scalameta: https://github.com/scalameta/scalameta/issues/1792
     */
-  private def wrapInterpolations(builtTree: Tree) = builtTree transform {
+  private def wrapInterpolations(builtTree: Tree): Tree = builtTree transform {
     case Term.Interpolate(prefix, parts, args) =>
       Term.Interpolate(prefix, parts, args map {
         case t: Term.Name => Term.Block(List(t))

--- a/core/src/main/scala/stryker4s/mutants/Mutator.scala
+++ b/core/src/main/scala/stryker4s/mutants/Mutator.scala
@@ -51,8 +51,9 @@ class Mutator(mutantFinder: MutantFinder, transformer: StatementTransformer, mat
     if (excludedMutants > 0) {
       info(s"Of which $excludedMutants Mutant(s) are excluded.")
     }
-    if (includedMutants == 0) {
-      warn("0 mutants are found. This is likely an issue with configuration.")
+    if (totalMutants == 0) {
+      warn("It's a mutant-free world, nothing to test.")
+      warn("This is likely an issue with configuration.")
       warn("Please check your configuration and try again.")
     }
   }

--- a/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
@@ -82,6 +82,23 @@ class MutatorTest extends Stryker4sSuite with TreeEquality with LogMatchers {
       "4 Mutant(s) generated" shouldBe loggedAsInfo
       s"Of which 3 Mutant(s) are excluded." shouldBe loggedAsInfo
     }
+
+    it("should log a warning if no mutants are found") {
+      implicit val conf: Config = Config()
+      val files = new TestSourceCollector(Seq(FileUtil.getResource("fileTests/filledDir/src/main/scala/package/someFile.scala")))
+        .collectFilesToMutate()
+
+      val sut = new Mutator(
+        new MutantFinder(new MutantMatcher),
+        new StatementTransformer,
+        new MatchBuilder
+      )
+
+      sut.mutate(files)
+
+      "0 mutants are found. This is likely an issue with configuration." shouldBe loggedAsWarning
+      s"Please check your configuration and try again." shouldBe loggedAsWarning
+    }
   }
 
   describe("string interpolation") {

--- a/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
@@ -96,8 +96,27 @@ class MutatorTest extends Stryker4sSuite with TreeEquality with LogMatchers {
 
       sut.mutate(files)
 
-      "0 mutants are found. This is likely an issue with configuration." shouldBe loggedAsWarning
-      s"Please check your configuration and try again." shouldBe loggedAsWarning
+      "It's a mutant-free world, nothing to test." shouldBe loggedAsWarning
+      "This is likely an issue with configuration." shouldBe loggedAsWarning
+      "Please check your configuration and try again." shouldBe loggedAsWarning
+    }
+
+    it("should not log a no-mutants-found warning when mutants are found") {
+      implicit val conf: Config = Config()
+      val files = new TestSourceCollector(Seq(FileUtil.getResource("scalaFiles/simpleFile.scala")))
+        .collectFilesToMutate()
+
+      val sut = new Mutator(
+        new MutantFinder(new MutantMatcher),
+        new StatementTransformer,
+        new MatchBuilder
+      )
+
+      sut.mutate(files)
+
+      "It's a mutant-free world, nothing to test." should not be loggedAsWarning
+      "This is likely an issue with configuration." should not be loggedAsWarning
+      "Please check your configuration and try again." should not be loggedAsWarning
     }
   }
 

--- a/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
@@ -80,6 +80,8 @@ class MutatorTest extends Stryker4sSuite with TreeEquality with LogMatchers {
 
       "Found 1 of 1 file(s) to be mutated." shouldBe loggedAsInfo
       "4 Mutant(s) generated. Of which 3 Mutant(s) are excluded." shouldBe loggedAsInfo
+      "Files to be mutated are found, but no mutations were found in those files." should not be loggedAsInfo
+      "If this is not intended, please check your configuration and try again." should not be loggedAsInfo
     }
 
     it("should log a warning if no mutants are found") {
@@ -95,25 +97,10 @@ class MutatorTest extends Stryker4sSuite with TreeEquality with LogMatchers {
 
       sut.mutate(files)
 
+      "Found 0 of 1 file(s) to be mutated." shouldBe loggedAsInfo
+      "0 Mutant(s) generated." shouldBe loggedAsInfo
       "Files to be mutated are found, but no mutations were found in those files." shouldBe loggedAsInfo
       "If this is not intended, please check your configuration and try again." shouldBe loggedAsInfo
-    }
-
-    it("should not log a no-mutants-found warning when mutants are found") {
-      implicit val conf: Config = Config()
-      val files = new TestSourceCollector(Seq(FileUtil.getResource("scalaFiles/simpleFile.scala")))
-        .collectFilesToMutate()
-
-      val sut = new Mutator(
-        new MutantFinder(new MutantMatcher),
-        new StatementTransformer,
-        new MatchBuilder
-      )
-
-      sut.mutate(files)
-
-      "Files to be mutated are found, but no mutations were found in those files." should not be loggedAsInfo
-      "If this is not intended, please check your configuration and try again." should not be loggedAsInfo
     }
 
     it("should log if no files are found") {
@@ -133,6 +120,9 @@ class MutatorTest extends Stryker4sSuite with TreeEquality with LogMatchers {
       "0 Mutant(s) generated." shouldBe loggedAsInfo
       """No files marked to be mutated. Stryker4s will perform a dry-run without actually mutating anything.
       |You can configure the `mutate` property in your configuration""".stripMargin shouldBe loggedAsWarning
+
+      "Files to be mutated are found, but no mutations were found in those files." should not be loggedAsInfo
+      "If this is not intended, please check your configuration and try again." should not be loggedAsInfo
     }
 
     it("should log if all mutations are excluded") {
@@ -152,6 +142,11 @@ class MutatorTest extends Stryker4sSuite with TreeEquality with LogMatchers {
       "4 Mutant(s) generated. Of which 4 Mutant(s) are excluded." shouldBe loggedAsInfo
       s"""All found mutations are excluded. Stryker4s will perform a dry-run without actually mutating anything.
        |You can configure the `excluded-mutations` property in your configuration""".stripMargin shouldBe loggedAsWarning
+
+      """No files marked to be mutated. Stryker4s will perform a dry-run without actually mutating anything.
+        |You can configure the `mutate` property in your configuration""".stripMargin should not be loggedAsWarning
+      "Files to be mutated are found, but no mutations were found in those files." should not be loggedAsInfo
+      "If this is not intended, please check your configuration and try again." should not be loggedAsInfo
     }
   }
 

--- a/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
@@ -80,7 +80,7 @@ class MutatorTest extends Stryker4sSuite with TreeEquality with LogMatchers {
 
       "Found 1 of 1 file(s) to be mutated." shouldBe loggedAsInfo
       "4 Mutant(s) generated" shouldBe loggedAsInfo
-      s"Of which 3 Mutant(s) are excluded." shouldBe loggedAsInfo
+      "Of which 3 Mutant(s) are excluded." shouldBe loggedAsInfo
     }
 
     it("should log a warning if no mutants are found") {
@@ -96,9 +96,8 @@ class MutatorTest extends Stryker4sSuite with TreeEquality with LogMatchers {
 
       sut.mutate(files)
 
-      "It's a mutant-free world, nothing to test." shouldBe loggedAsWarning
-      "This is likely an issue with configuration." shouldBe loggedAsWarning
-      "Please check your configuration and try again." shouldBe loggedAsWarning
+      "It's a mutant-free world, nothing to test." shouldBe loggedAsInfo
+      "If this is not intended, please check your configuration and try again." shouldBe loggedAsInfo
     }
 
     it("should not log a no-mutants-found warning when mutants are found") {
@@ -114,9 +113,8 @@ class MutatorTest extends Stryker4sSuite with TreeEquality with LogMatchers {
 
       sut.mutate(files)
 
-      "It's a mutant-free world, nothing to test." should not be loggedAsWarning
-      "This is likely an issue with configuration." should not be loggedAsWarning
-      "Please check your configuration and try again." should not be loggedAsWarning
+      "It's a mutant-free world, nothing to test." should not be loggedAsInfo
+      "If this is not intended, please check your configuration and try again." should not be loggedAsInfo
     }
   }
 

--- a/core/src/test/scala/stryker4s/scalatest/FileUtil.scala
+++ b/core/src/test/scala/stryker4s/scalatest/FileUtil.scala
@@ -6,12 +6,10 @@ import better.files.File
 
 object FileUtil {
 
-  private val classLoader = getClass.getClassLoader
+  private lazy val classLoader = getClass.getClassLoader
 
-  def getResource(name: String): File = {
-    val resource = Option(classLoader.getResource(name))
-    resource
+  def getResource(name: String): File =
+    Option(classLoader.getResource(name))
       .map(File(_))
       .getOrElse(throw new FileNotFoundException(s"File $name could not be found"))
-  }
 }


### PR DESCRIPTION
### Fixes #132 

#### What it does

Logs when 0 mutants are found, letting the user know something could be wrong with their configuration.

#### How it works

Logging magic 🔮