### PR TITLE
Change Stryker4sSuite to abstract class

### DIFF
--- a/core/src/test/scala/stryker4s/testutil/Stryker4sSuite.scala
+++ b/core/src/test/scala/stryker4s/testutil/Stryker4sSuite.scala
@@ -4,4 +4,4 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.{LoneElement, OptionValues}
 
-trait Stryker4sSuite extends AnyFunSpec with Matchers with OptionValues with LoneElement
+abstract class Stryker4sSuite extends AnyFunSpec with Matchers with OptionValues with LoneElement

--- a/runners/maven/src/test/scala/stryker4s/testutil/Stryker4sSuite.scala
+++ b/runners/maven/src/test/scala/stryker4s/testutil/Stryker4sSuite.scala
@@ -4,4 +4,4 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.{LoneElement, OptionValues}
 
-trait Stryker4sSuite extends AnyFunSpec with Matchers with OptionValues with LoneElement
+ abstract class Stryker4sSuite extends AnyFunSpec with Matchers with OptionValues with LoneElement

--- a/runners/maven/src/test/scala/stryker4s/testutil/Stryker4sSuite.scala
+++ b/runners/maven/src/test/scala/stryker4s/testutil/Stryker4sSuite.scala
@@ -4,4 +4,4 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.{LoneElement, OptionValues}
 
- abstract class Stryker4sSuite extends AnyFunSpec with Matchers with OptionValues with LoneElement
+abstract class Stryker4sSuite extends AnyFunSpec with Matchers with OptionValues with LoneElement


### PR DESCRIPTION
Changes the base ScalaTest Stryker4sSuite to an abstract class, as [recommended by ScalaTest](http://www.scalatest.org/user_guide/defining_base_classes)