### PR TITLE
Remove dependency to scalameta contrib

### DIFF
--- a/core/src/main/scala/stryker4s/extension/mutationtype/MutationTypes.scala
+++ b/core/src/main/scala/stryker4s/extension/mutationtype/MutationTypes.scala
@@ -1,6 +1,7 @@
 package stryker4s.extension.mutationtype
 
-import scala.meta.contrib._
+import stryker4s.extension.TreeExtensions.IsEqualExtension
+
 import scala.meta.{Lit, Term, Tree}
 
 /**

--- a/core/src/main/scala/stryker4s/extension/mutationtype/StringLiteral.scala
+++ b/core/src/main/scala/stryker4s/extension/mutationtype/StringLiteral.scala
@@ -30,7 +30,7 @@ case object NonEmptyString {
 /** Not a mutation, just an extractor for pattern matching on interpolated strings
   */
 case object StringInterpolation {
-  import scala.meta.contrib.implicits.Equality._
+  import stryker4s.extension.TreeExtensions.IsEqualExtension
 
   def unapply(arg: Term.Interpolate): Option[Term.Interpolate] =
     Some(arg).filter(_.prefix.isEqual(Term.Name("s")))

--- a/core/src/main/scala/stryker4s/mutants/applymutants/MatchBuilder.scala
+++ b/core/src/main/scala/stryker4s/mutants/applymutants/MatchBuilder.scala
@@ -1,13 +1,12 @@
 package stryker4s.mutants.applymutants
 
 import grizzled.slf4j.Logging
-import stryker4s.extension.TreeExtensions.TransformOnceExtension
+import stryker4s.extension.TreeExtensions.{IsEqualExtension, TransformOnceExtension}
 import stryker4s.extension.exception.UnableToBuildPatternMatchException
 import stryker4s.model.{Mutant, SourceTransformations, TransformedMutants}
 import stryker4s.mutants.applymutants.ActiveMutationContext.ActiveMutationContext
 
 import scala.meta._
-import scala.meta.contrib.implicits.Equality.XtensionTreeEquality
 import scala.util.{Failure, Success}
 
 class MatchBuilder(mutationContext: ActiveMutationContext) extends Logging {

--- a/core/src/main/scala/stryker4s/mutants/applymutants/StatementTransformer.scala
+++ b/core/src/main/scala/stryker4s/mutants/applymutants/StatementTransformer.scala
@@ -3,8 +3,7 @@ package stryker4s.mutants.applymutants
 import stryker4s.extension.TreeExtensions._
 import stryker4s.model._
 
-import scala.meta.contrib._
-import scala.meta.{Source, Term, Tree}
+import scala.meta.{Source, Term}
 
 class StatementTransformer {
 
@@ -37,7 +36,7 @@ class StatementTransformer {
   def transformStatement(topStatement: Term, toMutate: Term, mutation: Term): Term =
     topStatement
       .transform {
-        case foundTree: Tree if foundTree.isEqual(toMutate) && foundTree.pos == toMutate.pos =>
+        case foundTree: Term if foundTree.isEqual(toMutate) && foundTree.pos == toMutate.pos =>
           mutation
       }
       .asInstanceOf[Term]

--- a/core/src/test/scala/stryker4s/mutants/applymutants/MatchBuilderTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/applymutants/MatchBuilderTest.scala
@@ -9,7 +9,6 @@ import stryker4s.testutil.Stryker4sSuite
 
 import scala.language.postfixOps
 import scala.meta._
-import scala.meta.contrib._
 
 class MatchBuilderTest extends Stryker4sSuite with TreeEquality with LogMatchers {
   private val activeMutationString = Lit.String("ACTIVE_MUTATION")
@@ -50,7 +49,7 @@ class MatchBuilderTest extends Stryker4sSuite with TreeEquality with LogMatchers
       }
 
       // Act
-      val expectedException = the[UnableToBuildPatternMatchException] thrownBy sut.buildNewSource(transformedStatements)
+      an[UnableToBuildPatternMatchException] shouldBe thrownBy(sut.buildNewSource(transformedStatements))
 
       // Assert
       "Failed to construct pattern match: original statement [true]" shouldBe loggedAsError

--- a/core/src/test/scala/stryker4s/mutants/findmutants/MutantMatcherTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/MutantMatcherTest.scala
@@ -2,13 +2,13 @@ package stryker4s.mutants.findmutants
 
 import stryker4s.config.Config
 import stryker4s.extension.ImplicitMutationConversion.mutationToTree
+import stryker4s.extension.TreeExtensions.IsEqualExtension
 import stryker4s.extension.mutationtype._
 import stryker4s.model.Mutant
 import stryker4s.scalatest.TreeEquality
 import stryker4s.testutil.Stryker4sSuite
 
 import scala.meta._
-import scala.meta.contrib._
 
 class MutantMatcherTest extends Stryker4sSuite with TreeEquality {
 

--- a/core/src/test/scala/stryker4s/scalatest/TreeEquality.scala
+++ b/core/src/test/scala/stryker4s/scalatest/TreeEquality.scala
@@ -1,9 +1,9 @@
 package stryker4s.scalatest
 
 import org.scalactic.Equality
+import stryker4s.extension.TreeExtensions.IsEqualExtension
 
 import scala.meta.Tree
-import scala.meta.contrib.XtensionTreeEquality
 
 /** Provides equality checking for ScalaTest on the structure of Trees.
   * Checks if two trees have the same structure and syntax
@@ -13,10 +13,10 @@ import scala.meta.contrib.XtensionTreeEquality
   */
 trait TreeEquality {
   // Needs to be T <: Tree to work with subtypes of Tree instead of just Tree
-  implicit def structureEquality[T <: Tree]: Equality[T] = new Equality[T] {
-    override def areEqual(first: T, secondAny: Any): Boolean = secondAny match {
-      case second: Tree => second.isEqual(first)
-      case _            => false
+  implicit def structureEquality[T <: Tree]: Equality[T] =
+    (first: T, secondAny: Any) =>
+      secondAny match {
+        case second: Tree => second.isEqual(first)
+        case _            => false
     }
-  }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   object versions {
     val scala212 = "2.12.8"
 
-    val scalameta = "4.1.5"
+    val scalameta = "4.1.6"
     val pureconfig = "0.10.2"
     val scalatest = "3.0.7"
     val mockitoScala = "1.3.1"
@@ -27,7 +27,6 @@ object Dependencies {
 
   val pureconfig = "com.github.pureconfig" %% "pureconfig" % versions.pureconfig
   val scalameta = "org.scalameta" %% "scalameta" % versions.scalameta
-  val scalametaContrib = "org.scalameta" %% "contrib" % versions.scalameta
   val betterFiles = "com.github.pathikrit" %% "better-files" % versions.betterFiles
   val log4jApi = "org.apache.logging.log4j" % "log4j-api" % versions.log4j
   val log4jCore = "org.apache.logging.log4j" % "log4j-core" % versions.log4j

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -34,7 +34,6 @@ object Settings {
       Dependencies.test.mutationTestingSchema,
       Dependencies.pureconfig,
       Dependencies.scalameta,
-      Dependencies.scalametaContrib,
       Dependencies.betterFiles,
       Dependencies.log4jApi,
       Dependencies.log4jCore,


### PR DESCRIPTION
The `org.scalameta:contrib` library was only used for two methods. This PR removes the extra dependency