### PR TITLE
Revert reporter regressions

### DIFF
--- a/core/src/main/scala/stryker4s/report/ConsoleReporter.scala
+++ b/core/src/main/scala/stryker4s/report/ConsoleReporter.scala
@@ -5,8 +5,8 @@ import mutationtesting.{MutantResult, MutantStatus}
 import stryker4s.config.Config
 import stryker4s.model.{Mutant, MutantRunResult}
 import stryker4s.run.threshold._
-
 import scala.concurrent.duration.{Duration, MILLISECONDS}
+import mutationtesting.Position
 
 class ConsoleReporter(implicit config: Config) extends FinishedRunReporter with ProgressReporter with Logging {
   private val startTime = System.currentTimeMillis()
@@ -25,7 +25,7 @@ class ConsoleReporter(implicit config: Config) extends FinishedRunReporter with 
     val FinishedRunReport(report, metrics) = runReport
     val duration = Duration(System.currentTimeMillis() - startTime, MILLISECONDS)
     val (detectedMutants, rest) = report.files.toSeq flatMap {
-      case (loc, f) => f.mutants.map(m => (loc, m))
+      case (loc, f) => f.mutants.map(m => (loc, m, f.source))
     } partition (
         m => isDetected(m._2)
     )
@@ -53,22 +53,44 @@ class ConsoleReporter(implicit config: Config) extends FinishedRunReporter with 
     }
   }
 
-  private def resultToString(name: String, mutants: Seq[(String, MutantResult)]): String =
+  private def resultToString(name: String, mutants: Seq[(String, MutantResult, String)]): String =
     s"$name mutants:\n" +
       mutants
         .sortBy(m => m._2.id)
-        .map(mutantDiff)
+        .map({ case (filePath, mutant, testResult) => mutantDiff(filePath, mutant, testResult) })
         .mkString("\n")
 
-  private def mutantDiff(mrr: (String, MutantResult)): String = {
-    val (filePath, mutant) = mrr
-    val line = mutant.location.start.line + 1
-    val col = mutant.location.start.column + 1
+  private def mutantDiff(filePath: String, mutant: MutantResult, source: String): String = {
+    val line = mutant.location.start.line
+    val col = mutant.location.start.column
 
     s"""${mutant.id}. [${mutant.status}] [${mutant.mutatorName}]
        |$filePath:$line:$col
-       |${mutant.replacement.linesIterator.map("\t" + _).mkString("\n")}
+       |-${tabbed(findOriginal(source, mutant))}
+       |+${tabbed(mutant.replacement)}
        |""".stripMargin
+  }
+
+  private def tabbed(string: String) = string.linesIterator.map("\t" + _).mkString("\n")
+
+  private def findOriginal(source: String, mutant: MutantResult): String = {
+    val Position(startLinePos, startColumnPos) = mutant.location.start
+    val Position(endLinePos, endColumnPos) = mutant.location.end
+    val lines = source.linesIterator.toSeq
+    val startLine = lines(startLinePos - 1).substring(startColumnPos - 1)
+    endLinePos - startLinePos match {
+      // Mutation is 1 line
+      case 0 => startLine.substring(0, endColumnPos - startColumnPos)
+      // Mutation is two lines
+      case 1 =>
+        val endLine = lines(endLinePos - 1).substring(0, endColumnPos - 1)
+        s"$startLine\n$endLine"
+      // Mutation is multiple lines
+      case _ =>
+        val linesBetween = lines.slice(startLinePos, endLinePos - 1)
+        val endLine = lines(endLinePos - 1).substring(0, endColumnPos - 1)
+        (startLine +: linesBetween :+ endLine).mkString("\n")
+    }
   }
 
   private def isDetected(mutant: MutantResult): Boolean =

--- a/core/src/main/scala/stryker4s/report/ConsoleReporter.scala
+++ b/core/src/main/scala/stryker4s/report/ConsoleReporter.scala
@@ -1,7 +1,7 @@
 package stryker4s.report
 
 import grizzled.slf4j.Logging
-import mutationtesting.{MetricsResult, MutantResult, MutantStatus, MutationTestReport}
+import mutationtesting.{MutantResult, MutantStatus}
 import stryker4s.config.Config
 import stryker4s.model.{Mutant, MutantRunResult}
 import stryker4s.run.threshold._
@@ -21,7 +21,8 @@ class ConsoleReporter(implicit config: Config) extends FinishedRunReporter with 
     info(s"Finished mutation run $id/$totalMutants (${((id / totalMutants.toDouble) * 100).round}%)")
   }
 
