### PR TITLE
Fix possible conflict with generated code in user's variable names

### DIFF
--- a/core/src/main/scala/stryker4s/mutants/applymutants/MatchBuilder.scala
+++ b/core/src/main/scala/stryker4s/mutants/applymutants/MatchBuilder.scala
@@ -41,7 +41,7 @@ class MatchBuilder(mutationContext: ActiveMutationContext) extends Logging {
       transformedMutant.originalStatement)
 
     val activeMutationEnv = Lit.String("ACTIVE_MUTATION")
-    q"(sys.$mutationContext.get($activeMutationEnv) match { ..case $cases })"
+    q"(_root_.scala.sys.$mutationContext.get($activeMutationEnv) match { ..case $cases })"
   }
 
   private def mutantToCase(mutant: Mutant): Case =

--- a/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
@@ -25,7 +25,7 @@ class MutatorTest extends Stryker4sSuite with TreeEquality with LogMatchers {
       val result = sut.mutate(files)
 
       val expected = """object Foo {
-                       |  def bar = sys.props.get("ACTIVE_MUTATION") match {
+                       |  def bar = _root_.scala.sys.props.get("ACTIVE_MUTATION") match {
                        |    case Some("0") =>
                        |      15 >= 14
                        |    case Some("1") =>
@@ -35,7 +35,7 @@ class MutatorTest extends Stryker4sSuite with TreeEquality with LogMatchers {
                        |    case _ =>
                        |      15 > 14
                        |  }
-                       |  def foobar = sys.props.get("ACTIVE_MUTATION") match {
+                       |  def foobar = _root_.scala.sys.props.get("ACTIVE_MUTATION") match {
                        |    case Some("3") =>
                        |      s""
                        |    case _ =>

--- a/core/src/test/scala/stryker4s/mutants/applymutants/MatchBuilderTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/applymutants/MatchBuilderTest.scala
@@ -12,7 +12,7 @@ import scala.meta._
 
 class MatchBuilderTest extends Stryker4sSuite with TreeEquality with LogMatchers {
   private val activeMutationString = Lit.String("ACTIVE_MUTATION")
-  private val activeMutationPropsExpr: Term.Apply = q"sys.props.get($activeMutationString)"
+  private val activeMutationPropsExpr: Term.Apply = q"_root_.scala.sys.props.get($activeMutationString)"
 
   describe("buildMatch") {
     it("should transform 2 mutations into match statement with 2 mutated and 1 original") {
@@ -77,7 +77,7 @@ class MatchBuilderTest extends Stryker4sSuite with TreeEquality with LogMatchers
       // Assert
       val expected =
         """class Foo {
-          |  def bar: Boolean = sys.props.get("ACTIVE_MUTATION") match {
+          |  def bar: Boolean = _root_.scala.sys.props.get("ACTIVE_MUTATION") match {
           |    case Some("0") =>
           |      15 < 14
           |    case Some("1") =>
@@ -107,7 +107,7 @@ class MatchBuilderTest extends Stryker4sSuite with TreeEquality with LogMatchers
       // Assert
       val expected =
         """class Foo {
-          |  def bar: Boolean = sys.props.get("ACTIVE_MUTATION") match {
+          |  def bar: Boolean = _root_.scala.sys.props.get("ACTIVE_MUTATION") match {
           |    case Some("0") =>
           |      15 < 14 && 14 >= 13
           |    case Some("1") =>
@@ -147,20 +147,20 @@ class MatchBuilderTest extends Stryker4sSuite with TreeEquality with LogMatchers
       // Assert
       val expected =
         """class Foo {
-          |  def foo = sys.props.get("ACTIVE_MUTATION") match {
+          |  def foo = _root_.scala.sys.props.get("ACTIVE_MUTATION") match {
           |    case Some("0") =>
-          |      (sys.props.get("ACTIVE_MUTATION") match {
+          |      (_root_.scala.sys.props.get("ACTIVE_MUTATION") match {
           |        case Some("1") => ""
           |        case _ => "foo"
-          |      }) != (sys.props.get("ACTIVE_MUTATION") match {
+          |      }) != (_root_.scala.sys.props.get("ACTIVE_MUTATION") match {
           |        case Some("2") => "Stryker was here!"
           |        case _ => ""
           |      })
           |    case _ =>
-          |      (sys.props.get("ACTIVE_MUTATION") match {
+          |      (_root_.scala.sys.props.get("ACTIVE_MUTATION") match {
           |        case Some("1") => ""
           |        case _ => "foo"
-          |      }) == (sys.props.get("ACTIVE_MUTATION") match {
+          |      }) == (_root_.scala.sys.props.get("ACTIVE_MUTATION") match {
           |        case Some("2") => "Stryker was here!"
           |        case _ => ""
           |      })
@@ -179,7 +179,7 @@ class MatchBuilderTest extends Stryker4sSuite with TreeEquality with LogMatchers
 
       val result = sut.buildMatch(transformed)
 
-      result.expr should equal(q"sys.props.get($activeMutationString)")
+      result.expr should equal(q"_root_.scala.sys.props.get($activeMutationString)")
     }
 
     it("should build a pattern match with sys.env if envVar is given") {
@@ -190,7 +190,7 @@ class MatchBuilderTest extends Stryker4sSuite with TreeEquality with LogMatchers
 
       val result = sut.buildMatch(transformed)
 
-      result.expr should equal(q"sys.env.get($activeMutationString)")
+      result.expr should equal(q"_root_.scala.sys.env.get($activeMutationString)")
     }
   }
 


### PR DESCRIPTION
### Fixes #238 

#### What it does

Fixes the scenario where a user has the variable `sys` would conflict with generated code and cause a compile error.

#### How it works

Thansk to @dwestheide's suggestion! Generated code now uses `_root_.scala.sys.env.get(...)` instead of `sys.env.get(...)`