### PR TITLE
Add test-filter to Config

### DIFF
--- a/core/src/main/scala/stryker4s/config/Config.scala
+++ b/core/src/main/scala/stryker4s/config/Config.scala
@@ -6,6 +6,7 @@ import pureconfig.generic.auto._
 
 final case class Config(
     mutate: Seq[String] = Seq("**/main/scala/**.scala"),
+    testFilter: Seq[String] = Seq(),
     baseDir: File = File.currentWorkingDirectory,
     reporters: Set[ReporterType] = Set(Console, Html),
     files: Option[Seq[String]] = None,

--- a/core/src/main/scala/stryker4s/config/TestFilter.scala
+++ b/core/src/main/scala/stryker4s/config/TestFilter.scala
@@ -1,0 +1,50 @@
+package stryker4s.config
+
+import java.util.regex.Pattern
+import scala.util.Try
+import stryker4s.config.TestFilter.wildcardToRegex
+
+class TestFilter(implicit config: Config) {
+
+  val exclamationMark = "!"
+
+  lazy val partition: Partition = config.testFilter.partition(_.startsWith(exclamationMark)) match {
+    case (negative, positive) =>
+      Partition(
+        negative.map(p => Regex(wildcardToRegex(p.substring(1)))),
+        positive.map(p => Regex(wildcardToRegex(p)))
+      )
+  }
+
+  def filter(testName: String): Boolean = {
+    def matches(regexSeq: Seq[Regex]): Boolean =
+      regexSeq.foldLeft(false)((acc, regex) => acc || regex.matches(testName))
+
+    if (matches(partition.negative))
+      false
+    else
+      partition.positive.isEmpty || matches(partition.positive)
+  }
+}
+
+case class Partition(negative: Seq[Regex], positive: Seq[Regex])
+
+case class Regex(regex: String) {
+  def matches(testName: String): Boolean = Try(Pattern.matches(regex, testName)).fold(_ => false, b => b)
+}
+
+object TestFilter {
+
+  def wildcardToRegex(wildcard: String): String = s"^${wildcard.toList.map(convertChar).mkString}$$"
+
+  def convertChar(c: Char): String =
+    c match {
+      case '*'                 => ".*"
+      case '?'                 => "."
+      case _ if isRegexChar(c) => s"\\${c.toString}"
+      case c                   => c.toString
+    }
+
+  def isRegexChar(c: Char): Boolean =
+    Seq('(', ')', '[', ']', '$', '^', '.', '{', '}', '|', '\\').foldLeft(false)((acc, elt) => acc || c == elt)
+}

--- a/core/src/test/scala/stryker4s/config/ConfigTest.scala
+++ b/core/src/test/scala/stryker4s/config/ConfigTest.scala
@@ -24,6 +24,7 @@ class ConfigTest extends Stryker4sSuite {
            |    console,
            |    html
            |]
+           |test-filter=[]
            |thresholds {
            |    break=0
            |    high=80
@@ -37,7 +38,7 @@ class ConfigTest extends Stryker4sSuite {
       val filePaths = List("**/main/scala/**/Foo.scala", "**/main/scala/**/Bar.scala")
       val sut = Config(
         filePaths,
-        File("tmp"),
+        baseDir = File("tmp"),
         reporters = Set(Html),
         excludedMutations = ExcludedMutations(Set("BooleanLiteral")),
         dashboard = DashboardOptions(
@@ -70,6 +71,7 @@ class ConfigTest extends Stryker4sSuite {
            |reporters=[
            |    html
            |]
+           |test-filter=[]
            |thresholds {
            |    break=0
            |    high=80

--- a/core/src/test/scala/stryker4s/config/TestFilterTest.scala
+++ b/core/src/test/scala/stryker4s/config/TestFilterTest.scala
@@ -1,0 +1,32 @@
+package stryker4s.config
+
+import stryker4s.testutil.Stryker4sSuite
+
+class TestFilterTest extends Stryker4sSuite {
+  describe("filter with default") {
+    implicit val conf: Config = Config.default
+    it("should work") {
+      val testFilter = new TestFilter
+      assert(testFilter.filter("stryker4s.extension.FileExtensionsTest"))
+    }
+  }
+
+  describe("filter with custom") {
+    implicit val conf: Config = Config.default.copy(testFilter = Seq("stryker4s.extension.*"))
+    it("should work") {
+      val testFilter = new TestFilter
+      assert(testFilter.filter("stryker4s.extension.FileExtensionsTest"))
+      assert(!testFilter.filter("stryker4s.config.TestFilterTest"))
+    }
+  }
+
+  describe("filter with custom and negation") {
+    implicit val conf: Config = Config.default.copy(testFilter = Seq("!stryker4s.extension.*"))
+    it("should work") {
+      val testFilter = new TestFilter
+      assert(!testFilter.filter("stryker4s.extension.FileExtensionsTest"))
+      assert(testFilter.filter("stryker4s.config.TestFilterTest"))
+    }
+  }
+
+}

--- a/core/src/test/scala/stryker4s/config/TestFilterTest.scala
+++ b/core/src/test/scala/stryker4s/config/TestFilterTest.scala
@@ -3,30 +3,26 @@ package stryker4s.config
 import stryker4s.testutil.Stryker4sSuite
 
 class TestFilterTest extends Stryker4sSuite {
-  describe("filter with default") {
-    implicit val conf: Config = Config.default
-    it("should work") {
+  describe("filter") {
+
+    it("should work with default") {
+      implicit val conf: Config = Config.default
       val testFilter = new TestFilter
       assert(testFilter.filter("stryker4s.extension.FileExtensionsTest"))
     }
-  }
 
-  describe("filter with custom") {
-    implicit val conf: Config = Config.default.copy(testFilter = Seq("stryker4s.extension.*"))
-    it("should work") {
+    it("should work with custom") {
+      implicit val conf: Config = Config.default.copy(testFilter = Seq("stryker4s.extension.*"))
       val testFilter = new TestFilter
       assert(testFilter.filter("stryker4s.extension.FileExtensionsTest"))
       assert(!testFilter.filter("stryker4s.config.TestFilterTest"))
     }
-  }
 
-  describe("filter with custom and negation") {
-    implicit val conf: Config = Config.default.copy(testFilter = Seq("!stryker4s.extension.*"))
-    it("should work") {
+    it("should work with custom and negation") {
+      implicit val conf: Config = Config.default.copy(testFilter = Seq("!stryker4s.extension.*"))
       val testFilter = new TestFilter
       assert(!testFilter.filter("stryker4s.extension.FileExtensionsTest"))
       assert(testFilter.filter("stryker4s.config.TestFilterTest"))
     }
   }
-
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -11,6 +11,7 @@ stryker4s {
 - [Configuration](#configuration)
   - [General config](#general-config)
       - [mutate](#mutate)
+      - [test-filter](#test-filter)
       - [files](#files)
       - [base-dir](#base-dir)
       - [reporters](#reporters)
@@ -35,6 +36,17 @@ Generally speaking, these should be your own source files.
 The default for this will find files in the common Scala project format.
 
 You can *ignore* files by adding an exclamation mark (`!`) at the start of an expression.
+
+#### test-filter
+
+**Config file:** `test-filter: [ "com.mypackage.MyTest" ]`  
+**Default value:** `[]`  
+**Mandatory:** No  
+**Description:**  
+With `test-filter` you configure the subset of tests to use for mutation testing.
+You can use wildcard pattern: `com.mypackage.*` 
+
+You can *ignore* tests by adding an exclamation mark (`!`) at the start of an expression.
 
 #### files
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -43,10 +43,12 @@ You can *ignore* files by adding an exclamation mark (`!`) at the start of an ex
 **Default value:** `[]`  
 **Mandatory:** No  
 **Description:**  
-With `test-filter` you configure the subset of tests to use for mutation testing.
-You can use wildcard pattern: `com.mypackage.*` 
+With `test-filter` you configure the subset of tests to use for mutation testing. By default all tests are included. 
+You can use wildcard pattern: `com.mypackage.*`. 
 
 You can *ignore* tests by adding an exclamation mark (`!`) at the start of an expression.
+
+Note: only supported in the sbt plugin.
 
 #### files
 

--- a/sbt/src/main/scala/stryker4s/sbt/runner/SbtMutantRunner.scala
+++ b/sbt/src/main/scala/stryker4s/sbt/runner/SbtMutantRunner.scala
@@ -7,7 +7,7 @@ import better.files.{File, _}
 import sbt.Keys._
 import sbt._
 import sbt.internal.LogManager
-import stryker4s.config.Config
+import stryker4s.config.{Config, TestFilter}
 import stryker4s.extension.FileExtensions._
 import stryker4s.extension.exception.InitialTestRunFailedException
 import stryker4s.model._
@@ -49,6 +49,8 @@ class SbtMutantRunner(state: State, sourceCollector: SourceCollector, reporter: 
   private lazy val emptyLogManager =
     LogManager.defaultManager(ConsoleOut.printStreamOut(new PrintStream((_: Int) => {})))
 
+  private lazy val testFilter = new TestFilter
+
   private val settings: Seq[Def.Setting[_]] = Seq(
     scalacOptions --= blacklistedScalacOptions,
     fork in Test := true,
@@ -56,7 +58,8 @@ class SbtMutantRunner(state: State, sourceCollector: SourceCollector, reporter: 
     logManager := {
       if ((logLevel in stryker).value == Level.Debug) logManager.value
       else emptyLogManager
-    }
+    },
+    Test / testOptions := Seq(Tests.Filter(testFilter.filter))
   ) ++
     filteredSystemProperties.map(properties => {
       debug(s"System properties added to the forked JVM: ${properties.mkString(",")}")

--- a/sbt/src/sbt-test/sbt-stryker4s/test-1/src/test/scala/example/IgnoreMeTest.scala
+++ b/sbt/src/sbt-test/sbt-stryker4s/test-1/src/test/scala/example/IgnoreMeTest.scala
@@ -1,0 +1,12 @@
+package example
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.funspec.AnyFunSpec
+
+class IgnoreMeTest extends AnyFunSpec with Matchers {
+  describe("Person") {
+    it("not be able to drink with age 16") {
+      Example.canDrink(16) should be(false)
+    }
+  }
+}

--- a/sbt/src/sbt-test/sbt-stryker4s/test-1/stryker4s.conf
+++ b/sbt/src/sbt-test/sbt-stryker4s/test-1/stryker4s.conf
@@ -7,4 +7,5 @@ stryker4s {
     low: 65
     break: 64
   }
+  test-filter: ["!*IgnoreMeTest"]
 }


### PR DESCRIPTION
#### What it does

Adds `test-filter` to `Config`

#### How it works

It restricts the tests that are run for every mutation, so that we can ignore heavy `integration` tests and focus on `unit` ones
