### PR TITLE
Setup VS Code devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,49 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+FROM openjdk:11-jdk
+
+# This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
+# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
+# will be updated to match your local UID/GID (when using the dockerFile property).
+# See https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Configure apt
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    #
+    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
+    && groupadd --gid $USER_GID $USERNAME \
+    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    # [Optional] Add sudo support for the non-root user
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    #
+    # Verify git, needed tools installed
+    && apt-get -y install git openssh-client less iproute2 procps curl lsb-release curl
+
+# Install coursier
+ENV PATH="$PATH:/root/.local/share/coursier/bin"
+RUN curl -fLo /usr/bin/cs https://git.io/coursier-cli-linux \
+    && chmod +x /usr/bin/cs
+
+# Install build-tools
+RUN cs install bloop
+RUN curl -Lo /usr/bin/sbt https://raw.githubusercontent.com/coursier/sbt-extras/master/sbt \
+    && chmod +x /usr/bin/sbt
+
+# Clean up
+RUN apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+ENV DEBIAN_FRONTEND=dialog
+
+# Allow for a consistant java home location for settings - image is changing over time
+RUN if [ ! -d "/docker-java-home" ]; then ln -s "${JAVA_HOME}" /docker-java-home; fi

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json
+// Based on https://github.com/microsoft/vscode-dev-containers/tree/v0.117.0/containers/java-11
+{
+	"name": "Scala - JDK 11",
+	"dockerFile": "Dockerfile",
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"java.home": "/docker-java-home",
+		"metals.javaHome": "/docker-java-home",
+		"metals.sbtScript": "/usr/bin/sbt"
+	},
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"scalameta.metals"
+	]
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "java -version",
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+}


### PR DESCRIPTION
Adds [VS Code devcontainers](https://code.visualstudio.com/docs/remote/containers) setup. It allows all development to be done inside a Docker container with a VS Code 'server' component running. This should make it easier for new contributors to get started, as all they need is to have VS Code and Docker installed