### PR TITLE
Inject reporters into (renamed) AggregateReporter

### DIFF
--- a/command-runner/src/test/scala/stryker4s/run/ProcessMutantRunnerTest.scala
+++ b/command-runner/src/test/scala/stryker4s/run/ProcessMutantRunnerTest.scala
@@ -6,7 +6,7 @@ import stryker4s.extension.exception.InitialTestRunFailedException
 import stryker4s.extension.mutationtype.EmptyString
 import stryker4s.model._
 import stryker4s.mutants.findmutants.SourceCollector
-import stryker4s.report.Reporter
+import stryker4s.report.AggregateReporter
 import stryker4s.run.process.Command
 import stryker4s.scalatest.{FileUtil, LogMatchers}
 import stryker4s.testutil.stubs.TestProcessRunner
@@ -21,7 +21,7 @@ import cats.effect.IO
 class ProcessMutantRunnerTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
   implicit private val config: Config = Config(baseDir = FileUtil.getResource("scalaFiles"))
   private val fileCollectorMock: SourceCollector = mock[SourceCollector]
-  private val reporterMock = mock[Reporter]
+  private val reporterMock = mock[AggregateReporter]
   when(reporterMock.reportRunFinished(any[FinishedRunReport])).thenReturn(IO.unit)
   when(reporterMock.reportMutationComplete(any[MutantRunResult], anyInt)).thenReturn(IO.unit)
   when(reporterMock.reportMutationStart(any[Mutant])).thenReturn(IO.unit)

--- a/core/src/main/scala/stryker4s/env/package.scala
+++ b/core/src/main/scala/stryker4s/env/package.scala
@@ -1,5 +1,5 @@
-package stryker4s.env
+package stryker4s
 
