### PR TITLE
Refactor Mutant and MutantRunner

### DIFF
--- a/core/src/main/scala/stryker4s/model/Mutant.scala
+++ b/core/src/main/scala/stryker4s/model/Mutant.scala
@@ -1,7 +1,5 @@
 package stryker4s.model
 
-import stryker4s.extension.mutationtype.Mutation
+import scala.meta.Term
 
-import scala.meta.{Term, Tree}
-
-case class Mutant(id: Int, original: Term, mutated: Term, mutationType: Mutation[_ <: Tree])
+case class Mutant(id: Int, original: Term, mutated: Term)

--- a/core/src/main/scala/stryker4s/model/MutantRunResult.scala
+++ b/core/src/main/scala/stryker4s/model/MutantRunResult.scala
@@ -21,7 +21,7 @@ sealed trait Undetected extends MutantRunResult
 
 case class Killed(mutant: Mutant, fileSubPath: Path) extends Detected
 
-case class TimedOut(reason: TimeoutException, mutant: Mutant, fileSubPath: Path) extends Detected
+case class TimedOut(mutant: Mutant, fileSubPath: Path) extends Detected
 
 case class Survived(mutant: Mutant, fileSubPath: Path) extends Undetected
 

--- a/core/src/main/scala/stryker4s/mutants/applymutants/StatementTransformer.scala
+++ b/core/src/main/scala/stryker4s/mutants/applymutants/StatementTransformer.scala
@@ -26,7 +26,7 @@ class StatementTransformer {
 
     val transformedMutants = registered.map { mutant =>
       val newMutated = transformStatement(topStatement, mutant.original, mutant.mutated)
-      Mutant(mutant.id, topStatement, newMutated, mutant.mutationType)
+      Mutant(mutant.id, topStatement, newMutated)
     }.toList
 
     TransformedMutants(topStatement, transformedMutants)

--- a/core/src/main/scala/stryker4s/mutants/findmutants/FileCollector.scala
+++ b/core/src/main/scala/stryker4s/mutants/findmutants/FileCollector.scala
@@ -9,11 +9,13 @@ import stryker4s.run.process.{Command, ProcessRunner}
 import scala.util.{Failure, Success}
 
 trait SourceCollector {
+  protected val processRunner: ProcessRunner
+
   def collectFilesToMutate(): Iterable[File]
-  def filesToCopy(processRunner: ProcessRunner): Iterable[File]
+  def filesToCopy: Iterable[File]
 }
 
-class FileCollector(implicit config: Config) extends SourceCollector with Logging {
+class FileCollector(protected val processRunner: ProcessRunner)(implicit config: Config) extends SourceCollector with Logging {
 
   /**
     * Get path separator because windows and unix systems have different separators.
@@ -38,7 +40,7 @@ class FileCollector(implicit config: Config) extends SourceCollector with Loggin
     * Option 2: Copy every file that is listed by git.
     * Option 3: Copy every file in the 'baseDir' excluding target folders.
     */
-  override def filesToCopy(processRunner: ProcessRunner): Iterable[File] = {
+  override def filesToCopy: Iterable[File] = {
     (listFilesBasedOnConfiguration() orElse
       listFilesBasedOnGit(processRunner) getOrElse
       listAllFiles())

--- a/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
+++ b/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
@@ -67,7 +67,7 @@ class MutantMatcher()(implicit config: Config) {
         if (matchExcluded(mutation))
           None
         else
-          Some(Mutant(stream.next, original, mutation.tree, mutation))
+          Some(Mutant(stream.next, original, mutation.tree))
       }
     }
 
@@ -75,7 +75,7 @@ class MutantMatcher()(implicit config: Config) {
       if (matchExcluded(mutated))
         None :: Nil
       else
-        Some(Mutant(stream.next, original, mutated(f), mutated)) :: Nil
+        Some(Mutant(stream.next, original, mutated(f))) :: Nil
     }
 
     private def ifNotInAnnotation(maybeMutants: => Seq[Option[Mutant]]): Seq[Option[Mutant]] = {

--- a/core/src/main/scala/stryker4s/run/InitialTestRun.scala
+++ b/core/src/main/scala/stryker4s/run/InitialTestRun.scala
@@ -1,0 +1,20 @@
+package stryker4s.run
+import better.files.File
+import grizzled.slf4j.Logging
+import stryker4s.extension.exception.InitialTestRunFailedException
+
+trait InitialTestRun extends Logging {
+
+  def initialTestRun(tmpDir: File): Unit = {
+    info("Starting initial test run...")
+    if (!runInitialTest(tmpDir)) {
+      throw InitialTestRunFailedException(
+        "Initial test run failed. Please make sure your tests pass before running Stryker4s."
+      )
+    }
+    info("Initial test run succeeded! Testing mutants...")
+  }
+
+  def runInitialTest(workingDir: File): Boolean
+
+}

--- a/core/src/main/scala/stryker4s/run/MutantRunner.scala
+++ b/core/src/main/scala/stryker4s/run/MutantRunner.scala
@@ -83,14 +83,14 @@ abstract class MutantRunner(process: ProcessRunner, sourceCollector: SourceColle
       subPath = mutatedFile.fileOrigin.relativePath
       mutant <- mutatedFile.mutants
     } yield {
-      val result = runMutant(mutant, tmpDir, subPath)
+      val result = runMutant(mutant, tmpDir)(subPath)
       val id = mutant.id + 1
       info(s"Finished mutation run $id/$totalMutants (${((id / totalMutants.toDouble) * 100).round}%)")
       result
     }
   }
 
-  def runMutant(mutant: Mutant, workingDir: File, subPath: Path): MutantRunResult
+  def runMutant(mutant: Mutant, workingDir: File): Path => MutantRunResult
   def runInitialTest(workingDir: File): Boolean
 
 }

--- a/core/src/main/scala/stryker4s/run/MutantRunner.scala
+++ b/core/src/main/scala/stryker4s/run/MutantRunner.scala
@@ -9,11 +9,10 @@ import stryker4s.extension.FileExtensions._
 import stryker4s.extension.score.MutationScoreCalculator
 import stryker4s.model._
 import stryker4s.mutants.findmutants.SourceCollector
-import stryker4s.run.process.ProcessRunner
 
 import scala.concurrent.duration.{Duration, MILLISECONDS}
 
-abstract class MutantRunner(process: ProcessRunner, sourceCollector: SourceCollector)(implicit config: Config)
+abstract class MutantRunner(sourceCollector: SourceCollector)(implicit config: Config)
     extends InitialTestRun
     with MutationScoreCalculator
     with Logging {
@@ -41,7 +40,7 @@ abstract class MutantRunner(process: ProcessRunner, sourceCollector: SourceColle
   }
 
   private def prepareEnv(mutatedFiles: Iterable[MutatedFile]): Unit = {
-    val files = sourceCollector.filesToCopy(process)
+    val files = sourceCollector.filesToCopy
 
     debug("Using temp directory: " + tmpDir)
 

--- a/core/src/main/scala/stryker4s/run/Stryker4sRunner.scala
+++ b/core/src/main/scala/stryker4s/run/Stryker4sRunner.scala
@@ -6,6 +6,7 @@ import stryker4s.mutants.Mutator
 import stryker4s.mutants.applymutants.ActiveMutationContext.ActiveMutationContext
 import stryker4s.mutants.applymutants.{MatchBuilder, StatementTransformer}
 import stryker4s.mutants.findmutants.{FileCollector, MutantFinder, MutantMatcher, SourceCollector}
+import stryker4s.run.process.ProcessRunner
 import stryker4s.run.report.Reporter
 import stryker4s.run.threshold.ScoreStatus
 
@@ -21,7 +22,7 @@ trait Stryker4sRunner {
     // it is cleaned before it starts.
     PlatformTokenizerCache.megaCache.clear()
 
-    val collector = new FileCollector
+    val collector = new FileCollector(ProcessRunner())
     val stryker4s = new Stryker4s(
       collector,
       new Mutator(new MutantFinder(new MutantMatcher), new StatementTransformer, new MatchBuilder(mutationActivation)),

--- a/core/src/main/scala/stryker4s/run/process/ProcessMutantRunner.scala
+++ b/core/src/main/scala/stryker4s/run/process/ProcessMutantRunner.scala
@@ -30,7 +30,7 @@ class ProcessMutantRunner(command: Command, processRunner: ProcessRunner, source
     processRunner(command, workingDir, ("ACTIVE_MUTATION", "None")) match {
       case Success(0)                         => true
       case Success(exitCode) if exitCode != 0 => false
-      case Failure(_: TimeoutException)     => false
+      case Failure(_: TimeoutException)       => false
     }
   }
 }

--- a/core/src/main/scala/stryker4s/run/process/ProcessMutantRunner.scala
+++ b/core/src/main/scala/stryker4s/run/process/ProcessMutantRunner.scala
@@ -15,13 +15,14 @@ class ProcessMutantRunner(command: Command, processRunner: ProcessRunner, source
     implicit config: Config)
     extends MutantRunner(processRunner, sourceCollector) {
 
-  def runMutant(mutant: Mutant, workingDir: File, subPath: Path): MutantRunResult = {
+  def runMutant(mutant: Mutant, workingDir: File): Path => MutantRunResult = {
     val id = mutant.id
     info(s"Starting test-run ${id + 1}...")
     processRunner(command, workingDir, ("ACTIVE_MUTATION", id.toString)) match {
-      case Success(0)                         => Survived(mutant, subPath)
-      case Success(exitCode) if exitCode != 0 => Killed(mutant, subPath)
-      case Failure(exc: TimeoutException)     => TimedOut(exc, mutant, subPath)
+      case Success(0)                         => Survived(mutant, _)
+      case Success(exitCode) if exitCode != 0 => Killed(mutant, _)
+      case Failure(_: TimeoutException)       => TimedOut(mutant, _)
+      case _                                  => Error(mutant, _)
     }
   }
 
@@ -29,7 +30,7 @@ class ProcessMutantRunner(command: Command, processRunner: ProcessRunner, source
     processRunner(command, workingDir, ("ACTIVE_MUTATION", "None")) match {
       case Success(0)                         => true
       case Success(exitCode) if exitCode != 0 => false
-      case Failure(exc: TimeoutException)     => false
+      case Failure(_: TimeoutException)     => false
     }
   }
 }

--- a/core/src/main/scala/stryker4s/run/process/ProcessMutantRunner.scala
+++ b/core/src/main/scala/stryker4s/run/process/ProcessMutantRunner.scala
@@ -13,7 +13,7 @@ import scala.util.{Failure, Success}
 
 class ProcessMutantRunner(command: Command, processRunner: ProcessRunner, sourceCollector: SourceCollector)(
     implicit config: Config)
-    extends MutantRunner(processRunner, sourceCollector) {
+    extends MutantRunner(sourceCollector) {
 
   def runMutant(mutant: Mutant, workingDir: File): Path => MutantRunResult = {
     val id = mutant.id

--- a/core/src/main/scala/stryker4s/run/process/ProcessRunner.scala
+++ b/core/src/main/scala/stryker4s/run/process/ProcessRunner.scala
@@ -32,7 +32,7 @@ trait ProcessRunner extends Logging {
 object ProcessRunner {
   private val isWindows: Boolean = sys.props("os.name").toLowerCase.contains("windows")
 
-  def resolveRunner(): ProcessRunner = {
+  def apply(): ProcessRunner = {
     if (isWindows) new WindowsProcessRunner
     else new UnixProcessRunner
   }

--- a/core/src/test/scala/stryker4s/Stryker4sTest.scala
+++ b/core/src/test/scala/stryker4s/Stryker4sTest.scala
@@ -7,7 +7,7 @@ import stryker4s.model.{Killed, Mutant}
 import stryker4s.mutants.Mutator
 import stryker4s.mutants.applymutants.{ActiveMutationContext, MatchBuilder, StatementTransformer}
 import stryker4s.mutants.findmutants.{FileCollector, MutantFinder, MutantMatcher}
-import stryker4s.run.process.{Command, ProcessMutantRunner}
+import stryker4s.run.process.{Command, ProcessMutantRunner, ProcessRunner}
 import stryker4s.run.threshold.SuccessStatus
 import stryker4s.scalatest.{FileUtil, LogMatchers}
 import stryker4s.testutil.Stryker4sSuite
@@ -24,7 +24,7 @@ class Stryker4sTest extends Stryker4sSuite with LogMatchers {
       val testFiles = Seq(file)
       val testSourceCollector = new TestSourceCollector(testFiles)
       val testProcessRunner = TestProcessRunner(Success(1), Success(1), Success(1), Success(1))
-      val testMutantRunner = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, new FileCollector())
+      val testMutantRunner = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, new FileCollector(testProcessRunner))
       val testReporter = new TestReporter
 
       val sut = new Stryker4s(

--- a/core/src/test/scala/stryker4s/Stryker4sTest.scala
+++ b/core/src/test/scala/stryker4s/Stryker4sTest.scala
@@ -44,10 +44,10 @@ class Stryker4sTest extends Stryker4sSuite with LogMatchers {
 
       result shouldBe SuccessStatus
       reportedResults should matchPattern {
-        case List(Killed(Mutant(0, _, _, _), `expectedPath`),
-                  Killed(Mutant(1, _, _, _), `expectedPath`),
-                  Killed(Mutant(2, _, _, _), `expectedPath`),
-                  Killed(Mutant(3, _, _, _), `expectedPath`)) =>
+        case List(Killed(Mutant(0, _, _), `expectedPath`),
+                  Killed(Mutant(1, _, _), `expectedPath`),
+                  Killed(Mutant(2, _, _), `expectedPath`),
+                  Killed(Mutant(3, _, _), `expectedPath`)) =>
       }
     }
 

--- a/core/src/test/scala/stryker4s/mutants/applymutants/MatchBuilderTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/applymutants/MatchBuilderTest.scala
@@ -20,7 +20,7 @@ class MatchBuilderTest extends Stryker4sSuite with TreeEquality {
       val ids = Iterator.from(0)
       val originalStatement = q"x >= 15"
       val mutants = List(q"x > 15", q"x <= 15")
-        .map(Mutant(ids.next(), originalStatement, _, GreaterThan))
+        .map((mutated: Term.ApplyInfix) => Mutant(ids.next(), originalStatement, mutated))
       val sut = new MatchBuilder(ActiveMutationContext.sysProps)
 
       // Act
@@ -174,7 +174,7 @@ class MatchBuilderTest extends Stryker4sSuite with TreeEquality {
     val topStatement = source.find(origStatement).value.topStatement()
     val mutant = mutants
       .map(m => topStatement transformOnce { case orig if orig.isEqual(origStatement) => m } get)
-      .map(m => Mutant(ids.next(), topStatement, m.asInstanceOf[Term], mutation))
+      .map(m => Mutant(ids.next(), topStatement, m.asInstanceOf[Term]))
       .toList
 
     TransformedMutants(topStatement, mutant)

--- a/core/src/test/scala/stryker4s/mutants/applymutants/StatementTransformerTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/applymutants/StatementTransformerTest.scala
@@ -65,7 +65,7 @@ class StatementTransformerTest extends Stryker4sSuite with TreeEquality {
       val originalTopTree = q"val x: Boolean = 15 >= 5"
       val originalTree = originalTopTree.find(q">=").value
       val mutants = List(EqualTo, GreaterThan, LesserThanEqualTo)
-        .map(Mutant(0, originalTree, _, GreaterThanEqualTo))
+        .map((mutated: EqualityOperator) => Mutant(0, originalTree, mutated))
 
       // Act
       val transformedMutant = sut.transformMutant(originalTree, mutants)
@@ -85,7 +85,7 @@ class StatementTransformerTest extends Stryker4sSuite with TreeEquality {
       val source = "object Foo { def bar: Boolean = 15 >= 4 }".parse[Source].get
       val origTree = source.find(q">=").value
       val mutants = List(EqualTo, GreaterThan, LesserThanEqualTo)
-        .map(Mutant(0, origTree, _, GreaterThanEqualTo))
+        .map((mutated: EqualityOperator) => Mutant(0, origTree, mutated))
 
       // Act
       val result = sut.transformSource(source, mutants)
@@ -104,11 +104,11 @@ class StatementTransformerTest extends Stryker4sSuite with TreeEquality {
 
     val firstOrigTree = source.find(q">=").value
     val firstMutants: Seq[Mutant] = List(EqualTo, GreaterThan, LesserThanEqualTo)
-      .map(Mutant(0, firstOrigTree, _, GreaterThanEqualTo))
+      .map((mutated: EqualityOperator) => Mutant(0, firstOrigTree, mutated))
 
     val secOrigTree = source.find(q"<").value
     val secondMutants: Seq[Mutant] = List(LesserThanEqualTo, GreaterThan, EqualTo)
-      .map(Mutant(0, secOrigTree, _, GreaterThanEqualTo))
+      .map((mutated: EqualityOperator) => Mutant(0, secOrigTree, mutated))
 
     val statements = firstMutants ++ secondMutants
 

--- a/core/src/test/scala/stryker4s/mutants/findmutants/FileCollectorTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/FileCollectorTest.scala
@@ -178,7 +178,7 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
       when(processRunnerMock(Command("git ls-files", "--others --exclude-standard --cached"), config.baseDir))
         .thenReturn(gitProcessResult)
 
-      val sut = new FileCollector(TestProcessRunner())
+      val sut = new FileCollector(processRunnerMock)
 
       val results = sut.filesToCopy
 
@@ -193,7 +193,7 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
       when(processRunnerMock(Command("git ls-files", "--others --exclude-standard --cached"), config.baseDir))
         .thenReturn(gitProcessResult)
 
-      val sut = new FileCollector(TestProcessRunner())
+      val sut = new FileCollector(processRunnerMock)
 
       val results = sut.filesToCopy
 
@@ -205,7 +205,7 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
         Config(baseDir = filledDirPath, files = Some(Seq("**/main/scala/**/*.scala")))
       val expectedFileList = Seq(basePath / "someFile.scala", basePath / "secondFile.scala", basePath / "target.scala")
 
-      val sut = new FileCollector(TestProcessRunner())
+      val sut = new FileCollector(processRunnerMock)
 
       val results = sut.filesToCopy
 
@@ -223,7 +223,7 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
       val gitProcessResult = Failure(new Exception("Exception"))
       when(processRunnerMock(any[Command], any[File])).thenReturn(gitProcessResult)
 
-      val sut = new FileCollector(TestProcessRunner())
+      val sut = new FileCollector(processRunnerMock)
 
       val results = sut.filesToCopy
 
@@ -238,7 +238,7 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
       when(processRunnerMock(Command("git ls-files", "--others --exclude-standard --cached"), config.baseDir))
         .thenReturn(gitProcessResult)
 
-      val sut = new FileCollector(TestProcessRunner())
+      val sut = new FileCollector(processRunnerMock)
 
       val results = sut.filesToCopy
 
@@ -251,7 +251,7 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
         val gitProcessResult = Failure(new Exception(""))
         when(processRunnerMock(any[Command], any[File])).thenReturn(gitProcessResult)
 
-        val sut = new FileCollector(TestProcessRunner())
+        val sut = new FileCollector(processRunnerMock)
 
         sut.filesToCopy
 

--- a/core/src/test/scala/stryker4s/mutants/findmutants/FileCollectorTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/FileCollectorTest.scala
@@ -6,6 +6,7 @@ import stryker4s.config.Config
 import stryker4s.run.process.{Command, ProcessRunner}
 import stryker4s.scalatest.{FileUtil, LogMatchers}
 import stryker4s.testutil.Stryker4sSuite
+import stryker4s.testutil.stubs.TestProcessRunner
 
 import scala.util.{Failure, Try}
 
@@ -24,7 +25,7 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
 
       it("should not collect the baseDir") {
         implicit val config: Config = Config(baseDir = emptyDir)
-        val sut = new FileCollector()
+        val sut = new FileCollector(TestProcessRunner())
 
         val results = sut.collectFilesToMutate()
 
@@ -36,7 +37,7 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
 
       it("should find all scala files and not the non-scala files with default config") {
         implicit val config: Config = Config(baseDir = filledDirPath)
-        val sut = new FileCollector()
+        val sut = new FileCollector(TestProcessRunner())
 
         val results = sut.collectFilesToMutate()
 
@@ -47,7 +48,7 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
       it("should find matching files with custom config match pattern") {
         implicit val config: Config =
           Config(mutate = Seq("src/**/second*.scala"), baseDir = filledDirPath)
-        val sut = new FileCollector()
+        val sut = new FileCollector(TestProcessRunner())
 
         val results = sut.collectFilesToMutate()
         val onlyResult = results.loneElement
@@ -58,7 +59,7 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
       it("should find no matches with a non-matching glob") {
         implicit val config: Config =
           Config(mutate = Seq("**/noMatchesToBeFoundHere.scala"), baseDir = filledDirPath)
-        val sut = new FileCollector()
+        val sut = new FileCollector(TestProcessRunner())
 
         val results = sut.collectFilesToMutate()
 
@@ -68,7 +69,7 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
       it("should match on multiple globs") {
         implicit val config: Config =
           Config(mutate = Seq("**/someFile.scala", "**/secondFile.scala"), baseDir = filledDirPath)
-        val sut = new FileCollector()
+        val sut = new FileCollector(TestProcessRunner())
 
         val results = sut.collectFilesToMutate()
 
@@ -79,7 +80,7 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
       it("should only add a glob once even when it matches twice") {
         implicit val config: Config =
           Config(mutate = Seq("**/someFile.scala", "**/*.scala"), baseDir = filledDirPath)
-        val sut = new FileCollector()
+        val sut = new FileCollector(TestProcessRunner())
 
         val results = sut.collectFilesToMutate()
 
@@ -92,7 +93,7 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
           Config(mutate = Seq("**/someFile.scala", "**/secondFile.scala", "!**/*.scala", "!**/someFile.scala"),
                  baseDir = filledDirPath)
 
-        val sut = new FileCollector()
+        val sut = new FileCollector(TestProcessRunner())
 
         val results = sut.collectFilesToMutate()
 
@@ -105,7 +106,7 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
           baseDir = filledDirPath
         )
 
-        val sut = new FileCollector()
+        val sut = new FileCollector(TestProcessRunner())
 
         val results = sut.collectFilesToMutate()
 
@@ -118,7 +119,7 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
           Config(mutate = Seq("**/someFile.scala", "**/secondFile.scala", "!**/someFile.scala", "!**/secondFile.scala"),
                  baseDir = filledDirPath)
 
-        val sut = new FileCollector()
+        val sut = new FileCollector(TestProcessRunner())
 
         val results = sut.collectFilesToMutate()
 
@@ -131,7 +132,7 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
           baseDir = filledDirPath
         )
 
-        val sut = new FileCollector()
+        val sut = new FileCollector(TestProcessRunner())
 
         val results = sut.collectFilesToMutate()
 
@@ -141,7 +142,7 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
       it("Should exclude all files from previous runs in the target folder") {
         implicit val config: Config = Config(baseDir = filledDirPath)
 
-        val sut = new FileCollector()
+        val sut = new FileCollector(TestProcessRunner())
 
         val results = sut.collectFilesToMutate()
 
@@ -155,7 +156,7 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
           baseDir = filledDirPath
         )
 
-        val sut = new FileCollector()
+        val sut = new FileCollector(TestProcessRunner())
 
         val results = sut.collectFilesToMutate()
 
@@ -177,9 +178,9 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
       when(processRunnerMock(Command("git ls-files", "--others --exclude-standard --cached"), config.baseDir))
         .thenReturn(gitProcessResult)
 
-      val sut = new FileCollector()
+      val sut = new FileCollector(TestProcessRunner())
 
-      val results = sut.filesToCopy(processRunnerMock)
+      val results = sut.filesToCopy
 
       results should contain theSameElementsAs expectedFileList
     }
@@ -192,9 +193,9 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
       when(processRunnerMock(Command("git ls-files", "--others --exclude-standard --cached"), config.baseDir))
         .thenReturn(gitProcessResult)
 
-      val sut = new FileCollector()
+      val sut = new FileCollector(TestProcessRunner())
 
-      val results = sut.filesToCopy(processRunnerMock)
+      val results = sut.filesToCopy
 
       results should contain theSameElementsAs expectedFileList
     }
@@ -204,9 +205,9 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
         Config(baseDir = filledDirPath, files = Some(Seq("**/main/scala/**/*.scala")))
       val expectedFileList = Seq(basePath / "someFile.scala", basePath / "secondFile.scala", basePath / "target.scala")
 
-      val sut = new FileCollector()
+      val sut = new FileCollector(TestProcessRunner())
 
-      val results = sut.filesToCopy(processRunnerMock)
+      val results = sut.filesToCopy
 
       results should contain theSameElementsAs expectedFileList
     }
@@ -222,9 +223,9 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
       val gitProcessResult = Failure(new Exception("Exception"))
       when(processRunnerMock(any[Command], any[File])).thenReturn(gitProcessResult)
 
-      val sut = new FileCollector()
+      val sut = new FileCollector(TestProcessRunner())
 
-      val results = sut.filesToCopy(processRunnerMock)
+      val results = sut.filesToCopy
 
       results should have size 4
       results should contain theSameElementsAs expectedFileList
@@ -237,9 +238,9 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
       when(processRunnerMock(Command("git ls-files", "--others --exclude-standard --cached"), config.baseDir))
         .thenReturn(gitProcessResult)
 
-      val sut = new FileCollector()
+      val sut = new FileCollector(TestProcessRunner())
 
-      val results = sut.filesToCopy(processRunnerMock)
+      val results = sut.filesToCopy
 
       results should be(empty)
     }
@@ -250,9 +251,9 @@ class FileCollectorTest extends Stryker4sSuite with MockitoFixture with LogMatch
         val gitProcessResult = Failure(new Exception(""))
         when(processRunnerMock(any[Command], any[File])).thenReturn(gitProcessResult)
 
-        val sut = new FileCollector()
+        val sut = new FileCollector(TestProcessRunner())
 
-        sut.filesToCopy(processRunnerMock)
+        sut.filesToCopy
 
         "No 'files' specified and not a git repository." shouldBe loggedAsWarning
         "Falling back to copying everything except the 'target/' folder(s)" shouldBe loggedAsWarning

--- a/core/src/test/scala/stryker4s/run/process/ProcessMutantRunnerTest.scala
+++ b/core/src/test/scala/stryker4s/run/process/ProcessMutantRunnerTest.scala
@@ -29,7 +29,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
       val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant), 0)
 
-      when(fileCollectorMock.filesToCopy(testProcessRunner)).thenReturn(List(file))
+      when(fileCollectorMock.filesToCopy).thenReturn(List(file))
 
       val result = sut(Seq(mutatedFile))
 
@@ -46,7 +46,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
       val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant), 0)
 
-      when(fileCollectorMock.filesToCopy(testProcessRunner)).thenReturn(List(file))
+      when(fileCollectorMock.filesToCopy).thenReturn(List(file))
 
       val result = sut(Seq(mutatedFile))
 
@@ -64,7 +64,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
       val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant), 0)
 
-      when(fileCollectorMock.filesToCopy(testProcessRunner)).thenReturn(List(file))
+      when(fileCollectorMock.filesToCopy).thenReturn(List(file))
 
       val result = sut(Seq(mutatedFile))
 
@@ -83,7 +83,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
       val mutants = Seq(mutant, secondMutant)
       val mutatedFile = MutatedFile(file, q"def foo = 4", mutants, 0)
 
-      when(fileCollectorMock.filesToCopy(testProcessRunner)).thenReturn(List(file))
+      when(fileCollectorMock.filesToCopy).thenReturn(List(file))
 
       val result = sut(Seq(mutatedFile))
 
@@ -106,7 +106,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
       val mutants = Seq(mutant, secondMutant, thirdMutant)
       val mutatedFile = MutatedFile(file, q"def foo = 4", mutants, 0)
 
-      when(fileCollectorMock.filesToCopy(testProcessRunner)).thenReturn(List(file))
+      when(fileCollectorMock.filesToCopy).thenReturn(List(file))
 
       val result = sut(Seq(mutatedFile))
 
@@ -124,7 +124,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
       val testProcessRunner = TestProcessRunner.failInitialTestRun()
       val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, fileCollectorMock)
 
-      when(fileCollectorMock.filesToCopy(testProcessRunner)).thenReturn(List.empty)
+      when(fileCollectorMock.filesToCopy).thenReturn(List.empty)
 
       a[InitialTestRunFailedException] shouldBe thrownBy(sut(Seq.empty))
     }
@@ -137,7 +137,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
         val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
         val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant), 0)
 
-        when(fileCollectorMock.filesToCopy(testProcessRunner)).thenReturn(List(file))
+        when(fileCollectorMock.filesToCopy).thenReturn(List(file))
 
         sut(Seq(mutatedFile))
 
@@ -153,7 +153,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
         val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
         val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant0, mutant1), 0)
 
-        when(fileCollectorMock.filesToCopy(testProcessRunner)).thenReturn(List(file))
+        when(fileCollectorMock.filesToCopy).thenReturn(List(file))
 
         sut(Seq(mutatedFile))
 
@@ -167,7 +167,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
         val testProcessRunner = TestProcessRunner()
         val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, fileCollectorMock)
 
-        when(fileCollectorMock.filesToCopy(testProcessRunner)).thenReturn(List.empty)
+        when(fileCollectorMock.filesToCopy).thenReturn(List.empty)
 
         sut(Seq.empty)
 

--- a/core/src/test/scala/stryker4s/run/process/ProcessMutantRunnerTest.scala
+++ b/core/src/test/scala/stryker4s/run/process/ProcessMutantRunnerTest.scala
@@ -25,7 +25,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
     it("should return a Survived mutant on an exitcode 0 process") {
       val testProcessRunner = TestProcessRunner(Success(0))
       val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, fileCollectorMock)
-      val mutant = Mutant(0, q"4", q"5", EmptyString)
+      val mutant = Mutant(0, q"4", q"5")
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
       val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant), 0)
 
@@ -42,7 +42,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
     it("should return a Killed mutant on an exitcode 1 process") {
       val testProcessRunner = TestProcessRunner(Success(1))
       val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, fileCollectorMock)
-      val mutant = Mutant(0, q"4", q"5", EmptyString)
+      val mutant = Mutant(0, q"4", q"5")
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
       val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant), 0)
 
@@ -60,7 +60,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
       val exception = new TimeoutException("Test")
       val testProcessRunner = TestProcessRunner(Failure(exception))
       val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, fileCollectorMock)
