### PR TITLE
Add a Json reporter

### DIFF
--- a/core/src/main/scala/stryker4s/config/ReporterType.scala
+++ b/core/src/main/scala/stryker4s/config/ReporterType.scala
@@ -11,3 +11,7 @@ case object ConsoleReporterType extends ReporterType {
 case object HtmlReporterType extends ReporterType {
   override val name: String = "html"
 }
+
+case object JsonReporterType extends ReporterType {
+  override val name: String = "json"
+}

--- a/core/src/main/scala/stryker4s/model/MutantRunResult.scala
+++ b/core/src/main/scala/stryker4s/model/MutantRunResult.scala
@@ -4,7 +4,9 @@ import java.nio.file.Path
 
 import scala.concurrent.duration.Duration
 
-case class MutantRunResults(results: Iterable[MutantRunResult], mutationScore: Double, duration: Duration)
+case class MutantRunResults(results: Iterable[MutantRunResult], mutationScore: Double, duration: Duration) {
+  @transient val timestamp: Long = System.currentTimeMillis()
+}
 
 /** The base result type of a mutant run.
   * Extends Product with Serializable to clean up the type signature, as all subtypes are case classes

--- a/core/src/main/scala/stryker4s/report/HtmlReporter.scala
+++ b/core/src/main/scala/stryker4s/report/HtmlReporter.scala
@@ -48,7 +48,7 @@ class HtmlReporter(fileIO: FileIO)(implicit config: Config)
   }
 
   override def reportRunFinished(runResults: MutantRunResults): Unit = {
-    val targetLocation = config.baseDir / s"target/stryker4s-report-${System.currentTimeMillis()}"
+    val targetLocation = config.baseDir / s"target/stryker4s-report-${runResults.timestamp}"
 
     val mutationTestElementsLocation = targetLocation / mutationTestElementsName
     val indexLocation = targetLocation / "index.html"

--- a/core/src/main/scala/stryker4s/report/JsonReporter.scala
+++ b/core/src/main/scala/stryker4s/report/JsonReporter.scala
@@ -1,0 +1,33 @@
+package stryker4s.report
+
+import better.files.File
+import grizzled.slf4j.Logging
+import stryker4s.config.Config
+import stryker4s.files.FileIO
+import stryker4s.model.MutantRunResults
+import stryker4s.report.mapper.MutantRunResultMapper
+import stryker4s.report.model.MutationTestReport
+
+class JsonReporter(fileIO: FileIO)(implicit config: Config)
+    extends FinishedRunReporter
+    with MutantRunResultMapper
+    with Logging {
+
+  def buildScoreResult(report: MutantRunResults): MutationTestReport = {
+    toReport(report)
+  }
+
+  def writeReportJsonTo(file: File, report: MutantRunResults): Unit = {
+    val content = buildScoreResult(report)
+    fileIO.createAndWrite(file, content.toJson)
+  }
+
+  override def reportRunFinished(runResults: MutantRunResults): Unit = {
+    val targetLocation = config.baseDir / s"target/stryker4s-report-${runResults.timestamp}"
+    val resultLocation = targetLocation / "report.json"
+
+    writeReportJsonTo(resultLocation, runResults)
+
+    info(s"Written JSON report to $resultLocation")
+  }
+}

--- a/core/src/main/scala/stryker4s/report/Reporter.scala
+++ b/core/src/main/scala/stryker4s/report/Reporter.scala
@@ -1,7 +1,7 @@
 package stryker4s.report
 
 import grizzled.slf4j.Logging
-import stryker4s.config.{Config, ConsoleReporterType, HtmlReporterType}
+import stryker4s.config.{Config, ConsoleReporterType, HtmlReporterType, JsonReporterType}
 import stryker4s.files.DiskFileIO
 import stryker4s.model.{Mutant, MutantRunResult, MutantRunResults}
 
@@ -13,6 +13,7 @@ class Reporter(implicit config: Config) extends FinishedRunReporter with Progres
     config.reporters collect {
       case ConsoleReporterType => new ConsoleReporter()
       case HtmlReporterType    => new HtmlReporter(DiskFileIO)
+      case JsonReporterType    => new JsonReporter(DiskFileIO)
     }
   }
 

--- a/core/src/test/scala/stryker4s/report/JsonReporterTest.scala
+++ b/core/src/test/scala/stryker4s/report/JsonReporterTest.scala
@@ -1,0 +1,69 @@
+package stryker4s.report
+
+import better.files.File
+import org.mockito.captor.ArgCaptor
+import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
+import stryker4s.config.Config
+import stryker4s.files.FileIO
+import stryker4s.model.MutantRunResults
+import stryker4s.scalatest.LogMatchers
+import stryker4s.testutil.Stryker4sSuite
+
+import scala.concurrent.duration._
+
+class JsonReporterTest extends Stryker4sSuite with MockitoSugar with ArgumentMatchersSugar with LogMatchers {
+
+  describe("reportJson") {
+    it("should contain the report") {
+      implicit val config: Config = Config()
+      val mockFileIO = mock[FileIO]
+      val sut = new JsonReporter(mockFileIO)
+      val testFile = config.baseDir / "foo.bar"
+      val mutationScore = 22.0
+      val durationMinutes = 10
+      val runResults = MutantRunResults(
+        results = Seq(),
+        mutationScore = mutationScore,
+        duration = durationMinutes.minutes
+      )
+
+      sut.writeReportJsonTo(testFile, runResults)
+
+      val expectedJs =
+        s"""{"schemaVersion":"1","thresholds":{"high":80,"low":60},"files":{}}"""
+      verify(mockFileIO).createAndWrite(testFile, expectedJs)
+    }
+  }
+
+  describe("reportRunFinished") {
+    implicit val config: Config = Config()
+    val stryker4sReportFolderRegex = ".*target(/|\\\\)stryker4s-report-(\\d*)(/|\\\\)[a-z-]*\\.[a-z]*$"
+
+    it("should write the report file to the report directory") {
+      val mockFileIO = mock[FileIO]
+      val sut = new JsonReporter(mockFileIO)
+      val runResults = MutantRunResults(Nil, 50.0, 30.seconds)
+
+      sut.reportRunFinished(runResults)
+
+      val writtenFilesCaptor = ArgCaptor[File]
+
+      verify(mockFileIO, times(1)).createAndWrite(writtenFilesCaptor, any[String])
+
+      val paths = writtenFilesCaptor.values.map(_.pathAsString)
+      all(paths) should fullyMatch regex stryker4sReportFolderRegex
+
+      writtenFilesCaptor.values.map(_.name) should contain only "report.json"
+    }
+
+    it("should info log a message") {
+      val mockFileIO = mock[FileIO]
+      val sut = new JsonReporter(mockFileIO)
+      val runResults = MutantRunResults(Nil, 50.0, 30.seconds)
+
+      sut.reportRunFinished(runResults)
+
+      "Written JSON report to " shouldBe loggedAsInfo
+    }
+  }
+}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -8,9 +8,18 @@ stryker4s {
 }
 ```
 
-- [General config](#general-config)
-- [Process runner config](#process-runner-config)
-- [Other configuration options](#other-configuration-options)
+- [Configuration](#configuration)
+  - [General config](#general-config)
+      - [mutate](#mutate)
+      - [files](#files)
+      - [base-dir](#base-dir)
+      - [reporters](#reporters)
+      - [excluded-mutations](#excluded-mutations)
+      - [thresholds](#thresholds)
+  - [Process runner config](#process-runner-config)
+      - [test-runner](#test-runner)
+  - [Other configuration options](#other-configuration-options)
+      - [log-level](#log-level)
 
 ## General config
 
@@ -47,7 +56,7 @@ With `base-dir` you specify the directory from which stryker4s starts and search
 
 #### reporters
 
-**Config file:** `reporters: ["console", "html"]`  
+**Config file:** `reporters: ["console", "html", "json"]`  
 **Default value:** The `console` and `html` reporters  
 **Mandatory:** No  
 **Description:**  
@@ -55,6 +64,7 @@ With `reporters` you can specify reporters for stryker4s to use. The following r
 
 - `console` will output progress and the final result to the console.
 - `html` outputs a nice HTML report to `target/stryker4s-report-$timestamp/index.html`. See the [mutation-testing-elements repo](https://github.com/stryker-mutator/mutation-testing-elements/tree/master/packages/mutation-testing-elements#mutation-testing-elements) for more information.
+- `json` writes a json of the mutation result to the same folder as the HTML reporter. The JSON is in the [mutation-testing-report-schema](https://github.com/stryker-mutator/mutation-testing-elements/tree/master/packages/mutation-testing-report-schema) format.
 
 #### excluded-mutations
 


### PR DESCRIPTION
https://github.com/stryker-mutator/stryker4s/issues/208

#### What it does

It add a json output to be parse by bash to send curl to dashboard 

#### How it works

Just add `json` as reporter and a file will be created at 
```
config.baseDir / s"target/stryker4s-result-${System.currentTimeMillis()}" / "result.json"
```

The file will contains `mutationScore` and `durationSeconds`.

