### PR TITLE
fix: include pattern-matches in topStatements

### DIFF
--- a/core/src/main/scala/stryker4s/extension/TreeExtensions.scala
+++ b/core/src/main/scala/stryker4s/extension/TreeExtensions.scala
@@ -46,6 +46,7 @@ object TreeExtensions {
           case parent: Term.Select     => parent
           case parent: Term.ApplyType  => parent
           case parent: Term.ApplyInfix => parent
+          case parent: Term.Match      => parent
         }
     }
 

--- a/core/src/test/scala/stryker4s/extension/TreeExtensionsTest.scala
+++ b/core/src/test/scala/stryker4s/extension/TreeExtensionsTest.scala
@@ -263,6 +263,19 @@ class TreeExtensionsTest extends Stryker4sSuite with TreeEquality {
 
       result should equal(q"!foo")
     }
+
+    it("should include pattern matches") {
+      val expectedTopStatement = q"""list.nonEmpty match {
+        case true => someValue
+        case _ => otherValue
+      }"""
+      val tree = q"""def foo = { otherValue; $expectedTopStatement }"""
+      val subTree = tree.find(q"nonEmpty").value
+
+      val result = subTree.topStatement()
+
+      result should equal(expectedTopStatement)
+    }
   }
 
   describe("find") {


### PR DESCRIPTION
### Fixes #467 

#### What it does

The MatchBuilder replaces any nodes by folding a list of statements to be mutated. It finds the node to be replaced in an AST and replaces it with a new node (the mutation). If a node has already been replaced, the builder can't find the node and won't replaced it. That means the mutation is never properly activated, resulting in an always Survived mutant.

This happens when there is a mutation in a statement that and the result that it is pattern-matched on.

#### How it works

Count a pattern match as a top-statement so they'll always be mutated together and not skipped