### PR TITLE
Partial revert of #154 (95dd714), add mutationType back to Mutant

### DIFF
--- a/core/src/main/scala/stryker4s/model/Mutant.scala
+++ b/core/src/main/scala/stryker4s/model/Mutant.scala
@@ -1,5 +1,7 @@
 package stryker4s.model
 
-import scala.meta.Term
+import stryker4s.extension.mutationtype.Mutation
 
-case class Mutant(id: Int, original: Term, mutated: Term)
+import scala.meta.{Term, Tree}
+
+case class Mutant(id: Int, original: Term, mutated: Term, mutationType: Mutation[_ <: Tree])

--- a/core/src/main/scala/stryker4s/mutants/applymutants/StatementTransformer.scala
+++ b/core/src/main/scala/stryker4s/mutants/applymutants/StatementTransformer.scala
@@ -26,7 +26,7 @@ class StatementTransformer {
 
     val transformedMutants = registered.map { mutant =>
       val newMutated = transformStatement(topStatement, mutant.original, mutant.mutated)
-      Mutant(mutant.id, topStatement, newMutated)
+      mutant.copy(original = topStatement, mutated = newMutated)
     }.toList
 
     TransformedMutants(topStatement, transformedMutants)

--- a/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
+++ b/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
@@ -78,7 +78,7 @@ class MutantMatcher()(implicit config: Config) {
           if (matchExcluded(mutated))
             None
           else
-            Some(Mutant(stream.next, original, mutationToTerm(mutated)))
+            Some(Mutant(stream.next, original, mutationToTerm(mutated), mutated))
         }
       }
 

--- a/core/src/test/scala/stryker4s/Stryker4sTest.scala
+++ b/core/src/test/scala/stryker4s/Stryker4sTest.scala
@@ -44,10 +44,10 @@ class Stryker4sTest extends Stryker4sSuite with LogMatchers {
 
       result shouldBe SuccessStatus
       reportedResults should matchPattern {
-        case List(Killed(Mutant(0, _, _), `expectedPath`),
-                  Killed(Mutant(1, _, _), `expectedPath`),
-                  Killed(Mutant(2, _, _), `expectedPath`),
-                  Killed(Mutant(3, _, _), `expectedPath`)) =>
+        case List(Killed(Mutant(0, _, _, _), `expectedPath`),
+                  Killed(Mutant(1, _, _, _), `expectedPath`),
+                  Killed(Mutant(2, _, _, _), `expectedPath`),
+                  Killed(Mutant(3, _, _, _), `expectedPath`)) =>
       }
     }
 

--- a/core/src/test/scala/stryker4s/mutants/applymutants/MatchBuilderTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/applymutants/MatchBuilderTest.scala
@@ -20,7 +20,7 @@ class MatchBuilderTest extends Stryker4sSuite with TreeEquality {
       val ids = Iterator.from(0)
       val originalStatement = q"x >= 15"
       val mutants = List(q"x > 15", q"x <= 15")
-        .map((mutated: Term.ApplyInfix) => Mutant(ids.next(), originalStatement, mutated))
+        .map(Mutant(ids.next(), originalStatement, _, GreaterThan))
       val sut = new MatchBuilder(ActiveMutationContext.sysProps)
 
       // Act
@@ -174,7 +174,7 @@ class MatchBuilderTest extends Stryker4sSuite with TreeEquality {
     val topStatement = source.find(origStatement).value.topStatement()
     val mutant = mutants
       .map(m => topStatement transformOnce { case orig if orig.isEqual(origStatement) => m } get)
-      .map(m => Mutant(ids.next(), topStatement, m.asInstanceOf[Term]))
+      .map(m => Mutant(ids.next(), topStatement, m.asInstanceOf[Term], mutation))
       .toList
 
     TransformedMutants(topStatement, mutant)

--- a/core/src/test/scala/stryker4s/mutants/applymutants/StatementTransformerTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/applymutants/StatementTransformerTest.scala
@@ -65,7 +65,7 @@ class StatementTransformerTest extends Stryker4sSuite with TreeEquality {
       val originalTopTree = q"val x: Boolean = 15 >= 5"
       val originalTree = originalTopTree.find(q">=").value
       val mutants = List(EqualTo, GreaterThan, LesserThanEqualTo)
-        .map((mutated: EqualityOperator) => Mutant(0, originalTree, mutated))
+        .map(Mutant(0, originalTree, _, GreaterThanEqualTo))
 
       // Act
       val transformedMutant = sut.transformMutant(originalTree, mutants)
@@ -85,7 +85,7 @@ class StatementTransformerTest extends Stryker4sSuite with TreeEquality {
       val source = "object Foo { def bar: Boolean = 15 >= 4 }".parse[Source].get
       val origTree = source.find(q">=").value
       val mutants = List(EqualTo, GreaterThan, LesserThanEqualTo)
-        .map((mutated: EqualityOperator) => Mutant(0, origTree, mutated))
+        .map(Mutant(0, origTree, _, GreaterThanEqualTo))
 
       // Act
       val result = sut.transformSource(source, mutants)
@@ -104,11 +104,11 @@ class StatementTransformerTest extends Stryker4sSuite with TreeEquality {
 
     val firstOrigTree = source.find(q">=").value
     val firstMutants: Seq[Mutant] = List(EqualTo, GreaterThan, LesserThanEqualTo)
-      .map((mutated: EqualityOperator) => Mutant(0, firstOrigTree, mutated))
+      .map(Mutant(0, firstOrigTree, _, GreaterThanEqualTo))
 
     val secOrigTree = source.find(q"<").value
     val secondMutants: Seq[Mutant] = List(LesserThanEqualTo, GreaterThan, EqualTo)
-      .map((mutated: EqualityOperator) => Mutant(0, secOrigTree, mutated))
+      .map(Mutant(0, secOrigTree, _, GreaterThanEqualTo))
 
     val statements = firstMutants ++ secondMutants
 

--- a/core/src/test/scala/stryker4s/run/process/ProcessMutantRunnerTest.scala
+++ b/core/src/test/scala/stryker4s/run/process/ProcessMutantRunnerTest.scala
@@ -25,7 +25,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
     it("should return a Survived mutant on an exitcode 0 process") {
       val testProcessRunner = TestProcessRunner(Success(0))
       val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, fileCollectorMock)
-      val mutant = Mutant(0, q"4", q"5")
+      val mutant = Mutant(0, q"4", q"5", EmptyString)
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
       val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant), 0)
 
@@ -42,7 +42,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
     it("should return a Killed mutant on an exitcode 1 process") {
       val testProcessRunner = TestProcessRunner(Success(1))
       val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, fileCollectorMock)
-      val mutant = Mutant(0, q"4", q"5")
+      val mutant = Mutant(0, q"4", q"5", EmptyString)
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
       val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant), 0)
 
@@ -60,7 +60,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
       val exception = new TimeoutException("Test")
       val testProcessRunner = TestProcessRunner(Failure(exception))
       val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, fileCollectorMock)
