### PR TITLE
Fix mutations in `case` statements not always being added

### DIFF
--- a/core/src/main/scala/stryker4s/extension/TreeExtensions.scala
+++ b/core/src/main/scala/stryker4s/extension/TreeExtensions.scala
@@ -29,7 +29,7 @@ object TreeExtensions {
         case _                            => thisTerm
       }
 
-    /** Extractor object to check if the [[scala.meta.Term]] is inside a pattern match
+    /** Extractor object to check if the [[scala.meta.Term]] part of a pattern match (but not in the body of the pattern match)
       */
     private object ParentIsPatternMatch {
 
@@ -37,7 +37,7 @@ object TreeExtensions {
         */
       final def unapply(term: Term): Option[Term] =
         findParent[Case](term)
-          .filterNot(_.parent.exists(_.isInstanceOf[Term.Try]))
+          .filter(c => c.cond.exists(_.find(term).isDefined) || c.pat.find(term).isDefined)
           .flatMap(findParent[Term])
 
       private def findParent[T <: Tree](tree: Tree)(implicit classTag: ClassTag[T]): Option[T] =

--- a/core/src/main/scala/stryker4s/extension/mutationtype/StringLiteral.scala
+++ b/core/src/main/scala/stryker4s/extension/mutationtype/StringLiteral.scala
@@ -13,10 +13,6 @@ case object StrykerWasHereString extends StringLiteral[Lit.String] {
   override val tree: Lit.String = Lit.String("Stryker was here!")
 }
 
-case object EmptyStringInterpolation extends StringLiteral[Term.Interpolate] {
-  override val tree: Term.Interpolate = Term.Interpolate(Term.Name("s"), List(Lit.String("")), Nil)
-}
-
 /** Not a mutation, just an extractor for pattern matching on empty string
   */
 case object NonEmptyString {

--- a/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
+++ b/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
@@ -69,7 +69,7 @@ class MutantMatcher()(implicit config: Config) {
   def matchStringLiteral: PartialFunction[Tree, Seq[Option[Mutant]]] = {
     case EmptyString(orig)         => orig ~~> StrykerWasHereString
     case NonEmptyString(orig)      => orig ~~> EmptyString
-    case StringInterpolation(orig) => orig ~~> EmptyStringInterpolation
+    case StringInterpolation(orig) => orig ~~> EmptyString
   }
 
   implicit class TermExtensions(original: Term) {

--- a/core/src/test/scala/stryker4s/extension/TreeExtensionsTest.scala
+++ b/core/src/test/scala/stryker4s/extension/TreeExtensionsTest.scala
@@ -236,6 +236,20 @@ class TreeExtensionsTest extends Stryker4sSuite {
       assert(result.isEqual(q"variable match { case GET -> Root / $hello => 3; case _ => 4 }"))
     }
 
+    it("should stop before the body of a Case") {
+      val pf = q"{ case false => { foo(1); 2 }; case _ => 3 }"
+      val defTree =
+        q"""def foo: PartialFunction[Boolean, Int] = {
+            val foo = bar
+            $pf
+          }"""
+      val subTree = defTree.find(q"1").value
+
+      val result = subTree.topStatement()
+
+      assert(result.isEqual(q"foo(1)"))
+    }
+
     it("should match on a Literal") {
       val tree = q"def foo = list.map(_ == 4)"
       val subTree = tree.find(q"4").value

--- a/core/src/test/scala/stryker4s/mutants/AddAllMutationsTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/AddAllMutationsTest.scala
@@ -1,0 +1,42 @@
+package stryker4s.mutants
+
+import scala.meta._
+
+import stryker4s.config.Config
+import stryker4s.extension.TreeExtensions._
+import stryker4s.mutants.applymutants.{ActiveMutationContext, MatchBuilder, StatementTransformer}
+import stryker4s.mutants.findmutants.MutantMatcher
+import stryker4s.scalatest.LogMatchers
+import stryker4s.testutil.Stryker4sSuite
+
+class AddAllMutationsTest extends Stryker4sSuite with LogMatchers {
+
+  describe("failed to add mutations") {
+    implicit val config = Config.default
+
+    it("#586 (second function call with `case`)") {
+      checkAllMutationsAreAdded(q"""serviceProvider
+              .request { _ => 4 > 5 }
+              .recoverWith {
+                case e: Throwable =>
+                  logger.info(s"Something failed")
+              }""")
+    }
+
+    def checkAllMutationsAreAdded(tree: Stat) = {
+      val source = source"class Foo { $tree }"
+      val foundMutants = source.collect(new MutantMatcher().allMatchers).flatten.flatten
+      val transformed = new StatementTransformer().transformSource(source, foundMutants)
+      val mutatedTree = new MatchBuilder(ActiveMutationContext.envVar).buildNewSource(transformed)
+      foundMutants.foreach(mutant =>
+        mutatedTree
+          .find(mutant.mutated)
+          .map(_ => succeed)
+          .getOrElse(
+            fail(s"Could not find mutation ${mutant.original} (${mutant.mutated}) in mutated tree ${mutatedTree}")
+          )
+      )
+      "Failed to add mutation(s)" should not be loggedAsWarning
+    }
+  }
+}

--- a/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
@@ -37,7 +37,7 @@ class MutatorTest extends Stryker4sSuite with LogMatchers {
                        |  }
                        |  def foobar = _root_.scala.sys.props.get("ACTIVE_MUTATION") match {
                        |    case Some("3") =>
-                       |      s""
+                       |      ""
                        |    case _ =>
                        |      s"${bar}foo"
                        |  }

--- a/core/src/test/scala/stryker4s/mutants/applymutants/MatchBuilderTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/applymutants/MatchBuilderTest.scala
@@ -68,7 +68,7 @@ class MatchBuilderTest extends Stryker4sSuite with LogMatchers {
 
     it("should log mutations that couldn't be applied") {
       // Arrange
-      val source = """class Foo { def bar: Boolean = 15 > 14 }""".parse[Source].get
+      val source = source"""class Foo { def bar: Boolean = 15 > 14 }"""
 
       val failedMutants = List(
         Mutant(0, q"foo", q"bar", GreaterThan),
@@ -107,7 +107,7 @@ class MatchBuilderTest extends Stryker4sSuite with LogMatchers {
     it("should build a new tree with a case match in place of the 15 > 14 statement") {
       // Arrange
       implicit val ids: Iterator[Int] = Iterator.from(0)
-      val source = "class Foo { def bar: Boolean = 15 > 14 }".parse[Source].get
+      val source = source"class Foo { def bar: Boolean = 15 > 14 }"
 
       val transformed = toTransformed(source, GreaterThan, q">", q"<", q"==", q">=")
       val transStatements =
@@ -119,25 +119,25 @@ class MatchBuilderTest extends Stryker4sSuite with LogMatchers {
 
       // Assert
       val expected =
-        """class Foo {
-          |  def bar: Boolean = _root_.scala.sys.props.get("ACTIVE_MUTATION") match {
-          |    case Some("0") =>
-          |      15 < 14
-          |    case Some("1") =>
-          |      15 == 14
-          |    case Some("2") =>
-          |      15 >= 14
-          |    case _ =>
-          |      15 > 14
-          |  }
-          |}""".stripMargin.parse[Source].get
+        source"""class Foo {
+                   def bar: Boolean = _root_.scala.sys.props.get("ACTIVE_MUTATION") match {
+                     case Some("0") =>
+                       15 < 14
+                     case Some("1") =>
+                       15 == 14
+                     case Some("2") =>
+                       15 >= 14
+                     case _ =>
+                       15 > 14
+                   }
+                 }"""
       assert(result.isEqual(expected))
     }
 
     it("should build a tree with multiple cases out of multiple transformedStatements") {
       // Arrange
       implicit val ids: Iterator[Int] = Iterator.from(0)
-      val source = "class Foo { def bar: Boolean = 15 > 14 && 14 >= 13 }".parse[Source].get
+      val source = source"class Foo { def bar: Boolean = 15 > 14 && 14 >= 13 }"
       val firstTrans = toTransformed(source, GreaterThan, q">", q"<", q"==", q">=")
       val secondTrans = toTransformed(source, GreaterThanEqualTo, q">=", q">", q"==", q"<")
 
@@ -149,31 +149,31 @@ class MatchBuilderTest extends Stryker4sSuite with LogMatchers {
 
       // Assert
       val expected =
-        """class Foo {
-          |  def bar: Boolean = _root_.scala.sys.props.get("ACTIVE_MUTATION") match {
-          |    case Some("0") =>
-          |      15 < 14 && 14 >= 13
-          |    case Some("1") =>
-          |      15 == 14 && 14 >= 13
-          |    case Some("2") =>
-          |      15 >= 14 && 14 >= 13
-          |    case Some("3") =>
-          |      15 > 14 && 14 > 13
-          |    case Some("4") =>
-          |      15 > 14 && 14 == 13
-          |    case Some("5") =>
-          |      15 > 14 && 14 < 13
-          |    case _ =>
-          |      15 > 14 && 14 >= 13
-          |  }
-          |}""".stripMargin.parse[Source].get
+        source"""class Foo {
+                   def bar: Boolean = _root_.scala.sys.props.get("ACTIVE_MUTATION") match {
+                     case Some("0") =>
+                       15 < 14 && 14 >= 13
+                     case Some("1") =>
+                       15 == 14 && 14 >= 13
+                     case Some("2") =>
+                       15 >= 14 && 14 >= 13
+                     case Some("3") =>
+                       15 > 14 && 14 > 13
+                     case Some("4") =>
+                       15 > 14 && 14 == 13
+                     case Some("5") =>
+                       15 > 14 && 14 < 13
+                     case _ =>
+                       15 > 14 && 14 >= 13
+                   }
+                 }"""
       assert(result.isEqual(expected))
     }
 
     it("should build a new tree out of a single statement with 3 mutants") {
       // Arrange
       implicit val ids: Iterator[Int] = Iterator.from(0)
-      val source = """class Foo { def foo = "foo" == "" }""".parse[Source].get
+      val source = source"""class Foo { def foo = "foo" == "" }"""
 
       val firstTransformed = toTransformed(source, NotEqualTo, q"==", q"!=")
       val secondTransformed = toTransformed(source, EmptyString, Lit.String("foo"), Lit.String(""))
@@ -229,31 +229,40 @@ class MatchBuilderTest extends Stryker4sSuite with LogMatchers {
 
       // Assert
       val expected = source"""class Foo(list: Seq[String]) {
-                                def foo =
-                                  _root_.scala.sys.props.get("ACTIVE_MUTATION") match {
-                                    case Some("0") =>
-                                      list.isEmpty match {
-                                        case true => "nonEmpty"
-                                        case _    => otherValue
-                                      }
-                                    case Some("1") =>
-                                      list.nonEmpty match {
-                                        case false => "nonEmpty"
-                                        case _     => otherValue
-                                      }
-                                    case Some("2") =>
-                                      list.nonEmpty match {
-                                        case true => ""
-                                        case _    => otherValue
-                                      }
-                                    case _ =>
-                                      list.nonEmpty match {
-                                        case true => "nonEmpty"
-                                        case _    => otherValue
-                                      }
-                                  }
-                              }
-                              """
+                                def foo = 
+                                _root_.scala.sys.props.get("ACTIVE_MUTATION") match {
+                                  case Some("0") =>
+                                    list.isEmpty match {
+                                      case true =>
+                                        _root_.scala.sys.props.get("ACTIVE_MUTATION") match {
+                                          case Some("2") => ""
+                                          case _         => "nonEmpty"
+                                        }
+                                      case _ =>
+                                        otherValue
+                                    }
+                                  case Some("1") =>
+                                    list.nonEmpty match {
+                                      case false =>
+                                        _root_.scala.sys.props.get("ACTIVE_MUTATION") match {
+                                          case Some("2") => ""
+                                          case _         => "nonEmpty"
+                                        }
+                                      case _ =>
+                                        otherValue
+                                    }
+                                  case _ =>
+                                    list.nonEmpty match {
+                                      case true =>
+                                        _root_.scala.sys.props.get("ACTIVE_MUTATION") match {
+                                          case Some("2") => ""
+                                          case _         => "nonEmpty"
+                                        }
+                                      case _ =>
+                                        otherValue
+                                    }
+                                }
+                              }"""
       assert(result.isEqual(expected))
     }
 
@@ -315,7 +324,7 @@ class MatchBuilderTest extends Stryker4sSuite with LogMatchers {
     it("should build a pattern match with sys.props if sysProps is given") {
       val sut = new MatchBuilder(ActiveMutationContext.sysProps)
       implicit val ids: Iterator[Int] = Iterator.from(0)
-      val source = """class Foo { def foo = "foo" == "" }""".parse[Source].get
+      val source = source"""class Foo { def foo = "foo" == "" }"""
       val transformed = toTransformed(source, EmptyString, Lit.String("foo"), Lit.String(""))
 
       val result = sut.buildMatch(transformed)
@@ -326,7 +335,7 @@ class MatchBuilderTest extends Stryker4sSuite with LogMatchers {
     it("should build a pattern match with sys.env if envVar is given") {
       val sut = new MatchBuilder(ActiveMutationContext.envVar)
       implicit val ids: Iterator[Int] = Iterator.from(0)
-      val source = """class Foo { def foo = "foo" == "" }""".parse[Source].get
+      val source = source"""class Foo { def foo = "foo" == "" }"""
       val transformed = toTransformed(source, EmptyString, Lit.String("foo"), Lit.String(""))
 
       val result = sut.buildMatch(transformed)

--- a/core/src/test/scala/stryker4s/mutants/findmutants/MutantMatcherTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/MutantMatcherTest.scala
@@ -328,14 +328,14 @@ class MutantMatcherTest extends Stryker4sSuite {
       val interpolated =
         Term.Interpolate(q"s", List(Lit.String("interpolate "), Lit.String("")), List(q"foo"))
       val tree = q"def foo = $interpolated"
-      val emptyStringInterpolate = Term.Interpolate(q"s", List(Lit.String("")), Nil)
+      val emptyString = Lit.String("")
 
       interpolated.syntax should equal("s\"interpolate $foo\"")
       expectMutations(
         sut.matchStringLiteral,
         tree,
         interpolated,
-        emptyStringInterpolate
+        emptyString
       )
     }
 
@@ -347,14 +347,14 @@ class MutantMatcherTest extends Stryker4sSuite {
           List(q"fooVar", q"barVar + 1")
         )
       val tree = q"def foo = $interpolated"
-      val emptyStringInterpolate = Term.Interpolate(q"s", List(Lit.String("")), Nil)
+      val emptyString = Lit.String("")
 
       interpolated.syntax should equal("s\"interpolate $fooVar foo ${barVar" + " + 1} bar\"")
       expectMutations(
         sut.matchStringLiteral,
         tree,
         interpolated,
-        emptyStringInterpolate
+        emptyString
       )
     }
 


### PR DESCRIPTION
### Fixes #586

#### What it does

Mutations in `case` statements were not always added to mutated code. It is now 🎉

#### How it works

Changes in `topStatement` so it will stop at the body of a case instead of stopping at the `topStatement` of the case itself