-  override def reportRunFinished(report: MutationTestReport, metrics: MetricsResult): Unit = {
+  override def reportRunFinished(runReport: FinishedRunReport): Unit = {
+    val FinishedRunReport(report, metrics) = runReport
     val duration = Duration(System.currentTimeMillis() - startTime, MILLISECONDS)
     val (detectedMutants, rest) = report.files.toSeq flatMap {
       case (loc, f) => f.mutants.map(m => (loc, m))

--- a/core/src/main/scala/stryker4s/report/DashboardReporter.scala
+++ b/core/src/main/scala/stryker4s/report/DashboardReporter.scala
@@ -15,11 +15,11 @@ class DashboardReporter(dashboardConfigProvider: DashboardConfigProvider)(
     implicit httpBackend: SttpBackend[Identity, Nothing, NothingT]
 ) extends FinishedRunReporter
     with Logging {
-  override def reportRunFinished(report: MutationTestReport, metrics: MetricsResult): Unit =
+  override def reportRunFinished(runReport: FinishedRunReport): Unit =
     dashboardConfigProvider.resolveConfig() match {
       case Left(configKey) => warn(s"Could not resolve dashboard configuration key '$configKey', not sending report")
       case Right(dashboardConfig) =>
-        val request = buildRequest(dashboardConfig, report, metrics)
+        val request = buildRequest(dashboardConfig, runReport.report, runReport.metrics)
         val response = request.send()
         logResponse(response)
     }

--- a/core/src/main/scala/stryker4s/report/HtmlReporter.scala
+++ b/core/src/main/scala/stryker4s/report/HtmlReporter.scala
@@ -44,7 +44,7 @@ class HtmlReporter(fileIO: FileIO)(implicit config: Config) extends FinishedRunR
   }
 
   override def reportRunFinished(runReport: FinishedRunReport): Unit = {
-    val targetLocation = config.baseDir / s"target/stryker4s-report/"
+    val targetLocation = config.baseDir / s"target/stryker4s-report-${runReport.timestamp}/"
 
     val mutationTestElementsLocation = targetLocation / mutationTestElementsName
     val indexLocation = targetLocation / "index.html"

--- a/core/src/main/scala/stryker4s/report/HtmlReporter.scala
+++ b/core/src/main/scala/stryker4s/report/HtmlReporter.scala
@@ -43,7 +43,7 @@ class HtmlReporter(fileIO: FileIO)(implicit config: Config) extends FinishedRunR
     fileIO.createAndWrite(file, reportContent)
   }
 
-  override def reportRunFinished(report: MutationTestReport, metrics: MetricsResult): Unit = {
+  override def reportRunFinished(runReport: FinishedRunReport): Unit = {
     val targetLocation = config.baseDir / s"target/stryker4s-report/"
 
     val mutationTestElementsLocation = targetLocation / mutationTestElementsName
@@ -51,7 +51,7 @@ class HtmlReporter(fileIO: FileIO)(implicit config: Config) extends FinishedRunR
     val reportLocation = targetLocation / reportFilename
 
     writeIndexHtmlTo(indexLocation)
-    writeReportJsTo(reportLocation, report)
+    writeReportJsTo(reportLocation, runReport.report)
     writeMutationTestElementsJsTo(mutationTestElementsLocation)
 
     info(s"Written HTML report to $indexLocation")

--- a/core/src/main/scala/stryker4s/report/JsonReporter.scala
+++ b/core/src/main/scala/stryker4s/report/JsonReporter.scala
@@ -15,7 +15,7 @@ class JsonReporter(fileIO: FileIO)(implicit config: Config) extends FinishedRunR
   }
 
   override def reportRunFinished(runReport: FinishedRunReport): Unit = {
-    val targetLocation = config.baseDir / s"target/stryker4s-report"
+    val targetLocation = config.baseDir / s"target/stryker4s-report-${runReport.timestamp}/"
     val resultLocation = targetLocation / "report.json"
 
     writeReportJsonTo(resultLocation, runReport.report)

--- a/core/src/main/scala/stryker4s/report/JsonReporter.scala
+++ b/core/src/main/scala/stryker4s/report/JsonReporter.scala
@@ -2,9 +2,9 @@ package stryker4s.report
 
 import better.files.File
 import grizzled.slf4j.Logging
-import mutationtesting.{MetricsResult, MutationTestReport}
 import stryker4s.config.Config
 import stryker4s.files.FileIO
+import mutationtesting.MutationTestReport
 
 class JsonReporter(fileIO: FileIO)(implicit config: Config) extends FinishedRunReporter with Logging {
   def writeReportJsonTo(file: File, report: MutationTestReport): Unit = {
@@ -14,11 +14,11 @@ class JsonReporter(fileIO: FileIO)(implicit config: Config) extends FinishedRunR
     fileIO.createAndWrite(file, json)
   }
 
-  override def reportRunFinished(report: MutationTestReport, metrics: MetricsResult): Unit = {
+  override def reportRunFinished(runReport: FinishedRunReport): Unit = {
     val targetLocation = config.baseDir / s"target/stryker4s-report"
     val resultLocation = targetLocation / "report.json"
 
-    writeReportJsonTo(resultLocation, report)
+    writeReportJsonTo(resultLocation, runReport.report)
 
     info(s"Written JSON report to $resultLocation")
   }

--- a/core/src/main/scala/stryker4s/report/MutationRunReporter.scala
+++ b/core/src/main/scala/stryker4s/report/MutationRunReporter.scala
@@ -11,5 +11,7 @@ trait ProgressReporter extends MutationRunReporter {
 }
 
 trait FinishedRunReporter extends MutationRunReporter {
-  def reportRunFinished(report: MutationTestReport, metrics: MetricsResult): Unit
+  def reportRunFinished(runReport: FinishedRunReport): Unit
 }
+
+case class FinishedRunReport(report: MutationTestReport, metrics: MetricsResult)

--- a/core/src/main/scala/stryker4s/report/MutationRunReporter.scala
+++ b/core/src/main/scala/stryker4s/report/MutationRunReporter.scala
@@ -14,4 +14,6 @@ trait FinishedRunReporter extends MutationRunReporter {
   def reportRunFinished(runReport: FinishedRunReport): Unit
 }
 
-case class FinishedRunReport(report: MutationTestReport, metrics: MetricsResult)
+case class FinishedRunReport(report: MutationTestReport, metrics: MetricsResult) {
+  @transient val timestamp: Long = System.currentTimeMillis()
+}

--- a/core/src/main/scala/stryker4s/report/Reporter.scala
+++ b/core/src/main/scala/stryker4s/report/Reporter.scala
@@ -1,7 +1,6 @@
 package stryker4s.report
 
 import grizzled.slf4j.Logging
-import mutationtesting.{MetricsResult, MutationTestReport}
 import stryker4s.config._
 import stryker4s.files.DiskFileIO
 import stryker4s.model.{Mutant, MutantRunResult}
@@ -28,8 +27,8 @@ class Reporter(implicit config: Config) extends FinishedRunReporter with Progres
   override def reportMutationComplete(result: MutantRunResult, totalMutants: Int): Unit =
     progressReporters.foreach(_.reportMutationComplete(result, totalMutants))
 
-  override def reportRunFinished(report: MutationTestReport, metrics: MetricsResult): Unit = {
-    val reported = finishedRunReporters.map(reporter => Try(reporter.reportRunFinished(report, metrics)))
+  override def reportRunFinished(runReport: FinishedRunReport): Unit = {
+    val reported = finishedRunReporters.map(reporter => Try(reporter.reportRunFinished(runReport)))
     val failed = reported.collect({ case f: Failure[Unit] => f })
     if (failed.nonEmpty) {
       warn(s"${failed.size} reporter(s) failed to report:")

--- a/core/src/main/scala/stryker4s/run/MutantRunner.scala
+++ b/core/src/main/scala/stryker4s/run/MutantRunner.scala
@@ -11,6 +11,7 @@ import stryker4s.model._
 import stryker4s.mutants.findmutants.SourceCollector
 import stryker4s.report.Reporter
 import stryker4s.report.mapper.MutantRunResultMapper
+import stryker4s.report.FinishedRunReport
 
 abstract class MutantRunner(sourceCollector: SourceCollector, reporter: Reporter)(implicit config: Config)
     extends InitialTestRun
@@ -33,7 +34,7 @@ abstract class MutantRunner(sourceCollector: SourceCollector, reporter: Reporter
     val report = toReport(runResults)
     val metrics = Metrics.calculateMetrics(report)
 
-    reporter.reportRunFinished(report, metrics)
+    reporter.reportRunFinished(FinishedRunReport(report, metrics))
     metrics
   }
 

--- a/core/src/test/scala/stryker4s/Stryker4sTest.scala
+++ b/core/src/test/scala/stryker4s/Stryker4sTest.scala
@@ -3,7 +3,6 @@ package stryker4s
 import java.nio.file.Path
 
 import better.files.File
-import mutationtesting.{MetricsResult, MutationTestReport}
 import org.mockito.captor.ArgCaptor
 import org.scalatest.Inside
 import stryker4s.config.Config
@@ -21,6 +20,7 @@ import stryker4s.testutil.{MockitoSuite, Stryker4sSuite}
 
 import scala.meta._
 import scala.util.Success
+import stryker4s.report.FinishedRunReport
 
 class Stryker4sTest extends Stryker4sSuite with MockitoSuite with Inside with LogMatchers {
   class TestMutantRunner(sourceCollector: SourceCollector, reporter: Reporter)(implicit config: Config)
@@ -61,9 +61,9 @@ class Stryker4sTest extends Stryker4sSuite with MockitoSuite with Inside with Lo
       startCaptor.values should matchPattern {
         case List(Mutant(0, _, _, _), Mutant(1, _, _, _), Mutant(2, _, _, _), Mutant(3, _, _, _)) =>
       }
-      val reportMock = ArgCaptor[MutationTestReport]
-      verify(reporterMock).reportRunFinished(reportMock, any[MetricsResult])
-      val reportedResults = reportMock.value
+      val runReportMock = ArgCaptor[FinishedRunReport]
+      verify(reporterMock).reportRunFinished(runReportMock)
+      val FinishedRunReport(reportedResults, _) = runReportMock.value
 
       result shouldBe SuccessStatus
       reportedResults.files.flatMap(_._2.mutants) should have size 4

--- a/core/src/test/scala/stryker4s/report/ConsoleReporterTypeTest.scala
+++ b/core/src/test/scala/stryker4s/report/ConsoleReporterTypeTest.scala
@@ -84,7 +84,7 @@ class ConsoleTest extends Stryker4sSuite with LogMatchers {
         )
       )
       val metrics = Metrics.calculateMetrics(results)
-      sut.reportRunFinished(results, metrics)
+      sut.reportRunFinished(FinishedRunReport(results, metrics))
 
       "Mutation run finished! Took " shouldBe loggedAsInfo
       "Total mutants: 1, detected: 1, undetected: 0" shouldBe loggedAsInfo
@@ -116,7 +116,7 @@ class ConsoleTest extends Stryker4sSuite with LogMatchers {
         )
       )
       val metrics = Metrics.calculateMetrics(results)
-      sut.reportRunFinished(results, metrics)
+      sut.reportRunFinished(FinishedRunReport(results, metrics))
 
       "Mutation run finished! Took " shouldBe loggedAsInfo
       "Total mutants: 3, detected: 1, undetected: 2" shouldBe loggedAsInfo
@@ -158,7 +158,7 @@ class ConsoleTest extends Stryker4sSuite with LogMatchers {
           )
         )
       )
-      sut.reportRunFinished(results, Metrics.calculateMetrics(results))
+      sut.reportRunFinished(FinishedRunReport(results, Metrics.calculateMetrics(results)))
 
       "Total mutants: 3, detected: 0, undetected: 3" shouldBe loggedAsInfo
       s"""Undetected mutants:
@@ -197,7 +197,7 @@ class ConsoleTest extends Stryker4sSuite with LogMatchers {
         )
       )
       val metrics = Metrics.calculateMetrics(results)
-      sut.reportRunFinished(results, metrics)
+      sut.reportRunFinished(FinishedRunReport(results, metrics))
       "Total mutants: 1, detected: 0, undetected: 1" shouldBe loggedAsInfo
       s"""Undetected mutants:
          |0. [Survived] [StringLiteral]
@@ -224,7 +224,7 @@ class ConsoleTest extends Stryker4sSuite with LogMatchers {
         )
       )
 
-      sut.reportRunFinished(threeReport, Metrics.calculateMetrics(threeReport))
+      sut.reportRunFinished(FinishedRunReport(threeReport, Metrics.calculateMetrics(threeReport)))
 
       "Mutation score: 66.67%" shouldBe loggedAsInfo
     }
@@ -248,7 +248,7 @@ class ConsoleTest extends Stryker4sSuite with LogMatchers {
       implicit val config: Config = Config(thresholds = stryker4s.config.Thresholds(break = 48, low = 49, high = 50))
       val sut = new ConsoleReporter()
 
-      sut.reportRunFinished(report, metrics)
+      sut.reportRunFinished(FinishedRunReport(report, metrics))
 
       "Mutation score: 50.0%" shouldBe loggedAsInfo
     }
@@ -257,7 +257,7 @@ class ConsoleTest extends Stryker4sSuite with LogMatchers {
       implicit val config: Config = Config(thresholds = stryker4s.config.Thresholds(break = 49, low = 50, high = 51))
       val sut = new ConsoleReporter()
 
-      sut.reportRunFinished(report, metrics)
+      sut.reportRunFinished(FinishedRunReport(report, metrics))
 
       "Mutation score: 50.0%" shouldBe loggedAsWarning
     }
@@ -266,7 +266,7 @@ class ConsoleTest extends Stryker4sSuite with LogMatchers {
       implicit val config: Config = Config(thresholds = stryker4s.config.Thresholds(break = 50, low = 51, high = 52))
       val sut = new ConsoleReporter()
 
-      sut.reportRunFinished(report, metrics)
+      sut.reportRunFinished(FinishedRunReport(report, metrics))
 
       "Mutation score dangerously low!" shouldBe loggedAsError
       "Mutation score: 50.0%" shouldBe loggedAsError
@@ -276,7 +276,7 @@ class ConsoleTest extends Stryker4sSuite with LogMatchers {
       implicit val config: Config = Config(thresholds = stryker4s.config.Thresholds(break = 51, low = 52, high = 53))
       val sut = new ConsoleReporter()
 
-      sut.reportRunFinished(report, metrics)
+      sut.reportRunFinished(FinishedRunReport(report, metrics))
 
       "Mutation score below threshold! Score: 50.0%. Threshold: 51%" shouldBe loggedAsError
     }

--- a/core/src/test/scala/stryker4s/report/DashboardReporterTest.scala
+++ b/core/src/test/scala/stryker4s/report/DashboardReporterTest.scala
@@ -23,7 +23,7 @@ class DashboardReporterTest extends Stryker4sSuite with MockitoSuite with LogMat
       val mockDashConfig = mock[DashboardConfigProvider]
       val sut = new DashboardReporter(mockDashConfig)
       val dashConfig = baseDashConfig
-      val (report, metrics) = baseResults
+      val FinishedRunReport(report, metrics) = baseResults
 
       val request = sut.buildRequest(dashConfig, report, metrics)
       request.uri shouldBe uri"https://baseurl.com/api/reports/project/foo/version/bar"
@@ -45,7 +45,7 @@ class DashboardReporterTest extends Stryker4sSuite with MockitoSuite with LogMat
       val mockDashConfig = mock[DashboardConfigProvider]
       val sut = new DashboardReporter(mockDashConfig)
       val dashConfig = baseDashConfig.copy(reportType = MutationScoreOnly)
-      val (report, metrics) = baseResults
+      val FinishedRunReport(report, metrics) = baseResults
 
       val request = sut.buildRequest(dashConfig, report, metrics)
       request.uri shouldBe uri"https://baseurl.com/api/reports/project/foo/version/bar"
@@ -58,7 +58,7 @@ class DashboardReporterTest extends Stryker4sSuite with MockitoSuite with LogMat
       val mockDashConfig = mock[DashboardConfigProvider]
       val sut = new DashboardReporter(mockDashConfig)
       val dashConfig = baseDashConfig.copy(module = Some("myModule"))
-      val (report, metrics) = baseResults
+      val FinishedRunReport(report, metrics) = baseResults
 
       val request = sut.buildRequest(dashConfig, report, metrics)
 
@@ -73,9 +73,9 @@ class DashboardReporterTest extends Stryker4sSuite with MockitoSuite with LogMat
       val mockDashConfig = mock[DashboardConfigProvider]
       when(mockDashConfig.resolveConfig()).thenReturn(Right(baseDashConfig))
       val sut = new DashboardReporter(mockDashConfig)
-      val (report, metrics) = baseResults
+      val runReport = baseResults
 
-      sut.reportRunFinished(report, metrics)
+      sut.reportRunFinished(runReport)
 
       "Sent report to dashboard. Available at https://hrefHere.com" shouldBe loggedAsInfo
     }
@@ -85,9 +85,9 @@ class DashboardReporterTest extends Stryker4sSuite with MockitoSuite with LogMat
       val mockDashConfig = mock[DashboardConfigProvider]
       when(mockDashConfig.resolveConfig()).thenReturn(Left("fooConfigKey"))
       val sut = new DashboardReporter(mockDashConfig)
-      val (report, metrics) = baseResults
+      val runReport = baseResults
 
-      sut.reportRunFinished(report, metrics)
+      sut.reportRunFinished(runReport)
 
       "Could not resolve dashboard configuration key 'fooConfigKey', not sending report" shouldBe loggedAsWarning
     }
@@ -97,9 +97,9 @@ class DashboardReporterTest extends Stryker4sSuite with MockitoSuite with LogMat
       val mockDashConfig = mock[DashboardConfigProvider]
       when(mockDashConfig.resolveConfig()).thenReturn(Right(baseDashConfig))
       val sut = new DashboardReporter(mockDashConfig)
-      val (report, metrics) = baseResults
+      val runReport = baseResults
 
-      sut.reportRunFinished(report, metrics)
+      sut.reportRunFinished(runReport)
 
       "Dashboard report was sent successfully, but could not decode the response: 'some other response'. Error:" shouldBe loggedAsWarning
     }
@@ -110,9 +110,9 @@ class DashboardReporterTest extends Stryker4sSuite with MockitoSuite with LogMat
       val mockDashConfig = mock[DashboardConfigProvider]
       when(mockDashConfig.resolveConfig()).thenReturn(Right(baseDashConfig))
       val sut = new DashboardReporter(mockDashConfig)
-      val (report, metrics) = baseResults
+      val runReport = baseResults
 
-      sut.reportRunFinished(report, metrics)
+      sut.reportRunFinished(runReport)
 
       "Error HTTP PUT 'auth required'. Status code 401 Unauthorized. Did you provide the correct api key in the 'STRYKER_DASHBOARD_API_KEY' environment variable?" shouldBe loggedAsError
     }
@@ -125,9 +125,9 @@ class DashboardReporterTest extends Stryker4sSuite with MockitoSuite with LogMat
       val mockDashConfig = mock[DashboardConfigProvider]
       when(mockDashConfig.resolveConfig()).thenReturn(Right(baseDashConfig))
       val sut = new DashboardReporter(mockDashConfig)
-      val (report, metrics) = baseResults
+      val runReport = baseResults
 
-      sut.reportRunFinished(report, metrics)
+      sut.reportRunFinished(runReport)
 
       "Failed to PUT report to dashboard. Response status code: 500. Response body: 'internal error'" shouldBe loggedAsError
     }
@@ -138,7 +138,7 @@ class DashboardReporterTest extends Stryker4sSuite with MockitoSuite with LogMat
   def baseResults = {
     val report = MutationTestReport(thresholds = mutationtesting.Thresholds(80, 60), files = Map.empty)
     val metrics = Metrics.calculateMetrics(report)
-    (report, metrics)
+    FinishedRunReport(report, metrics)
   }
 
   def baseDashConfig = DashboardConfig(

--- a/core/src/test/scala/stryker4s/report/HtmlReporterTest.scala
+++ b/core/src/test/scala/stryker4s/report/HtmlReporterTest.scala
@@ -82,7 +82,7 @@ class HtmlReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers
       val report = MutationTestReport(thresholds = Thresholds(100, 0), files = Map.empty)
       val metrics = Metrics.calculateMetrics(report)
 
-      sut.reportRunFinished(report, metrics)
+      sut.reportRunFinished(FinishedRunReport(report, metrics))
 
       val writtenFilesCaptor = ArgCaptor[File]
 
@@ -101,7 +101,7 @@ class HtmlReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers
       val report = MutationTestReport(thresholds = Thresholds(100, 0), files = Map.empty)
       val metrics = Metrics.calculateMetrics(report)
 
-      sut.reportRunFinished(report, metrics)
+      sut.reportRunFinished(FinishedRunReport(report, metrics))
 
       val elementsCaptor = ArgCaptor[File]
       verify(mockFileIO, times(2)).createAndWrite(any[File], any[String])
@@ -117,7 +117,7 @@ class HtmlReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers
       val report = MutationTestReport(thresholds = Thresholds(100, 0), files = Map.empty)
       val metrics = Metrics.calculateMetrics(report)
 
-      sut.reportRunFinished(report, metrics)
+      sut.reportRunFinished(FinishedRunReport(report, metrics))
 
       val captor = ArgCaptor[File]
       verify(mockFileIO).createAndWrite(captor.capture, eqTo(expectedHtml))

--- a/core/src/test/scala/stryker4s/report/HtmlReporterTest.scala
+++ b/core/src/test/scala/stryker4s/report/HtmlReporterTest.scala
@@ -74,7 +74,7 @@ class HtmlReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers
 
   describe("reportRunFinished") {
     implicit val config: Config = Config.default
-    val stryker4sReportFolderRegex = ".*target(/|\\\\)stryker4s-report(/|\\\\)[a-z-]*\\.[a-z]*$"
+    val stryker4sReportFolderRegex = ".*target(/|\\\\)stryker4s-report-(\\d*)(/|\\\\)[a-z-]*\\.[a-z]*$"
 
     it("should write the report files to the report directory") {
       val mockFileIO = mock[FileIO]

--- a/core/src/test/scala/stryker4s/report/JsonReporterTest.scala
+++ b/core/src/test/scala/stryker4s/report/JsonReporterTest.scala
@@ -25,7 +25,7 @@ class JsonReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers
 
   describe("reportRunFinished") {
     implicit val config: Config = Config.default
-    val stryker4sReportFolderRegex = ".*target(/|\\\\)stryker4s-report(/|\\\\)[a-z-]*\\.[a-z]*$"
+    val stryker4sReportFolderRegex = ".*target(/|\\\\)stryker4s-report-(\\d*)(/|\\\\)[a-z-]*\\.[a-z]*$"
 
     it("should write the report file to the report directory") {
       val mockFileIO = mock[FileIO]

--- a/core/src/test/scala/stryker4s/report/JsonReporterTest.scala
+++ b/core/src/test/scala/stryker4s/report/JsonReporterTest.scala
@@ -33,7 +33,7 @@ class JsonReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers
       val report = MutationTestReport(thresholds = Thresholds(100, 0), files = Map.empty)
       val metrics = Metrics.calculateMetrics(report)
 
-      sut.reportRunFinished(report, metrics)
+      sut.reportRunFinished(FinishedRunReport(report, metrics))
 
       val writtenFilesCaptor = ArgCaptor[File]
 
@@ -51,7 +51,7 @@ class JsonReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers
       val report = MutationTestReport(thresholds = Thresholds(100, 0), files = Map.empty)
       val metrics = Metrics.calculateMetrics(report)
 
-      sut.reportRunFinished(report, metrics)
+      sut.reportRunFinished(FinishedRunReport(report, metrics))
 
       val captor = ArgCaptor[File]
       verify(mockFileIO).createAndWrite(captor.capture, any[String])

--- a/core/src/test/scala/stryker4s/report/ReporterTest.scala
+++ b/core/src/test/scala/stryker4s/report/ReporterTest.scala
@@ -14,14 +14,15 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
 
       val report = MutationTestReport(thresholds = Thresholds(100, 0), files = Map.empty)
       val metrics = Metrics.calculateMetrics(report)
+      val runReport = FinishedRunReport(report, metrics)
 
       val sut: Reporter = new Reporter() {
         override lazy val reporters: Seq[ConsoleReporter] = Seq(consoleReporterMock)
       }
 
-      sut.reportRunFinished(report, metrics)
+      sut.reportRunFinished(runReport)
 
-      verify(consoleReporterMock).reportRunFinished(report, metrics)
+      verify(consoleReporterMock).reportRunFinished(runReport)
     }
 
     describe("reportMutationStart") {
@@ -104,15 +105,16 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
 
         val report = MutationTestReport(thresholds = Thresholds(100, 0), files = Map.empty)
         val metrics = Metrics.calculateMetrics(report)
+        val runReport = FinishedRunReport(report, metrics)
 
         val sut: Reporter = new Reporter() {
           override lazy val reporters: Seq[MutationRunReporter] = Seq(consoleReporterMock, finishedRunReporterMock)
         }
 
-        sut.reportRunFinished(report, metrics)
+        sut.reportRunFinished(runReport)
 
-        verify(consoleReporterMock).reportRunFinished(report, metrics)
-        verify(finishedRunReporterMock).reportRunFinished(report, metrics)
+        verify(consoleReporterMock).reportRunFinished(runReport)
+        verify(finishedRunReporterMock).reportRunFinished(runReport)
       }
 
       it("should not report a finished mutation run to a progress reporter") {
@@ -122,14 +124,15 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
 
         val report = MutationTestReport(thresholds = Thresholds(100, 0), files = Map.empty)
         val metrics = Metrics.calculateMetrics(report)
+        val runReport = FinishedRunReport(report, metrics)
 
         val sut: Reporter = new Reporter() {
           override lazy val reporters: Seq[MutationRunReporter] = Seq(consoleReporterMock, progressReporterMock)
         }
 
-        sut.reportRunFinished(report, metrics)
+        sut.reportRunFinished(runReport)
 
-        verify(consoleReporterMock).reportRunFinished(report, metrics)
+        verify(consoleReporterMock).reportRunFinished(runReport)
         verifyZeroInteractions(progressReporterMock)
       }
 
@@ -140,16 +143,17 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
 
         val report = MutationTestReport(thresholds = Thresholds(100, 0), files = Map.empty)
         val metrics = Metrics.calculateMetrics(report)
-        when(consoleReporterMock.reportRunFinished(report, metrics))
+        val runReport = FinishedRunReport(report, metrics)
+        when(consoleReporterMock.reportRunFinished(runReport))
           .thenThrow(new RuntimeException("Something happened"))
 
         val sut: Reporter = new Reporter() {
           override lazy val reporters: Seq[MutationRunReporter] = Seq(consoleReporterMock, progressReporterMock)
         }
 
-        sut.reportRunFinished(report, metrics)
+        sut.reportRunFinished(runReport)
 
-        verify(progressReporterMock).reportRunFinished(report, metrics)
+        verify(progressReporterMock).reportRunFinished(runReport)
       }
 
       describe("logging") {
@@ -161,16 +165,17 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
 
         val report = MutationTestReport(thresholds = Thresholds(100, 0), files = Map.empty)
         val metrics = Metrics.calculateMetrics(report)
+        val runReport = FinishedRunReport(report, metrics)
 
         it("should log if a report throws an exception") {
           val consoleReporterMock = mock[ConsoleReporter]
           val sut: Reporter = new Reporter() {
             override lazy val reporters: Seq[MutationRunReporter] = Seq(consoleReporterMock, progressReporterMock)
           }
-          when(consoleReporterMock.reportRunFinished(report, metrics))
+          when(consoleReporterMock.reportRunFinished(runReport))
             .thenThrow(new RuntimeException("Something happened"))
 
-          sut.reportRunFinished(report, metrics)
+          sut.reportRunFinished(runReport)
 
           failedToReportMessage shouldBe loggedAsWarning
           exceptionMessage shouldBe loggedAsWarning
@@ -182,9 +187,9 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
             override lazy val reporters: Seq[MutationRunReporter] = Seq(consoleReporterMock, progressReporterMock)
           }
 
-          sut.reportRunFinished(report, metrics)
+          sut.reportRunFinished(runReport)
 
-          verify(consoleReporterMock).reportRunFinished(report, metrics)
+          verify(consoleReporterMock).reportRunFinished(runReport)
           failedToReportMessage should not be loggedAsWarning
           exceptionMessage should not be loggedAsWarning
         }


### PR DESCRIPTION
With the mutation testing dependency, some regressions were introduced:

- [x] The report directory was changed to no longer have a timestamp
- [x] The diff was changed to no longer include the original code

This PR changes that back