### PR TITLE
Add vscode settings and suggested extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,14 @@ project/boot/
 project/plugins/project/
 !core/src/test/resources/fileTests/target/IgnoredFile.scala
 
+# Metals
+.bloop/
+.metals/
+
 # stryker specific
 stryker4s.conf
 
 !bin/scalafmt
+
+!.vscode/extensions.json
+!.vscode/settings.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,15 @@
+{
+	// See http://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"scalameta.metals"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+		// Both conflict with metals
+		"dragos.scala-lsp",
+		"lightbend.vscode-sbt-scala"
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": true
+}


### PR DESCRIPTION
### Related to #169 

#### What it does

Adds a format-on-save setting for VS Code. And adds a suggested extension of [Metals](https://marketplace.visualstudio.com/items?itemName=scalameta.metals), which is needed for formatting, and acts as a [LSP](https://langserver.org/) for Scala.