### PR TITLE
Add sbt-projectmatrix 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           java-version: openjdk@1.11
       - name: Run tests
         # Only publish stryker4s-core, sbt-stryker4s is published by scripted tests
-        run: csbt 'stryker4s-core/publishLocal; scripted sbt-stryker4s/test-1'
+        run: csbt 'stryker4s-coreJVM2_12/publishLocal; scripted sbt-stryker4s/test-1'
   maven-plugin:
     name: Test Maven plugin
     runs-on: ubuntu-latest
@@ -73,7 +73,7 @@ jobs:
         with:
           java-version: openjdk@1.11
       - name: Publish stryker4s-core
-        run: csbt 'set version in ThisBuild := "SET-BY-SBT-SNAPSHOT"' stryker4s-core/publishM2
+        run: csbt 'set version in ThisBuild := "SET-BY-SBT-SNAPSHOT"' stryker4s-coreJVM2_12/publishM2
       - name: Run Maven tests
         run: |
           cd maven

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           export JAVA_OPTS="-XX:+CMSClassUnloadingEnabled -Xmx6G $JAVA_OPTS"
           echo 'stryker4s{reporters=["console","dashboard"],base-dir="core",dashboard.module="core"}' > stryker4s.conf
-          csbt 'project stryker4s-core; stryker'
+          csbt 'project stryker4s-coreJVM2_13; stryker'
         env:
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
 
@@ -60,7 +60,7 @@ jobs:
         run: |
           export JAVA_OPTS="-XX:+CMSClassUnloadingEnabled -Xmx6G $JAVA_OPTS"
           echo 'stryker4s{reporters=["console","dashboard"],base-dir="command-runner",dashboard.module="command-runner"}' > stryker4s.conf
-          csbt 'project stryker4s-command-runner; stryker'
+          csbt 'project stryker4s-command-runnerJVM2_13; stryker'
         env:
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
 
@@ -93,7 +93,7 @@ jobs:
       - name: Run Stryker4s
         run: |
           export JAVA_OPTS="-XX:+CMSClassUnloadingEnabled -Xmx6G $JAVA_OPTS"
