### PR TITLE
Propagate active profiles from Maven plugin configuration to stryker runs

### DIFF
--- a/maven/README.MD
+++ b/maven/README.MD
@@ -4,6 +4,50 @@
 
 This is the project for the Stryker4s Maven plugin. As you cannot build a Maven plugin from a sbt project, it is a separate project.
 
+## Overriding compiler flags
+
+Stryker4s can generate mutated code that produces warnings. 
+This will not work well with `-Xfatal-warnings` and/or `-Werror`. 
+To mitigate this, you can specify a profile where scala maven plugin uses different set of compiler flags.
+
+```xml
+    <profile>
+        <id>stryker4s</id>
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>net.alchim31.maven</groupId>
+                    <artifactId>scala-maven-plugin</artifactId>
+                    <configuration>
+                        <args combine.children="override">
+                            <arg>-language:postfixOps</arg>
+                            <arg>-language:higherKinds</arg>
+                            <!-- <arg>-Xfatal-warnings</arg> disabling for stryker4s -->
+                        </args>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </build>
+    </profile>
+```
+
+Then you can activate this profile in `stryker4s-maven-plugin`'s `configuration` section
+```xml
+    <plugin>
+        <groupId>io.stryker-mutator</groupId>
+        <artifactId>stryker4s-maven-plugin</artifactId>
+        <configuration>
+            <project>
+                <activeProfiles>
+                    <profile>
+                        <id>stryker4s</id>
+                    </profile>
+                </activeProfiles>
+            </project>
+        </configuration>
+    </plugin>
+```
+
 ## Developing
 
 The maven plugin depends on the `stryker4s-core` dependency. To install it locally, you can execute the following command in the root of this repository: `sbt 'set version in ThisBuild := "SET-BY-SBT-SNAPSHOT"' stryker4s-coreJVM2_12/publishM2`. This will install `stryker4s-core` into your local Maven repository so you can start local development.

--- a/maven/README.MD
+++ b/maven/README.MD
@@ -7,8 +7,8 @@ This is the project for the Stryker4s Maven plugin. As you cannot build a Maven 
 ## Overriding compiler flags
 
 Stryker4s can generate mutated code that produces warnings. 
-This will not work well with `-Xfatal-warnings` and/or `-Werror`. 
-To mitigate this, you can specify a profile where scala maven plugin uses different set of compiler flags.
+This will not work well with `-Xfatal-warnings` and/or `-Werror` Scala compiler options. 
+To mitigate this, you can specify a profile where the scala maven plugin uses different set of compiler flags.
 
 ```xml
     <profile>
@@ -31,7 +31,8 @@ To mitigate this, you can specify a profile where scala maven plugin uses differ
     </profile>
 ```
 
-Then you can activate this profile in `stryker4s-maven-plugin`'s `configuration` section
+Then you can activate this profile in `stryker4s-maven-plugin`'s `configuration` section. Or activate a profile from the command-line `mvn stryker4s:run -P stryker4s`.
+
 ```xml
     <plugin>
         <groupId>io.stryker-mutator</groupId>

--- a/maven/src/main/scala/stryker4s/maven/runner/MavenMutantRunner.scala
+++ b/maven/src/main/scala/stryker4s/maven/runner/MavenMutantRunner.scala
@@ -55,6 +55,7 @@ class MavenMutantRunner(project: MavenProject, invoker: Invoker, sourceCollector
       .setOutputHandler(debug(_))
       .setBatchMode(true)
       .setProperties(context.properties)
+      .setProfiles(project.getActiveProfiles.asScala.map(_.getId).asJava)
 
   private def createRequestWithMutation(mutant: Mutant, context: Context): InvocationRequest =
     createRequest(context)


### PR DESCRIPTION
### Fixes #541 

#### What it does

Propagate active profiles from stryker4s maven plugin configuration to stryker runs, which allows to change different settings specifically for stryker4s runs 