-      val mutant = Mutant(0, q"4", q"5", EmptyString)
+      val mutant = Mutant(0, q"4", q"5")
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
       val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant), 0)
 
@@ -71,14 +71,14 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
       testProcessRunner.timesCalled.next() should equal(1)
       result.mutationScore shouldBe 100.00
       val loneResult = result.results.loneElement
-      loneResult should equal(TimedOut(exception, mutant, Paths.get("simpleFile.scala")))
+      loneResult should equal(TimedOut(mutant, Paths.get("simpleFile.scala")))
     }
 
     it("should return a combination of results on multiple runs") {
       val testProcessRunner = TestProcessRunner(Success(1), Success(1))
       val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, fileCollectorMock)
-      val mutant = Mutant(0, q"0", q"zero", EmptyString)
-      val secondMutant = Mutant(1, q"1", q"one", EmptyString)
+      val mutant = Mutant(0, q"0", q"zero")
+      val secondMutant = Mutant(1, q"1", q"one")
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
       val mutants = Seq(mutant, secondMutant)
       val mutatedFile = MutatedFile(file, q"def foo = 4", mutants, 0)
@@ -99,9 +99,9 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
     it("should return a mutationScore of 66.67 when 2 of 3 mutants are killed") {
       val testProcessRunner = TestProcessRunner(Success(1), Success(1), Success(0))
       val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, fileCollectorMock)
