### PR TITLE
Fix sbt scripted tests not running in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         java-version: openjdk@1.11
     - name: Run tests
-      run: csbt publishLocal scripted
+      run: csbt 'publishLocal; scripted sbt-stryker4s/test-1'
   maven-plugin:
     name: Test Maven plugin
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,8 @@ jobs:
       with:
         java-version: openjdk@1.11
     - name: Run tests
-      run: csbt 'publishLocal; scripted sbt-stryker4s/test-1'
+      # Only publish stryker4s-core, sbt-stryker4s is published by scripted tests
+      run: csbt 'stryker4s-core/publishLocal; scripted sbt-stryker4s/test-1'
   maven-plugin:
     name: Test Maven plugin
     runs-on: ubuntu-latest

--- a/runners/sbt/src/sbt-test/sbt-stryker4s/test-1/src/test/scala/example/ExampleTest.scala
+++ b/runners/sbt/src/sbt-test/sbt-stryker4s/test-1/src/test/scala/example/ExampleTest.scala
@@ -4,7 +4,9 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.funspec.AnyFunSpec
 
 class ExampleTest extends AnyFunSpec with Matchers {
-  "Person" should "be able to drink with age 18" in {
-    Example.canDrink(18) should be(true)
+  describe("Person") {
+    it("be able to drink with age 18") {
+      Example.canDrink(18) should be(true)
+    }
   }
 }

--- a/runners/sbt/src/sbt-test/sbt-stryker4s/test-1/stryker4s.conf
+++ b/runners/sbt/src/sbt-test/sbt-stryker4s/test-1/stryker4s.conf
@@ -1,4 +1,5 @@
 stryker4s {
+  files: [ "*", "!global" ]
   reporters: ["console", "html"]
   thresholds: {
     # Should be 66,66%. Break if lower than that


### PR DESCRIPTION
### Fixes #303 

#### What it does

Fixes the sbt scripted tests to run on ci again

#### How it works

Apparently the coursier-based launcher is a bit more finnicky with how scripted tests should be run. So the command is now changed to something more specific.