### PR TITLE
Only delete stryker4s dependencies from cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,8 @@ before_cache:
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
   - find $HOME/.sbt        -name "*.lock"               -print -delete
   # Don't cache built dependencies
-  - rm -rf $HOME/.ivy2/cache/io.stryker-mutator
-  - rm -rf $HOME/.m2/repository/io/stryker-mutator
+  - rm -rf $HOME/.ivy2/cache/io.stryker-mutator/*stryker4s*
+  - rm -rf $HOME/.m2/repository/io/stryker-mutator/*stryker4s*
 
 cache:
   # These directories are cached to S3 at the end of the build


### PR DESCRIPTION
Prevents `mutation-testing-elements` from being re-downloaded each time