-      val mutant = Mutant(0, q"0", q"zero", EmptyString)
-      val secondMutant = Mutant(1, q"1", q"one", EmptyString)
-      val thirdMutant = Mutant(2, q"5", q"5", EmptyString)
+      val mutant = Mutant(0, q"0", q"zero")
+      val secondMutant = Mutant(1, q"1", q"one")
+      val thirdMutant = Mutant(2, q"5", q"5")
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
       val mutants = Seq(mutant, secondMutant, thirdMutant)
       val mutatedFile = MutatedFile(file, q"def foo = 4", mutants, 0)
@@ -133,7 +133,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
       it("Should log that test run 1 is started and finished when mutant id is 0") {
         val testProcessRunner = TestProcessRunner(Success(0))
         val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, fileCollectorMock)
-        val mutant = Mutant(0, q"4", q"5", EmptyString)
+        val mutant = Mutant(0, q"4", q"5")
         val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
         val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant), 0)
 
@@ -148,8 +148,8 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
       it("Should log multiple test runs") {
         val testProcessRunner = TestProcessRunner(Success(0), Success(0))
         val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, fileCollectorMock)
-        val mutant0 = Mutant(0, q"4", q"5", EmptyString)
-        val mutant1 = Mutant(1, q"4", q"5", EmptyString)
+        val mutant0 = Mutant(0, q"4", q"5")
+        val mutant1 = Mutant(1, q"4", q"5")
         val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
         val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant0, mutant1), 0)
 

