### PR TITLE
Fix catch-statements not being included in mutations

### DIFF
--- a/core/src/main/scala/stryker4s/extension/TreeExtensions.scala
+++ b/core/src/main/scala/stryker4s/extension/TreeExtensions.scala
@@ -33,10 +33,13 @@ object TreeExtensions {
       */
     private object ParentIsPatternMatch {
 
-      /** Go up the tree, until a Case is found, then go up until a `Term` is found
+      /** Go up the tree, until a Case is found (except for try-catches), then go up until a `Term` is found
         *
         */
-      final def unapply(term: Term): Option[Term] = findParent[Case](term) flatMap findParent[Term]
+      final def unapply(term: Term): Option[Term] =
+        findParent[Case](term)
+          .filterNot(_.parent.exists(_.isInstanceOf[Term.Try]))
+          .flatMap(findParent[Term])
 
       private def findParent[T <: Tree](tree: Tree)(implicit classTag: ClassTag[T]): Option[T] =
         mapParent[T, Option[T]](tree, Some(_), None)

--- a/core/src/test/scala/stryker4s/extension/TreeExtensionsTest.scala
+++ b/core/src/test/scala/stryker4s/extension/TreeExtensionsTest.scala
@@ -301,6 +301,19 @@ class TreeExtensionsTest extends Stryker4sSuite with TreeEquality {
 
       result should equal(q"baz.qux")
     }
+
+    it("should stop at the catch in a try-catch") {
+      val tree = q"""def foo = try {
+                      foo.bar
+                    } catch {
+                      case _ => baz.qux
+                    }"""
+      val subTree = tree.find(q"baz.qux").value
+
+      val result = subTree.topStatement()
+
+      result should equal(q"baz.qux")
+    }
   }
 
   describe("find") {


### PR DESCRIPTION
### Fixes #479 

#### What it does

Previously the whole try-catch would be included in a topStatement. This PR fixes that to stop at the `case` statement, so it will be included in the build pattern match.