-object Environment {
+package object env {
   type Environment = Map[String, String]
 }

--- a/core/src/main/scala/stryker4s/report/dashboard/DashboardConfigProvider.scala
+++ b/core/src/main/scala/stryker4s/report/dashboard/DashboardConfigProvider.scala
@@ -1,7 +1,7 @@
 package stryker4s.report.dashboard
 
 import stryker4s.config.Config
-import stryker4s.env.Environment.Environment
+import stryker4s.env.Environment
 import stryker4s.report.dashboard.Providers._
 import stryker4s.report.model.DashboardConfig
 

--- a/core/src/main/scala/stryker4s/report/dashboard/Providers.scala
+++ b/core/src/main/scala/stryker4s/report/dashboard/Providers.scala
@@ -1,6 +1,6 @@
 package stryker4s.report.dashboard
 import grizzled.slf4j.Logging
-import stryker4s.env.Environment.Environment
+import stryker4s.env.Environment
 
 object Providers extends Logging {
   def determineCiProvider(env: Environment): Option[CiProvider] =

--- a/core/src/main/scala/stryker4s/report/package.scala
+++ b/core/src/main/scala/stryker4s/report/package.scala
@@ -1,0 +1,5 @@
+package stryker4s
+
+package object report {
+  type Reporter = FinishedRunReporter with ProgressReporter
+}

--- a/core/src/main/scala/stryker4s/run/Stryker4sRunner.scala
+++ b/core/src/main/scala/stryker4s/run/Stryker4sRunner.scala
@@ -2,7 +2,8 @@ package stryker4s.run
 
 import cats.effect.{ContextShift, IO}
 import stryker4s.Stryker4s
-import stryker4s.config.{Config, ConfigReader}
+import stryker4s.config._
+import stryker4s.files.DiskFileIO
 import stryker4s.mutants.Mutator
 import stryker4s.mutants.applymutants.ActiveMutationContext.ActiveMutationContext
 import stryker4s.mutants.applymutants.{MatchBuilder, StatementTransformer}
@@ -11,8 +12,6 @@ import stryker4s.report._
 import stryker4s.report.dashboard.DashboardConfigProvider
 import stryker4s.run.process.ProcessRunner
 import stryker4s.run.threshold.ScoreStatus
-import stryker4s.config._
-import stryker4s.files.DiskFileIO
 import sttp.client.asynchttpclient.cats.AsyncHttpClientCatsBackend
 
 trait Stryker4sRunner {

--- a/core/src/main/scala/stryker4s/run/Stryker4sRunner.scala
+++ b/core/src/main/scala/stryker4s/run/Stryker4sRunner.scala
@@ -7,9 +7,13 @@ import stryker4s.mutants.Mutator
 import stryker4s.mutants.applymutants.ActiveMutationContext.ActiveMutationContext
 import stryker4s.mutants.applymutants.{MatchBuilder, StatementTransformer}
 import stryker4s.mutants.findmutants.{FileCollector, MutantFinder, MutantMatcher, SourceCollector}
-import stryker4s.report.Reporter
+import stryker4s.report._
+import stryker4s.report.dashboard.DashboardConfigProvider
 import stryker4s.run.process.ProcessRunner
 import stryker4s.run.threshold.ScoreStatus
+import stryker4s.config._
+import stryker4s.files.DiskFileIO
+import sttp.client.asynchttpclient.cats.AsyncHttpClientCatsBackend
 
 trait Stryker4sRunner {
   def run()(implicit cs: ContextShift[IO]): ScoreStatus = {
@@ -19,10 +23,24 @@ trait Stryker4sRunner {
     val stryker4s = new Stryker4s(
       collector,
       new Mutator(new MutantFinder(new MutantMatcher), new StatementTransformer, new MatchBuilder(mutationActivation)),
-      resolveRunner(collector, new Reporter())
+      resolveRunner(collector, new AggregateReporter(resolveReporters()))
     )
     stryker4s.run()
   }
+
+  def resolveReporters()(implicit config: Config, cs: ContextShift[IO]) =
+    config.reporters.toList.map {
+      case Console => new ConsoleReporter()
+      case Html    => new HtmlReporter(new DiskFileIO())
+      case Json    => new JsonReporter(new DiskFileIO())
+      case Dashboard =>
+        AsyncHttpClientCatsBackend[IO]()
+          .map { implicit backend =>
+            new DashboardReporter(new DashboardConfigProvider(sys.env))
+          }
+          // TODO: Figure out some other way to do this?
+          .unsafeRunSync()
+    }
 
   def resolveRunner(collector: SourceCollector, reporter: Reporter)(implicit config: Config): MutantRunner
 

--- a/core/src/test/scala/stryker4s/Stryker4sTest.scala
+++ b/core/src/test/scala/stryker4s/Stryker4sTest.scala
@@ -11,7 +11,7 @@ import stryker4s.model.{Killed, Mutant, MutantRunResult}
 import stryker4s.mutants.Mutator
 import stryker4s.mutants.applymutants.{ActiveMutationContext, MatchBuilder, StatementTransformer}
 import stryker4s.mutants.findmutants.{FileCollector, MutantFinder, MutantMatcher, SourceCollector}
-import stryker4s.report.Reporter
+import stryker4s.report.{AggregateReporter, Reporter}
 import stryker4s.run.MutantRunner
 import stryker4s.run.threshold.SuccessStatus
 import stryker4s.scalatest.{FileUtil, LogMatchers}
@@ -41,7 +41,7 @@ class Stryker4sTest extends Stryker4sSuite with MockitoSuite with Inside with Lo
     val testFiles = Seq(file)
     val testSourceCollector = new TestSourceCollector(testFiles)
     val testProcessRunner = TestProcessRunner(Success(1), Success(1), Success(1), Success(1))
-    val reporterMock = mock[Reporter]
+    val reporterMock = mock[AggregateReporter]
     when(reporterMock.reportRunFinished(any[FinishedRunReport])).thenReturn(IO.unit)
     when(reporterMock.reportMutationComplete(any[MutantRunResult], anyInt)).thenReturn(IO.unit)
     when(reporterMock.reportMutationStart(any[Mutant])).thenReturn(IO.unit)

--- a/core/src/test/scala/stryker4s/report/ReporterTest.scala
+++ b/core/src/test/scala/stryker4s/report/ReporterTest.scala
@@ -1,7 +1,6 @@
 package stryker4s.report
 
 import mutationtesting._
-import stryker4s.config.Config
 import stryker4s.model.{Mutant, MutantRunResult}
 import stryker4s.scalatest.LogMatchers
 import stryker4s.testutil.{MockitoSuite, Stryker4sSuite}
@@ -14,15 +13,11 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
     it("should log that the console reporter is used when a non existing reporter is configured") {
       val consoleReporterMock = mock[ConsoleReporter]
       when(consoleReporterMock.reportRunFinished(any[FinishedRunReport])).thenReturn(IO.unit)
-      implicit val config: Config = Config.default
 
       val report = MutationTestReport(thresholds = Thresholds(100, 0), files = Map.empty)
       val metrics = Metrics.calculateMetrics(report)
       val runReport = FinishedRunReport(report, metrics)
-
-      val sut: Reporter = new Reporter() {
-        override lazy val reporters: Seq[ConsoleReporter] = Seq(consoleReporterMock)
-      }
+      val sut = new AggregateReporter(Seq(consoleReporterMock))
 
       sut
         .reportRunFinished(runReport)
@@ -38,13 +33,7 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
         val progressReporterMock = mock[ProgressReporter]
         when(consoleReporterMock.reportMutationStart(any[Mutant])).thenReturn(IO.unit)
         when(progressReporterMock.reportMutationStart(any[Mutant])).thenReturn(IO.unit)
-
-        implicit val config: Config = Config(reporters = Set.empty)
-
-        val sut: Reporter = new Reporter() {
-          override lazy val reporters: Seq[MutationRunReporter] = Seq(consoleReporterMock, progressReporterMock)
-        }
-
+        val sut = new AggregateReporter(Seq(consoleReporterMock, progressReporterMock))
         sut
           .reportMutationStart(mutantMock)
           .unsafeRunSync()
@@ -58,13 +47,7 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
         when(consoleReporterMock.reportMutationStart(any[Mutant])).thenReturn(IO.unit)
         val finishedRunReporterMock = mock[FinishedRunReporter]
         val mutantMock = Mutant(0, q">", q"<", GreaterThan)
-
-        implicit val config: Config = Config.default
-
-        val sut: Reporter = new Reporter() {
-          override lazy val reporters: Seq[MutationRunReporter] = Seq(consoleReporterMock, finishedRunReporterMock)
-        }
-
+        val sut = new AggregateReporter(Seq(consoleReporterMock, finishedRunReporterMock))
         sut
           .reportMutationStart(mutantMock)
           .unsafeRunSync()
@@ -79,14 +62,9 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
         val mutantRunResultMock = mock[MutantRunResult]
         val consoleReporterMock = mock[ConsoleReporter]
         val progressReporterMock = mock[ProgressReporter]
+        val sut = new AggregateReporter(Seq(consoleReporterMock, progressReporterMock))
         when(consoleReporterMock.reportMutationComplete(any[MutantRunResult], anyInt)).thenReturn(IO.unit)
         when(progressReporterMock.reportMutationComplete(any[MutantRunResult], anyInt)).thenReturn(IO.unit)
-
-        implicit val config: Config = Config(reporters = Set.empty)
-
-        val sut: Reporter = new Reporter() {
-          override lazy val reporters: Seq[ProgressReporter] = Seq(consoleReporterMock, progressReporterMock)
-        }
 
         sut
           .reportMutationComplete(mutantRunResultMock, 1)
@@ -100,12 +78,8 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
         val consoleReporterMock = mock[ConsoleReporter]
         val finishedRunReporterMock = mock[FinishedRunReporter]
         val mutantRunResultMock = mock[MutantRunResult]
+        val sut = new AggregateReporter(Seq(consoleReporterMock, finishedRunReporterMock))
         when(consoleReporterMock.reportMutationComplete(any[MutantRunResult], anyInt)).thenReturn(IO.unit)
-        implicit val config: Config = Config.default
-
-        val sut: Reporter = new Reporter() {
-          override lazy val reporters: Seq[MutationRunReporter] = Seq(consoleReporterMock, finishedRunReporterMock)
-        }
 
         sut
           .reportMutationComplete(mutantRunResultMock, 1)
@@ -122,15 +96,10 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
         val finishedRunReporterMock = mock[FinishedRunReporter]
         when(consoleReporterMock.reportRunFinished(any[FinishedRunReport])).thenReturn(IO.unit)
         when(finishedRunReporterMock.reportRunFinished(any[FinishedRunReport])).thenReturn(IO.unit)
-        implicit val config: Config = Config.default
-
         val report = MutationTestReport(thresholds = Thresholds(100, 0), files = Map.empty)
         val metrics = Metrics.calculateMetrics(report)
         val runReport = FinishedRunReport(report, metrics)
-
-        val sut: Reporter = new Reporter() {
-          override lazy val reporters: Seq[MutationRunReporter] = Seq(consoleReporterMock, finishedRunReporterMock)
-        }
+        val sut: AggregateReporter = new AggregateReporter(Seq(consoleReporterMock, finishedRunReporterMock))
 
         sut
           .reportRunFinished(runReport)
@@ -144,15 +113,10 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
         val consoleReporterMock = mock[ConsoleReporter]
         val progressReporterMock = mock[ProgressReporter]
         when(consoleReporterMock.reportRunFinished(any[FinishedRunReport])).thenReturn(IO.unit)
-        implicit val config: Config = Config.default
-
         val report = MutationTestReport(thresholds = Thresholds(100, 0), files = Map.empty)
         val metrics = Metrics.calculateMetrics(report)
         val runReport = FinishedRunReport(report, metrics)
-
-        val sut: Reporter = new Reporter() {
-          override lazy val reporters: Seq[MutationRunReporter] = Seq(consoleReporterMock, progressReporterMock)
-        }
+        val sut = new AggregateReporter(Seq(consoleReporterMock, progressReporterMock))
 
         sut
           .reportRunFinished(runReport)
@@ -166,17 +130,12 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
         val consoleReporterMock = mock[ConsoleReporter]
         val progressReporterMock = mock[FinishedRunReporter]
         when(progressReporterMock.reportRunFinished(any[FinishedRunReport])).thenReturn(IO.unit)
-        implicit val config: Config = Config.default
-
         val report = MutationTestReport(thresholds = Thresholds(100, 0), files = Map.empty)
         val metrics = Metrics.calculateMetrics(report)
         val runReport = FinishedRunReport(report, metrics)
+        val sut = new AggregateReporter(Seq(consoleReporterMock, progressReporterMock))
         when(consoleReporterMock.reportRunFinished(runReport))
           .thenReturn(IO.raiseError(new RuntimeException("Something happened")))
-
-        val sut: Reporter = new Reporter() {
-          override lazy val reporters: Seq[MutationRunReporter] = Seq(consoleReporterMock, progressReporterMock)
-        }
 
         sut
           .reportRunFinished(runReport)
@@ -190,17 +149,13 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
         val exceptionMessage = "java.lang.RuntimeException: Something happened"
 
         val progressReporterMock = mock[ProgressReporter]
-        implicit val config: Config = Config.default
-
         val report = MutationTestReport(thresholds = Thresholds(100, 0), files = Map.empty)
         val metrics = Metrics.calculateMetrics(report)
         val runReport = FinishedRunReport(report, metrics)
 
         it("should log if a report throws an exception") {
           val consoleReporterMock = mock[ConsoleReporter]
-          val sut: Reporter = new Reporter() {
-            override lazy val reporters: Seq[MutationRunReporter] = Seq(consoleReporterMock, progressReporterMock)
-          }
+          val sut = new AggregateReporter(Seq(consoleReporterMock, progressReporterMock))
           when(consoleReporterMock.reportRunFinished(runReport))
             .thenReturn(IO.raiseError(new RuntimeException("Something happened")))
 
@@ -215,9 +170,7 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
         it("should not log warnings if no exceptions occur") {
           val consoleReporterMock = mock[ConsoleReporter]
           when(consoleReporterMock.reportRunFinished(any[FinishedRunReport])).thenReturn(IO.unit)
-          val sut: Reporter = new Reporter() {
-            override lazy val reporters: Seq[MutationRunReporter] = Seq(consoleReporterMock, progressReporterMock)
-          }
+          val sut = new AggregateReporter(Seq(consoleReporterMock, progressReporterMock))
 
           sut
             .reportRunFinished(runReport)


### PR DESCRIPTION
Renames `Reporter` to `AggregateReporter`, add a new type alias `Reporter` that combines both reporter types and inject the configured reporters into the `AggregateReporter` instead of creating them on initialization of the class