### PR TITLE
Write HTML report file

### DIFF
--- a/core/src/main/scala/stryker4s/files/fileIO.scala
+++ b/core/src/main/scala/stryker4s/files/fileIO.scala
@@ -1,0 +1,17 @@
+package stryker4s.files
+import better.files.{File, Resource}
+
+trait FileIO {
+  def readResource(resource: String): String
+
+  def createAndWrite(file: File, content: String): Unit
+}
+
+object DiskFileIO extends FileIO {
+
+  override def createAndWrite(file: File, content: String): Unit = {
+    file.createIfNotExists(asDirectory = false, createParents = true)
+    file.write(content)
+  }
+  override def readResource(resource: String): String = Resource.getAsString(resource)
+}

--- a/core/src/main/scala/stryker4s/report/HtmlReporter.scala
+++ b/core/src/main/scala/stryker4s/report/HtmlReporter.scala
@@ -1,21 +1,28 @@
 package stryker4s.report
 import better.files.Resource
+import grizzled.slf4j.Logging
 import stryker4s.config.Config
+import stryker4s.files.FileIO
 import stryker4s.model.MutantRunResults
 import stryker4s.report.mapper.MutantRunResultMapper
 
-class HtmlReporter(implicit config: Config) extends FinishedRunReporter with MutantRunResultMapper {
+class HtmlReporter(fileIO: FileIO)(implicit config: Config)
+    extends FinishedRunReporter
+    with MutantRunResultMapper
+    with Logging {
 
   private val reportVersion = "1.0.1"
+  private val htmlReportResource =
+    s"META-INF/resources/webjars/mutation-testing-elements/$reportVersion/dist/mutation-test-elements.js"
+  private val title = "Stryker4s report"
 
   def indexHtml(json: String): String = {
-    val mutationTestElementsScript = Resource.getAsString(
-      s"META-INF/resources/webjars/mutation-testing-elements/$reportVersion/dist/mutation-test-elements.js")
+    val mutationTestElementsScript = fileIO.readResource(htmlReportResource)
 
     s"""<!DOCTYPE html>
        |<html>
        |<body>
-       |  <mutation-test-report-app title-postfix="Stryker4s report"></mutation-test-report-app>
+       |  <mutation-test-report-app title-postfix="$title"></mutation-test-report-app>
        |  <script>
        |    document.querySelector('mutation-test-report-app').report = $json
        |  </script>
@@ -29,6 +36,10 @@ class HtmlReporter(implicit config: Config) extends FinishedRunReporter with Mut
   override def reportRunFinished(runResults: MutantRunResults): Unit = {
     val mapped = toReport(runResults).toJson
 
-    println(mapped)
+    val targetLocation = config.baseDir / s"target/stryker4s-report-${System.currentTimeMillis()}" / "index.html"
+    val reportContent = indexHtml(mapped)
+    fileIO.createAndWrite(targetLocation, reportContent)
+
+    debug(s"Written HTML report to $targetLocation")
   }
 }

--- a/core/src/main/scala/stryker4s/report/Reporter.scala
+++ b/core/src/main/scala/stryker4s/report/Reporter.scala
@@ -1,6 +1,7 @@
 package stryker4s.report
 
 import stryker4s.config.{Config, ConsoleReporterType, HtmlReporterType}
+import stryker4s.files.DiskFileIO
 import stryker4s.model.{Mutant, MutantRunResult, MutantRunResults}
 
 class Reporter(implicit config: Config) extends FinishedRunReporter with ProgressReporter {
@@ -8,7 +9,7 @@ class Reporter(implicit config: Config) extends FinishedRunReporter with Progres
   def reporters: Seq[MutationRunReporter] = {
     config.reporters collect {
       case ConsoleReporterType => new ConsoleReporter()
-      case HtmlReporterType    => new HtmlReporter()
+      case HtmlReporterType    => new HtmlReporter(DiskFileIO)
     }
   }
 

--- a/core/src/test/scala/stryker4s/report/HtmlReporterTest.scala
+++ b/core/src/test/scala/stryker4s/report/HtmlReporterTest.scala
@@ -1,0 +1,61 @@
+package stryker4s.report
+import better.files.File
+import org.mockito.captor.ArgCaptor
+import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
+import stryker4s.config.Config
+import stryker4s.files.FileIO
+import stryker4s.model.MutantRunResults
+import stryker4s.testutil.Stryker4sSuite
+
+import scala.concurrent.duration._
+
+class HtmlReporterTest extends Stryker4sSuite with MockitoSugar with ArgumentMatchersSugar {
+
+  describe("indexHtml") {
+    it("should contain title") {
+      implicit val config: Config = Config()
+      val mockFileIO = mock[FileIO]
+      val resourceLocation = "META-INF/resources/webjars/mutation-testing-elements/1.0.1/dist/mutation-test-elements.js"
+      when(mockFileIO.readResource(resourceLocation)) thenReturn "console.log('hello');"
+      val sut = new HtmlReporter(mockFileIO)
+
+      val result = sut.indexHtml("""{ 'foo': 'bar' }""")
+
+      val expected = s"""<!DOCTYPE html>
+                        |<html>
+                        |<body>
+                        |  <mutation-test-report-app title-postfix="Stryker4s report"></mutation-test-report-app>
+                        |  <script>
+                        |    document.querySelector('mutation-test-report-app').report = { 'foo': 'bar' }
+                        |  </script>
+                        |  <script>
+                        |    console.log('hello');
+                        |  </script>
+                        |</body>
+                        |</html>""".stripMargin
+      result should equal(expected)
+    }
+  }
+
+  describe("reportRunFinished") {
+    it("should write a file to the report directory") {
+      implicit val config: Config = Config()
+      val mockFileIO = mock[FileIO]
+      val sut = new HtmlReporter(mockFileIO)
+      val runResults = MutantRunResults(Nil, 50.0, 30.seconds)
+
+      sut.reportRunFinished(runResults)
+
+      val fileCaptor = ArgCaptor[File]
+      val expectedStart =
+        """<!DOCTYPE html>
+          |<html>
+          |<body>
+          |  <mutation-test-report-app title-postfix="Stryker4s report"></mutation-test-report-app>
+          |  <script>
+          |    document.querySelector('mutation-test-report-app').report = """.stripMargin
+      verify(mockFileIO).createAndWrite(fileCaptor, any[String])
+      fileCaptor.value.pathAsString should fullyMatch regex ".*target(/|\\\\)stryker4s-report-(\\d*)(/|\\\\)index.html$"
+    }
+  }
+}


### PR DESCRIPTION
#### What it does

Writes the html report to file when the HTMLReporter is called. Also added tests.

When this PR is merged, I'd just like to update some documentation and then I think the `feat-html-reporter` branch can be merged to master.

#### How it works

I've also added a `FileIO` trait that abstracts file IO away (duh) for testing purposes. Idea is to later move other file IO (like in the `MutantRunner`) to this trait as well, but that felt a bit out of scope for this PR.