### PR TITLE
Feature/add typed eq mutant

### DIFF
--- a/core/src/main/scala/stryker4s/extension/mutationtype/EqualityOperator.scala
+++ b/core/src/main/scala/stryker4s/extension/mutationtype/EqualityOperator.scala
@@ -25,3 +25,11 @@ case object EqualTo extends EqualityOperator {
 case object NotEqualTo extends EqualityOperator {
   override val tree: Term.Name = Term.Name("!=")
 }
+
+case object TypedEqualTo extends EqualityOperator {
+  override val tree: Term.Name = Term.Name("===")
+}
+
+case object TypedNotEqualTo extends EqualityOperator {
+  override val tree: Term.Name = Term.Name("=!=")
+}

--- a/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
+++ b/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
@@ -31,6 +31,8 @@ class MutantMatcher()(implicit config: Config) {
     case LesserThan(orig)         => orig ~~> (LesserThanEqualTo, GreaterThan, EqualTo)
     case EqualTo(orig)            => orig ~~> NotEqualTo
     case NotEqualTo(orig)         => orig ~~> EqualTo
+    case TypedEqualTo(orig)       => orig ~~> TypedNotEqualTo
+    case TypedNotEqualTo(orig)    => orig ~~> TypedEqualTo
   }
 
   def matchLogicalOperator: PartialFunction[Tree, Seq[Option[Mutant]]] = {

--- a/core/src/test/scala/stryker4s/mutants/findmutants/MutantMatcherTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/MutantMatcherTest.scala
@@ -167,6 +167,24 @@ class MutantMatcherTest extends Stryker4sSuite with TreeEquality {
         EqualTo
       )
     }
+
+    it("should match === to =!=") {
+      expectMutations(
+        sut.matchEqualityOperator,
+        q"def foo = 18 === 20",
+        TypedEqualTo,
+        TypedNotEqualTo
+      )
+    }
+
+    it("should match =!= to ===") {
+      expectMutations(
+        sut.matchEqualityOperator,
+        q"def foo = 18 =!= 20",
+        TypedNotEqualTo,
+        TypedEqualTo
+      )
+    }
   }
   describe("matchLogicalOperator matcher") {
     it("should match && to ||") {


### PR DESCRIPTION
### Relates to #33 

#### What it does
I'm using the typed equality (===) and non-equality (=!=) operators in my project and it seems that they start to become quite well spread (cats and scalaz among others).

#### How it works
Just added `=== -> =!=` and `=!= -> ===`
