### PR TITLE
Report sbt Error TestResult correctly as failed instead of error

### DIFF
--- a/sbt/src/main/scala/stryker4s/sbt/runner/SbtMutantRunner.scala
+++ b/sbt/src/main/scala/stryker4s/sbt/runner/SbtMutantRunner.scala
@@ -107,6 +107,7 @@ class SbtMutantRunner(state: State, sourceCollector: SourceCollector, reporter: 
     Project.runTask(executeTests in Test, state) match {
       case Some((_, Value(Output(TestResult.Passed, _, _)))) => onSuccess
       case Some((_, Value(Output(TestResult.Failed, _, _)))) => onFailed
+      case Some((_, Value(Output(TestResult.Error, _, _))))  => onFailed
       case _                                                 => onError
     }
 


### PR DESCRIPTION
Sbt can report test 'error's. ScalaTest reports this when a test class is unable to initialize. We should report this as a failed test-run, not an error. Resulting as an error will mark the mutant as `CompileError` which is wrong.

This change can result in a slightly different mutation score.