### PR TITLE
Handle NaN mutation score in report correctly

### DIFF
--- a/core/src/main/scala/stryker4s/report/ConsoleReporter.scala
+++ b/core/src/main/scala/stryker4s/report/ConsoleReporter.scala
@@ -103,6 +103,9 @@ class ConsoleReporter(implicit config: Config) extends FinishedRunReporter with 
 
   implicit class DoubleRoundTwoDecimals(score: Double) {
     def roundDecimals(decimals: Int): Double =
-      BigDecimal(score).setScale(decimals, BigDecimal.RoundingMode.HALF_UP).toDouble
+      if (!score.isNaN())
+        BigDecimal(score).setScale(decimals, BigDecimal.RoundingMode.HALF_UP).toDouble
+      else
+        score
   }
 }

--- a/core/src/test/scala/stryker4s/report/ConsoleReporterTest.scala
+++ b/core/src/test/scala/stryker4s/report/ConsoleReporterTest.scala
@@ -5,7 +5,7 @@ import java.nio.file.Paths
 import mutationtesting.{Position, _}
 import stryker4s.config.Config
 import stryker4s.extension.mutationtype.{GreaterThan, LesserThan}
-import stryker4s.model.{Killed, Mutant, Survived}
+import stryker4s.model._
 import stryker4s.scalatest.LogMatchers
 
 import scala.meta._
@@ -283,6 +283,29 @@ class ConsoleReporterTest extends Stryker4sSuite with LogMatchers {
         .unsafeRunSync()
 
       "Mutation score: 66.67%" shouldBe loggedAsInfo
+    }
+
+    it("should log NaN correctly") {
+      implicit val config: Config = Config.default
+      val sut = new ConsoleReporter()
+
+      val report = MutationTestReport(
+        thresholds = Thresholds(80, 60),
+        files = Map(
+          "stryker4s.scala" -> MutationTestResult(
+            source = "foo\nbar\nbaz",
+            mutants = Seq(
+              MutantResult("0", "", "bar\nbaz\nqu", Location(Position(1, 1), Position(2, 2)), MutantStatus.CompileError)
+            )
+          )
+        )
+      )
+
+      sut
+        .reportRunFinished(FinishedRunReport(report, Metrics.calculateMetrics(report)))
+        .unsafeRunSync()
+
+      "Mutation score: NaN" shouldBe loggedAsInfo
     }
 
     // 1 killed, 1 survived, mutation score 50


### PR DESCRIPTION
The metrics report score can be a NaN when there are no survived mutants. We should be able to handle that.