-      val mutant = Mutant(0, q"4", q"5")
+      val mutant = Mutant(0, q"4", q"5", EmptyString)
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
       val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant), 0)
 
@@ -77,8 +77,8 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
     it("should return a combination of results on multiple runs") {
       val testProcessRunner = TestProcessRunner(Success(1), Success(1))
       val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, fileCollectorMock)
-      val mutant = Mutant(0, q"0", q"zero")
-      val secondMutant = Mutant(1, q"1", q"one")
+      val mutant = Mutant(0, q"0", q"zero", EmptyString)
+      val secondMutant = Mutant(1, q"1", q"one", EmptyString)
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
       val mutants = Seq(mutant, secondMutant)
       val mutatedFile = MutatedFile(file, q"def foo = 4", mutants, 0)
@@ -99,9 +99,9 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
     it("should return a mutationScore of 66.67 when 2 of 3 mutants are killed") {
       val testProcessRunner = TestProcessRunner(Success(1), Success(1), Success(0))
       val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, fileCollectorMock)
-      val mutant = Mutant(0, q"0", q"zero")
-      val secondMutant = Mutant(1, q"1", q"one")
-      val thirdMutant = Mutant(2, q"5", q"5")
+      val mutant = Mutant(0, q"0", q"zero", EmptyString)
+      val secondMutant = Mutant(1, q"1", q"one", EmptyString)
+      val thirdMutant = Mutant(2, q"5", q"5", EmptyString)
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
       val mutants = Seq(mutant, secondMutant, thirdMutant)
       val mutatedFile = MutatedFile(file, q"def foo = 4", mutants, 0)
@@ -133,7 +133,7 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
       it("Should log that test run 1 is started and finished when mutant id is 0") {
         val testProcessRunner = TestProcessRunner(Success(0))
         val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, fileCollectorMock)
-        val mutant = Mutant(0, q"4", q"5")
+        val mutant = Mutant(0, q"4", q"5", EmptyString)
         val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
         val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant), 0)
 
@@ -148,8 +148,8 @@ class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoFixture with Lo
       it("Should log multiple test runs") {
         val testProcessRunner = TestProcessRunner(Success(0), Success(0))
         val sut = new ProcessMutantRunner(Command("foo", "test"), testProcessRunner, fileCollectorMock)
-        val mutant0 = Mutant(0, q"4", q"5")
-        val mutant1 = Mutant(1, q"4", q"5")
+        val mutant0 = Mutant(0, q"4", q"5", EmptyString)
+        val mutant1 = Mutant(1, q"4", q"5", EmptyString)
         val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
         val mutatedFile = MutatedFile(file, q"def foo = 4", Seq(mutant0, mutant1), 0)
 


### PR DESCRIPTION
It seems I was a bit too enthusiastic with removing code. I removed the mutationType from `Mutant`, not realizing this would still be needed for the HTML reports (and would be nice in the console reporter)