### PR TITLE
Fixes stryker-mutator/stryker4s#495

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ Do you have a suggestion for a (new) mutator? Feel free to create an [issue](htt
 
 An always up-to-date reference is also available in the [MutantMatcher source](core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala).
 
+## Additional mutations skipping
+
+Sometimes, you may be need to skip mutation in more preciese way, than file. Fore example if you have hardcoded constant, that have no practical reason to extract and you still want mutate surroundings.
+Therefore, you can annotate code block with `@SuppressWarning` annotation, passing mutation names you would like to skip.
+```scala
+@SuppressWarnings(Array("stryker4s.mutation.BooleanLiteral"))
+RequestLogger(logHeaders = false, logBody = false)(ResponseLogger(logHeaders = false, logBody = true)(httpClient))
+//theres no practical reason to mutate boolean values as its only for logging
+```
+All mutation names can be found in section above [Supported mutators](##Supported mutators) and it should be prefixed with "stryker4s.mutation."
+
 ## Changelog
 
 See the [releases page](https://github.com/stryker-mutator/stryker4s/releases) for all the latest changes made.

--- a/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
+++ b/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
@@ -87,9 +87,8 @@ class MutantMatcher()(implicit config: Config) {
     ): Seq[Option[Mutant]] =
       ifNotInAnnotation {
         mutations
-          .filterNot(isSuppressedByAnnotation(_, original))
           .map { mutated =>
-            if (matchExcluded(mutated))
+            if (matchExcluded(mutated) || isSuppressedByAnnotation(mutated, original))
               None
             else
               Some(Mutant(ids.next, original, mutationToTerm(mutated), mutated))

--- a/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
+++ b/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
@@ -1,11 +1,13 @@
 package stryker4s.mutants.findmutants
 
 import stryker4s.config.Config
-import stryker4s.extension.TreeExtensions.TreeIsInExtension
+import stryker4s.extension.TreeExtensions.{GetMods, PathToRoot, TreeIsInExtension}
 import stryker4s.extension.mutationtype._
 import stryker4s.model.Mutant
 
-import scala.meta.{Mod, Term, Tree}
+import scala.meta.Mod.Annot
+import scala.meta.Term.Apply
+import scala.meta.{Init, Lit, Mod, Name, Term, Tree, Type}
 
 class MutantMatcher()(implicit config: Config) {
   private[this] val ids = Iterator.from(0)
@@ -84,12 +86,14 @@ class MutantMatcher()(implicit config: Config) {
         mutationToTerm: T => Term
     ): Seq[Option[Mutant]] =
       ifNotInAnnotation {
-        mutations map { mutated =>
-          if (matchExcluded(mutated))
-            None
-          else
-            Some(Mutant(ids.next, original, mutationToTerm(mutated), mutated))
-        }
+        mutations
+          .filterNot(isSuppressedByAnnotation(_, original))
+          .map { mutated =>
+            if (matchExcluded(mutated))
+              None
+            else
+              Some(Mutant(ids.next, original, mutationToTerm(mutated), mutated))
+          }
       }
 
     private def ifNotInAnnotation(maybeMutants: => Seq[Option[Mutant]]): Seq[Option[Mutant]] = {
@@ -102,5 +106,22 @@ class MutantMatcher()(implicit config: Config) {
     private def matchExcluded(mutation: Mutation[_]): Boolean = {
       config.excludedMutations.exclusions.contains(mutation.mutationName)
     }
+
+    private def isSuppressedByAnnotation(mutation: Mutation[_], original: Term): Boolean = {
+      original.pathToRoot.flatMap(_.getMods).exists(isSupressWarningsAnnotation(_, mutation))
+    }
+
+    private def isSupressWarningsAnnotation(mod: Mod, mutation: Mutation[_]) = {
+      val mutationName = mutation.mutationName
+      mod match {
+        case Annot(Init(Type.Name("SuppressWarnings"), _, List(List(Apply(Name("Array"), params))))) =>
+          params.exists {
+            case Lit.String(`mutationName`) => true
+            case _                          => false
+          }
+        case _ => false
+      }
+    }
+
   }
 }

--- a/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
+++ b/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
@@ -112,7 +112,7 @@ class MutantMatcher()(implicit config: Config) {
     }
 
     private def isSupressWarningsAnnotation(mod: Mod, mutation: Mutation[_]) = {
-      val mutationName = mutation.mutationName
+      val mutationName = "stryker4s.mutation." + mutation.mutationName
       mod match {
         case Annot(Init(Type.Name("SuppressWarnings"), _, List(List(Apply(Name("Array"), params))))) =>
           params.exists {

--- a/core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala
@@ -149,7 +149,7 @@ class MutantFinderTest extends Stryker4sSuite with TreeEquality with LogMatchers
           """
 
       val (result, excluded) = sut.findMutants(source)
-      excluded shouldBe 0
+      excluded shouldBe 3
       result should have length 3
     }
   }

--- a/core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala
@@ -5,7 +5,6 @@ import java.nio.file.NoSuchFileException
 import better.files.File
 import stryker4s.config.{Config, ExcludedMutations}
 import stryker4s.extension.FileExtensions._
-import stryker4s.extension.mutationtype.StringLiteral
 import stryker4s.scalatest.{FileUtil, LogMatchers, TreeEquality}
 import stryker4s.testutil.Stryker4sSuite
 
@@ -128,23 +127,22 @@ class MutantFinderTest extends Stryker4sSuite with TreeEquality with LogMatchers
     it("should filter out @SuppressWarnings annotated code") {
       val sut = new MutantFinder(new MutantMatcher)
 
-      val stringMutatorName = Lit.String(classOf[StringLiteral[_]].getSimpleName)
       val source =
         source"""
                  final case class Bar(
-                    @SuppressWarnings(Array($stringMutatorName))
+                    @SuppressWarnings(Array("stryker4s.mutation.StringLiteral"))
                     s1: String = "filtered",
-                    @SuppressWarnings(Array($stringMutatorName))
+                    @SuppressWarnings(Array("stryker4s.mutation.StringLiteral"))
                     notFiltered1: Boolean = false) {
 
                     def aFunction(@SuppressWarnings param: String = "notFiltered2") = {
                       "notFiltered3"
                     }
 
-                    @SuppressWarnings(Array($stringMutatorName))
+                    @SuppressWarnings(Array("stryker4s.mutation.StringLiteral"))
                     val x = { val l = "s3"; l }
                   }
-                  @SuppressWarnings(Array($stringMutatorName))
+                  @SuppressWarnings(Array("stryker4s.mutation.StringLiteral"))
                   object Foo {
                     val value = "s5"
                   }


### PR DESCRIPTION
Use @SuppressWarnings annotation to skip mutations

### Fixes #495

#### What it does

This PR allow skip particular mutations in annotated context. For example if we dont need mutate exact line of code (like constant value)

#### How it works

It will iterate to root of syntax Tree checking for @SuppressWarnings annotation. If this annotation contains id of mutation (for example `@SuppressWarnings(Array("stryker4s.extension.mutationtype.StringLiteral))`), then this mutation will be skipped
