### PR TITLE
Update to Scalameta 4.1.5

### DIFF
--- a/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
@@ -39,9 +39,7 @@ class MutatorTest extends Stryker4sSuite with TreeEquality with LogMatchers {
                        |    case Some("3") =>
                        |      s""
                        |    case _ =>
-                       |      s"${{
-                       |        bar
-                       |      }}foo"
+                       |      s"${bar}foo"
                        |  }
                        |}""".stripMargin.parse[Source].get
       result.loneElement.tree should equal(expected)

--- a/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
@@ -151,18 +151,4 @@ class MutatorTest extends Stryker4sSuite with TreeEquality with LogMatchers {
       "If this is not intended, please check your configuration and try again." should not be loggedAsInfo
     }
   }
-
-  describe("string interpolation") {
-
-    it("checks if the Scalameta workaround is still needed") {
-      // If this test fails, the bug mentioned above is fixed, and the workaround can be removed
-      val interpolated =
-        Term.Interpolate(q"s", List(Lit.String("interpolate this"), Lit.String("bar")), List(q"foo"))
-
-      // We expect that after the fix the interpolate string will look as followed.
-      // interpolated.syntax should equal("""s"interpolate this${foo}bar"""")
-
-      interpolated.syntax should equal("""s"interpolate this$foobar"""")
-    }
-  }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   object versions {
     val scala212 = "2.12.8"
 
-    val scalameta = "4.1.2"
+    val scalameta = "4.1.5"
     val pureconfig = "0.9.2"
     val scalatest = "3.0.5"
     val mockitoScala = "1.0.6"


### PR DESCRIPTION
### Fixes #148 (among others)

#### What it does

Scalameta 4.1.5 provides some fixes for syntax printing of trees for issues that we ran into.