### PR TITLE
Filter out mutants that are in `val`s in an object

### DIFF
--- a/core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala
@@ -116,7 +116,7 @@ class MutantFinderTest extends Stryker4sSuite with LogMatchers {
                   }
                   @Annotation("Object Annotation")
                   object Foo {
-                    val value = "value"
+                    val value = () => "value"
                   }
           """
 
@@ -145,7 +145,7 @@ class MutantFinderTest extends Stryker4sSuite with LogMatchers {
                   }
                   @SuppressWarnings(Array("stryker4s.mutation.StringLiteral"))
                   object Foo {
-                    val value = "s5"
+                    val value = () => "s5"
                   }
           """
 


### PR DESCRIPTION
With #492, mutations that are initialized the moment the JVM is started cannot be tested. Examples of these mutations are when a `val` is directly inside an `object` like so:

```scala
object Foo {
  val bar = "42"
}
```

Because the JVM is only started once, the active mutation is checked and activated only once (on initialization), subsequent mutation runs will never properly activate the mutation and the mutant will always be `Survived`.

This PR filters out mutations when they are directly a `val` inside an `object`. This is a 'best guess' at filtering out these situations. If the mutation is inside a function it is not filtered out:

```scala
object Foo {
  // Filtered out
  val bar = "42"

  // Filtered out
  val bar2 = a.b("42")

  // Filtered out
  val bar3 = new Person("42")

  // Filtered out
  val bar4 = {
    val a = calculation()
    a + "42"
  }

  // Not filtered out
  val bar5 = () => "42"
}
```

@nicojs Thoughts on the solution (not necessarily the implementation)? I know you've run into something similar with mutation switching for Stryker JS.