### PR TITLE
Fix release process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ jobs:
       env:
         - CI_RELEASE=stryker4sPublishSigned
         - CI_SNAPSHOT_RELEASE=stryker4sPublish
+        - CI_SONATYPE_RELEASE=sonatypeReleaseAll
 
 script: sbt clean coverage test coverageReport
 

--- a/project/Release.scala
+++ b/project/Release.scala
@@ -13,28 +13,23 @@ object Release {
   private val publishM2 = "stryker4s-core/publishM2"
   private val crossPublish = "+publish"
   private val crossPublishSigned = "+publishSigned"
-  private def setVersion(version: String) = s"""set version in ThisBuild := "$version""""
 
-  lazy val releaseCommands: Setting[Seq[Command]] = commands ++= {
-    val originalVersion = version.value
-    Seq(
-      // Called by sbt-ci-release
-      Command.command(stryker4sPublish)(publishM2 :: stryker4sMvnDeploy :: crossPublish :: _),
-      Command.command(stryker4sPublishSigned)(publishM2 :: stryker4sMvnDeploy :: crossPublishSigned :: _),
-      // Called by stryker4sPublish(signed)
-      // Set version again after deploy (causes local changes, which changes the version)
-      Command.command(stryker4sMvnDeploy)(
-        mvnDeploy(baseDirectory.value, version.value) andThen (setVersion(originalVersion) :: _)
-      )
-    )
-  }
+  lazy val releaseCommands: Setting[Seq[Command]] = commands ++= Seq(
+    // Called by sbt-ci-release
+    Command.command(stryker4sPublish)(publishM2 :: stryker4sMvnDeploy :: crossPublish :: _),
+    Command.command(stryker4sPublishSigned)(publishM2 :: stryker4sMvnDeploy :: crossPublishSigned :: _),
+    // Called by stryker4sPublish(signed)
+    Command.command(stryker4sMvnDeploy)(mvnDeploy(baseDirectory.value, version.value))
+  )
 
   /** Sets version of mvn project, calls `mvn deploy` and fails state if the command fails
     */
   private def mvnDeploy(baseDir: File, version: String): State => State =
     state =>
       mvnGoal(s"versions:set -DnewVersion=$version", baseDir) #&&
-        mvnGoal(s"deploy --settings settings.xml -DskipTests", baseDir) ! match {
+        mvnGoal(s"deploy --settings settings.xml -DskipTests", baseDir) #&&
+        // Reset version setting after deployment
+        mvnGoal("versions:revert", baseDir) ! match {
         case 0 => state
         case _ => state.fail
     }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,4 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
 
 // Deployment plugins
-addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.2.2")
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.2.6")

--- a/runners/maven/pom.xml
+++ b/runners/maven/pom.xml
@@ -205,6 +205,8 @@
                                 <configuration>
                                     <keyname>strykermutator</keyname>
                                     <passphrase>${env.PGP_PASSPHRASE}</passphrase>
+                                    <skipStagingRepositoryClose>true</skipStagingRepositoryClose>
+                                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
                                 </configuration>
                             </execution>
                         </executions>
@@ -217,7 +219,6 @@
                         <configuration>
                             <serverId>ossrh</serverId>
                             <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/runners/maven/pom.xml
+++ b/runners/maven/pom.xml
@@ -205,8 +205,6 @@
                                 <configuration>
                                     <keyname>strykermutator</keyname>
                                     <passphrase>${env.PGP_PASSPHRASE}</passphrase>
-                                    <skipStagingRepositoryClose>true</skipStagingRepositoryClose>
-                                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
                                 </configuration>
                             </execution>
                         </executions>
@@ -219,6 +217,8 @@
                         <configuration>
                             <serverId>ossrh</serverId>
                             <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <skipStagingRepositoryClose>true</skipStagingRepositoryClose>
+                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
### Fixes #186 

#### What it does

Fixes the release build being broken, by it trying to upload a release version to the snapshot repository.

#### How it works

The issue in #186 was that after the maven plugin is deployed, there would be local git changes (pom.xml version was changed). The sbt-sonatype plugin would then think the release was a snapshot, and try to publish that. Versions without `-SNAPSHOT` appended cannot be uploaded to the snapshot repository, so the build would break. 

The mvn goal `versions:revert` is now called after a deploy, reverting any local git changes done, fixing the 

I've also changed the release process to first upload all projects (including the maven plugin) to staging, and then release those when all are completed. This way releasing should be more atomic.