### PR TITLE
Fix topStatement for argument Assign terms

### DIFF
--- a/core/src/main/scala/stryker4s/extension/TreeExtensions.scala
+++ b/core/src/main/scala/stryker4s/extension/TreeExtensions.scala
@@ -53,6 +53,7 @@ object TreeExtensions {
           case _: Term.Block    => true
           case _: Term.If       => true
           case _: Term.ForYield => true
+          case _: Term.Assign   => true
           case _                => false
         }
     }

--- a/core/src/test/scala/stryker4s/extension/TreeExtensionsTest.scala
+++ b/core/src/test/scala/stryker4s/extension/TreeExtensionsTest.scala
@@ -129,12 +129,12 @@ class TreeExtensionsTest extends Stryker4sSuite {
     }
 
     it("should not include if statement") {
-      val tree = q"def foo(x: Int) = if(x > 5) x > 10"
-      val subTree = tree.find(q"10").value
+      val tree = q"def foo(x: Int) = if(x > 5) x < 10"
+      val subTree = tree.find(q"<").value
 
       val result = subTree.topStatement()
 
-      assert(result.isEqual(q"x > 10"))
+      assert(result.isEqual(q"x < 10"))
     }
 
     it("should not include if statement if expression is in the if statement") {
@@ -312,6 +312,24 @@ class TreeExtensionsTest extends Stryker4sSuite {
       val result = subTree.topStatement()
 
       assert(result.isEqual(q"baz.qux"))
+    }
+
+    it("should stop at named argument assignments") {
+      val tree = q"def foo = bar(baz = true)"
+      val subTree = tree.find(q"true").value
+
+      val result = subTree.topStatement()
+
+      assert(result.isEqual(q"true"))
+    }
+
+    it("should stop at named argument assignments for inheritance assignment") {
+      val tree = q"case object GZIP extends Header(juzDeflaterNoWrap = true)"
+      val subTree = tree.find(q"true").value
+
+      val result = subTree.topStatement()
+
+      assert(result.isEqual(q"true"))
     }
   }
 


### PR DESCRIPTION
With the statement `def foo = bar(baz = true)` the `topStatement` of `true` would be `baz = true` which creates incorrect mutated code that doesn't compile. It is now just `true`.