### PR TITLE
Add minimum supported version to sbt plugin

### DIFF
--- a/sbt/src/main/scala/stryker4s/sbt/Stryker4sMain.scala
+++ b/sbt/src/main/scala/stryker4s/sbt/Stryker4sMain.scala
@@ -22,27 +22,46 @@ object Stryker4sMain extends AutoPlugin {
   override def trigger = allRequirements
 
   object autoImport {
-    val stryker = taskKey[State]("Run Stryker4s")
+    val stryker = taskKey[Unit]("Run Stryker4s mutation testing")
+    val strykerMinimumSbtVersion = settingKey[String]("Lowest supported sbt version by Stryker4s")
+    val strykerIsSupported = settingKey[Boolean]("If running Stryker4s is supported on this sbt version")
   }
   import autoImport._
 
   override lazy val projectSettings: Seq[Def.Setting[_]] = Seq(
     stryker := strykerTask.value,
     logLevel in stryker := Level.Info,
-    onLoadMessage := "" // Prevents "[info] Set current project to ..." in between mutations
+    onLoadMessage in stryker := "", // Prevents "[info] Set current project to ..." in between mutations
+    strykerMinimumSbtVersion := "1.1.1",
+    strykerIsSupported := sbtVersion.value >= strykerMinimumSbtVersion.value
   )
 
-  val strykerTask = Def.task {
+  lazy val strykerTask = Def.taskDyn[Unit] {
+    if (strykerIsSupported.value)
+      strykerImpl
+    else
+      strykerIsNotSupported
+  }
+
+  lazy val strykerImpl = Def.task {
     implicit val cs: ContextShift[CatsIO] = CatsIO.contextShift(implicitly[ExecutionContext])
     setStrykerLogLevel((logLevel in stryker).value)
 
-    val currentState = state.value
-    val result = new Stryker4sSbtRunner(currentState).run()
+    val result = new Stryker4sSbtRunner(state.value).run()
 
     result match {
       case ErrorStatus => throw new MessageOnlyException("Mutation score is below configured threshold")
-      case _           => currentState
+      case _           => ()
     }
+  }
+
+  private lazy val strykerIsNotSupported: Def.Initialize[Task[Unit]] = Def.task {
+    // Put in Unit def to prevent dead code warning
+    def throwVersionException(): Unit =
+      throw new UnsupportedSbtVersionException(
+        s"Sbt version ${sbtVersion.value} is not supported by Stryker4s. Please upgrade to a later version. The lowest supported version is ${strykerMinimumSbtVersion.value}. If you know what you are doing you can override this with the 'strykerIsSupported' sbt setting."
+      )
+    throwVersionException()
   }
 
   private def setStrykerLogLevel(level: Level.Value): Unit = {
@@ -57,4 +76,8 @@ object Stryker4sMain extends AutoPlugin {
       case Level.Debug => Log4jLevel.DEBUG
       case _           => Log4jLevel.INFO
     }
+
+  private class UnsupportedSbtVersionException(s: String)
+      extends IllegalArgumentException(s)
+      with FeedbackProvidedException
 }

--- a/sbt/src/sbt-test/sbt-stryker4s/test-1/build.sbt
+++ b/sbt/src/sbt-test/sbt-stryker4s/test-1/build.sbt
@@ -1,3 +1,3 @@
-scalaVersion := "2.12.10"
+scalaVersion := "2.12.11"
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.1" % Test
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.0" % Test

--- a/sbt/src/sbt-test/sbt-stryker4s/test-1/project/build.properties
+++ b/sbt/src/sbt-test/sbt-stryker4s/test-1/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.1.1

--- a/sbt/src/sbt-test/sbt-stryker4s/test-1/stryker4s.conf
+++ b/sbt/src/sbt-test/sbt-stryker4s/test-1/stryker4s.conf
@@ -1,6 +1,6 @@
 stryker4s {
   files: [ "*", "!global" ]
-  reporters: ["console", "html"]
+  reporters: ["console", "json", "html"]
   thresholds: {
     # Should be 66,66%. Break if lower than that
     high: 66


### PR DESCRIPTION
### Closes #507 

Adds a check before running Stryker4s if the current version is supported. Uses direct string comparison, so might be a little iffy in some cases. Though it worked in most I tested