--- a/core/src/test/scala/stryker4s/run/process/ProcessRunnerTest.scala
+++ b/core/src/test/scala/stryker4s/run/process/ProcessRunnerTest.scala
@@ -6,7 +6,7 @@ class ProcessRunnerTest extends Stryker4sSuite {
   describe("resolveRunner") {
     it("should resolve the proper runner for the current OS") {
       val os = sys.props("os.name")
-      val result = ProcessRunner.resolveRunner()
+      val result = ProcessRunner()
 
       if (os.toLowerCase.contains("windows"))
         result shouldBe a[WindowsProcessRunner]

--- a/core/src/test/scala/stryker4s/testutil/stubs/TestSourceCollector.scala
+++ b/core/src/test/scala/stryker4s/testutil/stubs/TestSourceCollector.scala
@@ -6,5 +6,6 @@ import stryker4s.run.process.ProcessRunner
 
 class TestSourceCollector(returns: Iterable[File]) extends SourceCollector {
   override def collectFilesToMutate(): Iterable[File] = returns
-  override def filesToCopy(processRunner: ProcessRunner): Iterable[File] = returns
+  override def filesToCopy: Iterable[File] = returns
+  override protected lazy val processRunner: ProcessRunner = ProcessRunner()
 }

--- a/runners/command-runner/src/main/scala/stryker4s/run/Stryker4sCommandRunner.scala
+++ b/runners/command-runner/src/main/scala/stryker4s/run/Stryker4sCommandRunner.scala
@@ -24,7 +24,7 @@ object Stryker4sCommandRunner extends App with Stryker4sRunner {
   override def resolveRunner(collector: SourceCollector)(implicit config: Config): MutantRunner =
     config.testRunner match {
       case CommandRunner(command, args) =>
-        new ProcessMutantRunner(Command(command, args), ProcessRunner.resolveRunner(), collector)
+        new ProcessMutantRunner(Command(command, args), ProcessRunner(), collector)
     }
 
   override val mutationActivation: ActiveMutationContext = ActiveMutationContext.envVar

--- a/runners/sbt/src/main/scala/stryker4s/sbt/SbtMutantRunner.scala
+++ b/runners/sbt/src/main/scala/stryker4s/sbt/SbtMutantRunner.scala
@@ -10,11 +10,10 @@ import stryker4s.extension.exception.InitialTestRunFailedException
 import stryker4s.model._
 import stryker4s.mutants.findmutants.SourceCollector
 import stryker4s.run.MutantRunner
-import stryker4s.run.process.ProcessRunner
 
-class SbtMutantRunner(state: State, processRunner: ProcessRunner, sourceCollector: SourceCollector)(
+class SbtMutantRunner(state: State, sourceCollector: SourceCollector)(
     implicit config: Config)
-    extends MutantRunner(processRunner, sourceCollector) {
+    extends MutantRunner(sourceCollector) {
 
   private lazy val filteredSystemProperties: Option[List[String]] = {
     // Matches strings that start with one of the options between brackets

--- a/runners/sbt/src/main/scala/stryker4s/sbt/SbtMutantRunner.scala
+++ b/runners/sbt/src/main/scala/stryker4s/sbt/SbtMutantRunner.scala
@@ -11,9 +11,8 @@ import stryker4s.extension.exception.InitialTestRunFailedException
 import stryker4s.model._
 import stryker4s.mutants.findmutants.SourceCollector
 import stryker4s.run.MutantRunner
-import stryker4s.run.process.ProcessRunner
 
-class SbtMutantRunner(state: State, processRunner: ProcessRunner, sourceCollector: SourceCollector)(
+class SbtMutantRunner(state: State, sourceCollector: SourceCollector)(
     implicit config: Config)
     extends MutantRunner(sourceCollector) {
 

--- a/runners/sbt/src/main/scala/stryker4s/sbt/SbtMutantRunner.scala
+++ b/runners/sbt/src/main/scala/stryker4s/sbt/SbtMutantRunner.scala
@@ -6,7 +6,7 @@ import better.files.File
 import sbt.Keys._
 import sbt._
 import stryker4s.config.Config
-import stryker4s.extension.exception.{InitialTestRunFailedException, MutationRunFailedException, Stryker4sException}
+import stryker4s.extension.exception.InitialTestRunFailedException
 import stryker4s.model._
 import stryker4s.mutants.findmutants.SourceCollector
 import stryker4s.run.MutantRunner
@@ -47,26 +47,28 @@ class SbtMutantRunner(state: State, processRunner: ProcessRunner, sourceCollecto
 
   override def runInitialTest(workingDir: File): Boolean = runTests(
     newState,
-    InitialTestRunFailedException(s"Unable to execute initial test run. Sbt is unable to find the task 'test'."),
+    throw InitialTestRunFailedException(s"Unable to execute initial test run. Sbt is unable to find the task 'test'."),
     onSuccess = true,
     onFailed = false
   )
 
-  override def runMutant(mutant: Mutant, workingDir: File, subPath: Path): MutantRunResult = {
+  override def runMutant(mutant: Mutant, workingDir: File): Path => MutantRunResult = {
     val mutationState = extracted.appendWithSession(settings :+ mutationSetting(mutant.id), newState)
     runTests(
-      mutationState,
-      MutationRunFailedException(s"An unexpected error occurred while running mutation ${mutant.id}"),
-      Survived(mutant, subPath),
-      Killed(mutant, subPath)
+      mutationState, { p: Path =>
+        error(s"An unexpected error occurred while running mutation ${mutant.id}")
+        Error(mutant, p)
+      },
+      Survived(mutant, _),
+      Killed(mutant, _)
     )
   }
 
   /** Runs tests with the giving state, calls the corresponding parameter on each result
     */
-  private def runTests[T](state: State, onError: => Stryker4sException, onSuccess: => T, onFailed: => T): T =
+  private def runTests[T](state: State, onError: => T, onSuccess: => T, onFailed: => T): T =
     Project.runTask(test in Test, state) match {
-      case None                => throw onError
+      case None                => onError
       case Some((_, Value(_))) => onSuccess
       case Some((_, Inc(_)))   => onFailed
     }

--- a/runners/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
+++ b/runners/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
@@ -16,7 +16,7 @@ import stryker4s.run.{MutantRunner, Stryker4sRunner}
 class Stryker4sSbtRunner(state: State) extends Stryker4sRunner {
 
   override def resolveRunner(collector: SourceCollector)(implicit config: Config): MutantRunner =
-    new SbtMutantRunner(state, ProcessRunner.resolveRunner(), collector)
+    new SbtMutantRunner(state, collector)
 
   override val mutationActivation: ActiveMutationContext = ActiveMutationContext.sysProps
 }


### PR DESCRIPTION
Ran into some better-code hub warnings while working on the Maven Plugin (#151). Figured it was a bit much to be inside that PR. So I've removed some unused parameters from the `Mutant` case class, removed the `ProcessRunner` from the `MutantRunner`, which is not needed. As well as made the `InitialTestRun` from the `MutantRunner` into its own trait to clean the code up a bit.