-          csbt 'set version in ThisBuild := "SET-BY-SBT-SNAPSHOT"' stryker4s-core/publishM2
+          csbt 'set version in ThisBuild := "SET-BY-SBT-SNAPSHOT"' stryker4s-coreJVM2_12/publishM2
           cd maven
           echo 'stryker4s{reporters=["console","dashboard"],dashboard.module="maven-plugin"}' > stryker4s.conf
           mvn -B --no-transfer-progress stryker4s:run

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,7 @@ lazy val stryker4sCommandRunner = newProject("stryker4s-command-runner", "comman
   .jvmPlatform(scalaVersions = Dependencies.versions.crossScalaVersions)
 
 // sbt project is a 'normal' project without projectMatrix because there is only 1 scala version
+// sbt plugins have to use Scala 2.12
 lazy val sbtStryker4s = (project withId "sbt-stryker4s" in file("sbt"))
   .enablePlugins(SbtPlugin)
   .settings(Settings.commonSettings, Settings.sbtPluginSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -4,11 +4,15 @@ lazy val root = (project withId "stryker4s" in file("."))
     skip in publish := true,
     onLoad in Global ~= (_ andThen ("writeHooks" :: _))
   )
-  .aggregate(stryker4sCore, sbtStryker4s, stryker4sCommandRunner)
-  .dependsOn(stryker4sCommandRunner) // So 'run' command also works from root of project
+  .aggregate(
+    stryker4sCore.jvm(Dependencies.versions.scala213),
+    stryker4sCommandRunner.jvm(Dependencies.versions.scala213),
+    sbtStryker4s
+  )
 
 lazy val stryker4sCore = newProject("stryker4s-core", "core")
   .settings(Settings.coreSettings)
+  .jvmPlatform(scalaVersions = Dependencies.versions.crossScalaVersions)
 
 lazy val stryker4sCommandRunner = newProject("stryker4s-command-runner", "command-runner")
   .settings(
@@ -16,15 +20,17 @@ lazy val stryker4sCommandRunner = newProject("stryker4s-command-runner", "comman
     mainClass in (Compile, run) := Some("stryker4s.run.Stryker4sCommandRunner")
   )
   .dependsOn(stryker4sCore, stryker4sCore % "test->test")
+  .jvmPlatform(scalaVersions = Dependencies.versions.crossScalaVersions)
 
-lazy val sbtStryker4s = newProject("sbt-stryker4s", "sbt")
+// sbt project is a 'normal' project without projectMatrix because there is only 1 scala version
+lazy val sbtStryker4s = (project withId "sbt-stryker4s" in file("sbt"))
   .enablePlugins(SbtPlugin)
-  .settings(Settings.sbtPluginSettings)
-  .dependsOn(stryker4sCore)
+  .settings(Settings.commonSettings, Settings.sbtPluginSettings)
+  .dependsOn(stryker4sCore.jvm(Dependencies.versions.scala212))
 
-def newProject(projectName: String, dir: String): Project =
-  sbt
-    .Project(projectName, file(dir))
+def newProject(projectName: String, dir: String) =
+  sbt.internal
+    .ProjectMatrix(projectName, file(dir))
     .settings(Settings.commonSettings)
 
 lazy val writeHooks = taskKey[Unit]("Write git hooks")

--- a/maven/README.MD
+++ b/maven/README.MD
@@ -6,4 +6,4 @@ This is the project for the Stryker4s Maven plugin. As you cannot build a Maven 
 
 ## Developing
 
-The maven plugin depends on the `stryker4s-core` dependency. To install it locally, you can execute the following command in the root of this repository: `sbt 'set version in ThisBuild := "SET-BY-SBT-SNAPSHOT"' stryker4s-core/publishM2`. This will install `stryker4s-core` into your local Maven repository so you can start local development.
+The maven plugin depends on the `stryker4s-core` dependency. To install it locally, you can execute the following command in the root of this repository: `sbt 'set version in ThisBuild := "SET-BY-SBT-SNAPSHOT"' stryker4s-coreJVM2_12/publishM2`. This will install `stryker4s-core` into your local Maven repository so you can start local development.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,6 +4,7 @@ object Dependencies {
   object versions {
     val scala212 = "2.12.11"
     val scala213 = "2.13.2"
+    val crossScalaVersions = Seq(scala213, scala212)
 
     val scalameta = "4.3.10"
     val pureconfig = "0.12.3"

--- a/project/Release.scala
+++ b/project/Release.scala
@@ -10,7 +10,7 @@ object Release {
   private val stryker4sReleaseAll = "stryker4sReleaseAll"
   // Helper command names
   private val stryker4sMvnDeploy = "stryker4sMvnDeploy"
-  private val publishM2 = "stryker4s-core/publishM2"
+  private val publishM2 = "stryker4s-coreJVM2_12/publishM2"
   private val crossPublish = "+publish"
   private val crossPublishSigned = "+publishSigned"
   private val sonatypePrepare = "sonatypePrepare"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -5,8 +5,6 @@ import sbt._
 
 object Settings {
   lazy val commonSettings: Seq[Setting[_]] = Seq(
-    crossScalaVersions := Seq(Dependencies.versions.scala212, Dependencies.versions.scala213),
-    scalaVersion := crossScalaVersions.value.head,
     Test / parallelExecution := false // For logging tests
   )
 
@@ -37,8 +35,6 @@ object Settings {
 
   lazy val sbtPluginSettings: Seq[Setting[_]] = Seq(
     // sbt plugin has to be 2.12
-    crossScalaVersions := Seq(Dependencies.versions.scala212),
-    scalaVersion := Dependencies.versions.scala212,
     scriptedLaunchOpts := {
       scriptedLaunchOpts.value ++
         Seq("-Xmx1024M", "-Dplugin.version=" + version.value)

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -34,7 +34,6 @@ object Settings {
   )
 
   lazy val sbtPluginSettings: Seq[Setting[_]] = Seq(
-    // sbt plugin has to be 2.12
     scriptedLaunchOpts := {
       scriptedLaunchOpts.value ++
         Seq("-Xmx1024M", "-Dplugin.version=" + version.value)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.3")
 addSbtPlugin("io.stryker-mutator" % "sbt-stryker4s" % "0.7.2")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.11")
+addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.5.2")


### PR DESCRIPTION
Adds [sbt-projectmatrix](https://github.com/sbt/sbt-projectmatrix/) to the build. This has two main benefits:

- Each scalaVersion can be compiled in parallel for each project, speeding up the build
- When developing, the 'main' scalaVersion can now be 2.13, which is faster to compile (and thus develop on)