### PR TITLE
Filter out scalacOptions that can break on Scala 2.13 projects

### DIFF
--- a/sbt/src/main/scala/stryker4s/sbt/runner/SbtMutantRunner.scala
+++ b/sbt/src/main/scala/stryker4s/sbt/runner/SbtMutantRunner.scala
@@ -38,9 +38,12 @@ class SbtMutantRunner(state: State, sourceCollector: SourceCollector, reporter: 
     * https://github.com/stryker-mutator/stryker4s/issues/321
     */
   private val blacklistedScalacOptions = Seq(
+    // Scala 2.12
     "-Ywarn-unused:patvars",
     "-Ywarn-unused:locals",
-    "-Xlint-unused"
+    // Scala 2.13
+    "-Wunused:patvars",
+    "-Wunused:locals"
   )
 
   private lazy val emptyLogManager =


### PR DESCRIPTION
### Fixes #453 

Adds some scalacOptions that are the same as on 2.12, but for 2.13