### PR TITLE
Make sure files in root of Scala source directory get mutated

### DIFF
--- a/core/src/main/scala/stryker4s/config/Config.scala
+++ b/core/src/main/scala/stryker4s/config/Config.scala
@@ -4,7 +4,7 @@ import better.files._
 import pureconfig.ConfigWriter
 import pureconfig.generic.auto._
 
-case class Config(mutate: Seq[String] = Seq("**/main/scala/**/*.scala"),
+case class Config(mutate: Seq[String] = Seq("**/main/scala/**.scala"),
                   baseDir: File = File.currentWorkingDirectory,
                   reporters: Seq[ReporterType] = Seq(ConsoleReporterType, HtmlReporterType),
                   files: Option[Seq[String]] = None,

--- a/core/src/test/resources/fileTests/filledDir/src/main/scala/fileInRootSourceDir.scala
+++ b/core/src/test/resources/fileTests/filledDir/src/main/scala/fileInRootSourceDir.scala
@@ -1,0 +1,1 @@
+object Foo {}

--- a/core/src/test/scala/stryker4s/config/ConfigReaderTest.scala
+++ b/core/src/test/scala/stryker4s/config/ConfigReaderTest.scala
@@ -38,7 +38,7 @@ class ConfigReaderTest extends Stryker4sSuite with LogMatchers with ConfigReader
       val result = ConfigReader.readConfig(confPath)
 
       result.baseDir shouldBe File.currentWorkingDirectory
-      result.mutate shouldBe Seq("**/main/scala/**/*.scala")
+      result.mutate shouldBe Seq("**/main/scala/**.scala")
       result.reporters should contain inOrderOnly (ConsoleReporterType, HtmlReporterType)
     }
 

--- a/core/src/test/scala/stryker4s/config/ConfigTest.scala
+++ b/core/src/test/scala/stryker4s/config/ConfigTest.scala
@@ -14,7 +14,7 @@ class ConfigTest extends Stryker4sSuite {
         s"""base-dir="${File.currentWorkingDirectory.pathAsString.replace("\\", "\\\\")}"
            |excluded-mutations=[]
            |mutate=[
-           |    "**/main/scala/**/*.scala"
+           |    "**/main/scala/**.scala"
            |]
            |reporters=[
            |    console,


### PR DESCRIPTION
### Fixes #218 

#### What it does

Fixes the collection of files to be mutated so that files located in the root Scala source directory are taken into account as well, not just those in sub directories.

#### How it works

Changes the glob pattern for collection files to be mutated so that files in the root Scala source directory are matching as well.
