### PR TITLE
Update Scalameta to 4.1.2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   object versions {
     val scala212 = "2.12.8"
 
-    val scalameta = "4.1.0"
+    val scalameta = "4.1.2"
     val pureconfig = "0.9.2"
     val scalatest = "3.0.5"
     val mockitoScala = "1.0.6"


### PR DESCRIPTION
This fixes a bug we found and @Wmaarts fixed related to infix syntax printing
