### PR TITLE
Filter out duplicate reporters in config

### DIFF
--- a/core/src/main/scala/stryker4s/config/Config.scala
+++ b/core/src/main/scala/stryker4s/config/Config.scala
@@ -7,7 +7,7 @@ import pureconfig.generic.auto._
 case class Config(
     mutate: Seq[String] = Seq("**/main/scala/**.scala"),
     baseDir: File = File.currentWorkingDirectory,
-    reporters: Seq[ReporterType] = Seq(Console, Html),
+    reporters: Set[ReporterType] = Set(Console, Html),
     files: Option[Seq[String]] = None,
     excludedMutations: ExcludedMutations = ExcludedMutations(),
     thresholds: Thresholds = Thresholds(),

--- a/core/src/main/scala/stryker4s/report/Reporter.scala
+++ b/core/src/main/scala/stryker4s/report/Reporter.scala
@@ -10,7 +10,7 @@ import scala.util.{Failure, Try}
 import sttp.client.HttpURLConnectionBackend
 
 class Reporter(implicit config: Config) extends FinishedRunReporter with ProgressReporter with Logging {
-  lazy val reporters: Seq[MutationRunReporter] = config.reporters map {
+  lazy val reporters: Iterable[MutationRunReporter] = config.reporters map {
     case Console => new ConsoleReporter()
     case Html    => new HtmlReporter(DiskFileIO)
     case Json    => new JsonReporter(DiskFileIO)
@@ -32,7 +32,7 @@ class Reporter(implicit config: Config) extends FinishedRunReporter with Progres
     val reported = finishedRunReporters.map(reporter => Try(reporter.reportRunFinished(report, metrics)))
     val failed = reported.collect({ case f: Failure[Unit] => f })
     if (failed.nonEmpty) {
-      warn(s"${failed.length} reporter(s) failed to report:")
+      warn(s"${failed.size} reporter(s) failed to report:")
       failed.map(_.exception).foreach(warn(_))
     }
   }

--- a/core/src/test/resources/stryker4sconfs/duplicateKeys.conf
+++ b/core/src/test/resources/stryker4sconfs/duplicateKeys.conf
@@ -1,0 +1,3 @@
+stryker4s {
+  reporters: ["html", "html"]
+}

--- a/core/src/test/scala/stryker4s/config/ConfigReaderTest.scala
+++ b/core/src/test/scala/stryker4s/config/ConfigReaderTest.scala
@@ -38,7 +38,7 @@ class ConfigReaderTest extends Stryker4sSuite with LogMatchers with ConfigReader
 
       result.baseDir shouldBe File.currentWorkingDirectory
       result.mutate shouldBe Seq("**/main/scala/**.scala")
-      result.reporters should contain inOrderOnly (Console, Html)
+      result.reporters should contain only (Console, Html)
       result.thresholds shouldBe Thresholds()
       result.dashboard shouldBe DashboardOptions(
         baseUrl = "https://dashboard.stryker-mutator.io",
@@ -94,6 +94,14 @@ class ConfigReaderTest extends Stryker4sSuite with LogMatchers with ConfigReader
         version = Some("someVersion"),
         module = Some("someModule")
       )
+    }
+
+    it("should filter out duplicate keys") {
+      val confPath = FileUtil.getResource("stryker4sconfs/duplicateKeys.conf")
+
+      val result = ConfigReader.readConfig(confPath)
+
+      result.reporters.loneElement shouldBe Html
     }
 
     it("should return a failure on a misshapen test runner") {

--- a/core/src/test/scala/stryker4s/config/ConfigTest.scala
+++ b/core/src/test/scala/stryker4s/config/ConfigTest.scala
@@ -38,7 +38,7 @@ class ConfigTest extends Stryker4sSuite {
       val sut = Config(
         filePaths,
         File("tmp"),
-        reporters = Seq(Html),
+        reporters = Set(Html),
         excludedMutations = ExcludedMutations(Set("BooleanLiteral")),
         dashboard = DashboardOptions(
           baseUrl = "https://fakeurl.com",

--- a/core/src/test/scala/stryker4s/report/ReporterTest.scala
+++ b/core/src/test/scala/stryker4s/report/ReporterTest.scala
@@ -30,7 +30,7 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
         val consoleReporterMock = mock[ConsoleReporter]
         val progressReporterMock = mock[ProgressReporter]
 
-        implicit val config: Config = Config(reporters = Seq())
+        implicit val config: Config = Config(reporters = Set.empty)
 
         val sut: Reporter = new Reporter() {
           override lazy val reporters: Seq[MutationRunReporter] = Seq(consoleReporterMock, progressReporterMock)
@@ -66,7 +66,7 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
         val consoleReporterMock = mock[ConsoleReporter]
         val progressReporterMock = mock[ProgressReporter]
 
-        implicit val config: Config = Config(reporters = Seq())
+        implicit val config: Config = Config(reporters = Set.empty)
 
         val sut: Reporter = new Reporter() {
           override lazy val reporters: Seq[ProgressReporter] = Seq(consoleReporterMock, progressReporterMock)


### PR DESCRIPTION
Reporters could be duplicate, causing them to be called twice. Now it is a `Set`, so each reporter is unique