### PR TITLE
Add GitHub actions dashboard CI provider

### DIFF
--- a/core/src/test/scala/stryker4s/report/dashboard/DashboardConfigProviderTest.scala
+++ b/core/src/test/scala/stryker4s/report/dashboard/DashboardConfigProviderTest.scala
@@ -54,6 +54,50 @@ class DashboardConfigProviderTest extends Stryker4sSuite with EitherValues {
       )
     }
 
+    it("should resolve a GitHub actions environment") {
+      implicit val config = Config.default
+      val env = Map(
+        "STRYKER_DASHBOARD_API_KEY" -> "apiKeyHere",
+        "GITHUB_ACTION" -> "true",
+        "GITHUB_REPOSITORY" -> "github/repo",
+        "GITHUB_REF" -> "refs/heads/feat/branch-1"
+      )
+      val sut = new DashboardConfigProvider(env)
+
+      val result = sut.resolveConfig()
+
+      result.right.value shouldBe DashboardConfig(
+        "apiKeyHere",
+        config.dashboard.baseUrl,
+        Full,
+        "github.com/github/repo",
+        "feat/branch-1",
+        None
+      )
+    }
+
+    it("should resolve a GitHub actions PR environment") {
+      implicit val config = Config.default
+      val env = Map(
+        "STRYKER_DASHBOARD_API_KEY" -> "apiKeyHere",
+        "GITHUB_ACTION" -> "true",
+        "GITHUB_REPOSITORY" -> "github/repo",
+        "GITHUB_REF" -> "refs/pull/10/merge"
+      )
+      val sut = new DashboardConfigProvider(env)
+
+      val result = sut.resolveConfig()
+
+      result.right.value shouldBe DashboardConfig(
+        "apiKeyHere",
+        config.dashboard.baseUrl,
+        Full,
+        "github.com/github/repo",
+        "PR-10",
+        None
+      )
+    }
+
     it("should resolve a configured environment") {
       implicit val config = Config.default.copy(
         dashboard = DashboardOptions(
@@ -79,6 +123,60 @@ class DashboardConfigProviderTest extends Stryker4sSuite with EitherValues {
         "versionHere",
         Some("moduleHere")
       )
+    }
+
+    it("should resolve without a module") {
+      implicit val config = Config.default.copy(
+        dashboard = DashboardOptions(
+          project = Some("projectHere"),
+          version = Some("versionHere"),
+          module = None
+        )
+      )
+      val env = Map("STRYKER_DASHBOARD_API_KEY" -> "apiKeyHere")
+      val sut = new DashboardConfigProvider(env)
+
+      val result = sut.resolveConfig()
+
+      result.right.value shouldBe DashboardConfig(
+        "apiKeyHere",
+        config.dashboard.baseUrl,
+        Full,
+        "projectHere",
+        "versionHere",
+        None
+      )
+    }
+
+    it("should not resolve a GitHub actions with malformed ref") {
+      implicit val config = Config.default
+      val env = Map(
+        "STRYKER_DASHBOARD_API_KEY" -> "apiKeyHere",
+        "GITHUB_ACTION" -> "true",
+        "GITHUB_REPOSITORY" -> "github/repo",
+        "GITHUB_REF" -> "refs/whatever"
+      )
+      val sut = new DashboardConfigProvider(env)
+
+      val result = sut.resolveConfig()
+
+      result.left.value shouldBe "dashboard.version"
+    }
+
+    it("should not resolve empty env variables") {
+      implicit val config = Config.default
+      val env = Map(
+        "STRYKER_DASHBOARD_API_KEY" -> "apiKeyHere",
+        "CIRCLECI" -> "true",
+        "CIRCLE_PROJECT_USERNAME" -> "circleUsername",
+        "CIRCLE_PROJECT_REPONAME" -> "circleRepoName",
+        "CIRCLE_BRANCH" -> ""
+      )
+      val sut = new DashboardConfigProvider(env)
+
+      val result = sut.resolveConfig()
+
+      result.left.value shouldBe "dashboard.version"
     }
 
     it("should not resolve when there is no STRYKER_DASHBOARD_API_KEY environment") {
@@ -121,29 +219,6 @@ class DashboardConfigProviderTest extends Stryker4sSuite with EitherValues {
       val result = sut.resolveConfig()
 
       result.left.value shouldBe "dashboard.version"
-    }
-
-    it("should still resolve without a module") {
-      implicit val config = Config.default.copy(
-        dashboard = DashboardOptions(
-          project = Some("projectHere"),
-          version = Some("versionHere"),
-          module = None
-        )
-      )
-      val env = Map("STRYKER_DASHBOARD_API_KEY" -> "apiKeyHere")
-      val sut = new DashboardConfigProvider(env)
-
-      val result = sut.resolveConfig()
-
-      result.right.value shouldBe DashboardConfig(
-        "apiKeyHere",
-        config.dashboard.baseUrl,
-        Full,
-        "projectHere",
-        "versionHere",
-        None
-      )
     }
   }
 }


### PR DESCRIPTION
### Fixes #307 

#### What it does

GitHub actions is now supported by the dashboard upload

#### How it works

Adds a new CI provider: GitHub actions