### PR TITLE
Set up cats-effect-testing-scalatest

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - chore/setup-scalatest-cats-effect
 
 jobs:
   core:

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - chore/setup-scalatest-cats-effect
 
 jobs:
   core:

--- a/core/src/main/scala/stryker4s/run/TestRunner.scala
+++ b/core/src/main/scala/stryker4s/run/TestRunner.scala
@@ -59,7 +59,7 @@ object TestRunner {
       }
     }
 
-  def retryRunner(inner: Resource[IO, TestRunner]): Resource[IO, TestRunner] =
+  def retryRunner(inner: Resource[IO, TestRunner])(implicit cs: ContextShift[IO]): Resource[IO, TestRunner] =
     inner.selfRecreatingResource { (testRunnerRef, releaseAndSwap) =>
       IO {
         new TestRunner with Logging {
@@ -90,7 +90,9 @@ object TestRunner {
       }
     }
 
-  def maxReuseTestRunner(maxReuses: Int, inner: Resource[IO, TestRunner]): Resource[IO, TestRunner] =
+  def maxReuseTestRunner(maxReuses: Int, inner: Resource[IO, TestRunner])(implicit
+      cs: ContextShift[IO]
+  ): Resource[IO, TestRunner] =
     inner.selfRecreatingResource { (testRunnerRef, releaseAndSwap) =>
       Ref[IO].of(0).map { usesRef =>
         new TestRunner with Logging {

--- a/core/src/test/scala/stryker4s/Stryker4sTest.scala
+++ b/core/src/test/scala/stryker4s/Stryker4sTest.scala
@@ -19,9 +19,9 @@ import stryker4s.run.MutantRunner
 import stryker4s.run.threshold.SuccessStatus
 import stryker4s.scalatest.{FileUtil, LogMatchers}
 import stryker4s.testutil.stubs.{TestProcessRunner, TestSourceCollector}
-import stryker4s.testutil.{MockitoSuite, Stryker4sSuite}
+import stryker4s.testutil.{MockitoIOSuite, Stryker4sIOSuite}
 
-class Stryker4sTest extends Stryker4sSuite with MockitoSuite with Inside with LogMatchers {
+class Stryker4sTest extends Stryker4sIOSuite with MockitoIOSuite with Inside with LogMatchers {
   implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
 
   case class TestTestRunnerContext() extends TestRunnerContext
@@ -37,16 +37,17 @@ class Stryker4sTest extends Stryker4sSuite with MockitoSuite with Inside with Lo
   }
 
   describe("run") {
-    val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
-    val testFiles = Seq(file)
-    val testSourceCollector = new TestSourceCollector(testFiles)
-    val testProcessRunner = TestProcessRunner(Success(1), Success(1), Success(1), Success(1))
-    val reporterMock = mock[AggregateReporter]
-    when(reporterMock.reportRunFinished(any[FinishedRunReport])).thenReturn(IO.unit)
-    when(reporterMock.reportMutationComplete(any[MutantRunResult], anyInt)).thenReturn(IO.unit)
-    when(reporterMock.reportMutationStart(any[Mutant])).thenReturn(IO.unit)
 
     it("should call mutate files and report the results") {
+      val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
+      val testFiles = Seq(file)
+      val testSourceCollector = new TestSourceCollector(testFiles)
+      val testProcessRunner = TestProcessRunner(Success(1), Success(1), Success(1), Success(1))
+      val reporterMock = mock[AggregateReporter]
+      when(reporterMock.reportRunFinished(any[FinishedRunReport])).thenReturn(IO.unit)
+      when(reporterMock.reportMutationComplete(any[MutantRunResult], anyInt)).thenReturn(IO.unit)
+      when(reporterMock.reportMutationStart(any[Mutant])).thenReturn(IO.unit)
+
       implicit val conf: Config = Config(baseDir = FileUtil.getResource("scalaFiles"))
 
       val testMutantRunner = new TestMutantRunner(new FileCollector(testProcessRunner), reporterMock)
@@ -61,21 +62,21 @@ class Stryker4sTest extends Stryker4sSuite with MockitoSuite with Inside with Lo
         testMutantRunner
       )
 
-      val result = sut.run().unsafeRunSync()
+      sut.run().asserting { result =>
+        val startCaptor = ArgCaptor[Mutant]
+        verify(reporterMock, times(4)).reportMutationStart(startCaptor)
+        startCaptor.values should matchPattern {
+          case List(Mutant(0, _, _, _), Mutant(1, _, _, _), Mutant(2, _, _, _), Mutant(3, _, _, _)) =>
+        }
+        val runReportMock = ArgCaptor[FinishedRunReport]
+        verify(reporterMock).reportRunFinished(runReportMock)
+        val FinishedRunReport(reportedResults, _, _, _) = runReportMock.value
 
-      val startCaptor = ArgCaptor[Mutant]
-      verify(reporterMock, times(4)).reportMutationStart(startCaptor)
-      startCaptor.values should matchPattern {
-        case List(Mutant(0, _, _, _), Mutant(1, _, _, _), Mutant(2, _, _, _), Mutant(3, _, _, _)) =>
-      }
-      val runReportMock = ArgCaptor[FinishedRunReport]
-      verify(reporterMock).reportRunFinished(runReportMock)
-      val FinishedRunReport(reportedResults, _, _, _) = runReportMock.value
-
-      result shouldBe SuccessStatus
-      reportedResults.files.flatMap(_._2.mutants) should have size 4
-      reportedResults.files.foreach { case (path, _) =>
-        path shouldBe "simpleFile.scala"
+        reportedResults.files.flatMap(_._2.mutants) should have size 4
+        reportedResults.files.map { case (path, _) =>
+          path shouldBe "simpleFile.scala"
+        }
+        result shouldBe SuccessStatus
       }
     }
   }

--- a/core/src/test/scala/stryker4s/Stryker4sTest.scala
+++ b/core/src/test/scala/stryker4s/Stryker4sTest.scala
@@ -1,11 +1,10 @@
 package stryker4s
 
-import scala.concurrent.ExecutionContext
 import scala.meta._
 import scala.util.Success
 
 import better.files.File
-import cats.effect.{IO, Resource, Timer}
+import cats.effect.{IO, Resource}
 import org.mockito.captor.ArgCaptor
 import org.scalatest.Inside
 import stryker4s.config.Config
@@ -22,7 +21,6 @@ import stryker4s.testutil.stubs.{TestProcessRunner, TestSourceCollector}
 import stryker4s.testutil.{MockitoIOSuite, Stryker4sIOSuite}
 
 class Stryker4sTest extends Stryker4sIOSuite with MockitoIOSuite with Inside with LogMatchers {
-  implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
 
   case class TestTestRunnerContext() extends TestRunnerContext
   class TestMutantRunner(sourceCollector: SourceCollector, reporter: Reporter)(implicit config: Config)

--- a/core/src/test/scala/stryker4s/extension/CatsEffectExtensionsTest.scala
+++ b/core/src/test/scala/stryker4s/extension/CatsEffectExtensionsTest.scala
@@ -4,36 +4,34 @@ import scala.concurrent.duration._
 
 import cats.effect.{Clock, IO}
 import stryker4s.extension.CatsEffectExtensions._
-import stryker4s.testutil.Stryker4sSuite
+import stryker4s.testutil.Stryker4sIOSuite
 
-class CatsEffectExtensionsTest extends Stryker4sSuite {
+class CatsEffectExtensionsTest extends Stryker4sIOSuite {
 
   describe("timed") {
     it("should give the time an execution takes") {
       implicit val clock: Clock[IO] = counterClock
 
-      val (_, duration) = IO.unit.timed.unsafeRunSync()
-
-      duration shouldBe 50.millis
+      IO.unit.timed
+        .asserting(_._2 shouldBe 50.millis)
     }
 
     it("should increase over longer execution times") {
       implicit val clock: Clock[IO] = counterClock
 
-      val ((_, firstDuration), secondDuration) =
-        // starttime 0
-        IO.unit
-          .flatMap(_ =>
-            // starttime 50
-            IO.unit.timed
-          // endTime 100
-          )
-          .timed
-          // endtime 150
-          .unsafeRunSync()
-
-      firstDuration shouldBe 50.millis
-      secondDuration shouldBe 150.millis
+      // starttime 0
+      IO.unit
+        .flatMap(_ =>
+          // starttime 50
+          IO.unit.timed
+        // endTime 100
+        )
+        .timed
+        // endtime 150
+        .asserting { case ((_, firstDuration), secondDuration) =>
+          firstDuration shouldBe 50.millis
+          secondDuration shouldBe 150.millis
+        }
     }
 
     /** A 'clock' that counts the number of times it is invoked

--- a/core/src/test/scala/stryker4s/extension/ResourceExtensionsTest.scala
+++ b/core/src/test/scala/stryker4s/extension/ResourceExtensionsTest.scala
@@ -1,9 +1,9 @@
 package stryker4s.extension
 
+import cats.effect.concurrent.Ref
 import cats.effect.{IO, Resource}
 import stryker4s.extension.ResourceExtensions.SelfRecreatingResource
 import stryker4s.testutil.Stryker4sIOSuite
-import cats.effect.concurrent.Ref
 
 class ResourceExtensionsTest extends Stryker4sIOSuite {
   describe("selfRecreatingResource") {

--- a/core/src/test/scala/stryker4s/report/DashboardReporterTest.scala
+++ b/core/src/test/scala/stryker4s/report/DashboardReporterTest.scala
@@ -9,11 +9,11 @@ import stryker4s.config.{Full, MutationScoreOnly}
 import stryker4s.report.dashboard.DashboardConfigProvider
 import stryker4s.report.model.{DashboardConfig, DashboardPutResult}
 import stryker4s.scalatest.LogMatchers
-import stryker4s.testutil.{MockitoSuite, Stryker4sSuite}
+import stryker4s.testutil.{MockitoIOSuite, Stryker4sIOSuite}
 import sttp.client._
 import sttp.model.{Header, MediaType, Method, StatusCode}
 
-class DashboardReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
+class DashboardReporterTest extends Stryker4sIOSuite with MockitoIOSuite with LogMatchers {
   describe("buildRequest") {
     it("should compose the request") {
       implicit val backend = backendStub
@@ -74,9 +74,9 @@ class DashboardReporterTest extends Stryker4sSuite with MockitoSuite with LogMat
 
       sut
         .reportRunFinished(runReport)
-        .unsafeRunSync()
-
-      "Sent report to dashboard. Available at https://hrefHere.com" shouldBe loggedAsInfo
+        .asserting { _ =>
+          "Sent report to dashboard. Available at https://hrefHere.com" shouldBe loggedAsInfo
+        }
     }
 
     it("log when not being able to resolve dashboard config") {
@@ -88,9 +88,9 @@ class DashboardReporterTest extends Stryker4sSuite with MockitoSuite with LogMat
 
       sut
         .reportRunFinished(runReport)
-        .unsafeRunSync()
-
-      "Could not resolve dashboard configuration key 'fooConfigKey', not sending report" shouldBe loggedAsWarning
+        .asserting { _ =>
+          "Could not resolve dashboard configuration key 'fooConfigKey', not sending report" shouldBe loggedAsWarning
+        }
     }
 
     it("should log when a response can't be parsed to a href") {
@@ -102,9 +102,9 @@ class DashboardReporterTest extends Stryker4sSuite with MockitoSuite with LogMat
 
       sut
         .reportRunFinished(runReport)
-        .unsafeRunSync()
-
-      "Dashboard report was sent successfully, but could not decode the response: 'some other response'. Error:" shouldBe loggedAsWarning
+        .asserting { _ =>
+          "Dashboard report was sent successfully, but could not decode the response: 'some other response'. Error:" shouldBe loggedAsWarning
+        }
     }
 
     it("should log when a 401 is returned by the API") {
@@ -117,9 +117,9 @@ class DashboardReporterTest extends Stryker4sSuite with MockitoSuite with LogMat
 
       sut
         .reportRunFinished(runReport)
-        .unsafeRunSync()
-
-      "Error HTTP PUT 'auth required'. Status code 401 Unauthorized. Did you provide the correct api key in the 'STRYKER_DASHBOARD_API_KEY' environment variable?" shouldBe loggedAsError
+        .asserting { _ =>
+          "Error HTTP PUT 'auth required'. Status code 401 Unauthorized. Did you provide the correct api key in the 'STRYKER_DASHBOARD_API_KEY' environment variable?" shouldBe loggedAsError
+        }
     }
 
     it("should log when a error code is returned by the API") {
@@ -134,9 +134,9 @@ class DashboardReporterTest extends Stryker4sSuite with MockitoSuite with LogMat
 
       sut
         .reportRunFinished(runReport)
-        .unsafeRunSync()
-
-      "Failed to PUT report to dashboard. Response status code: 500. Response body: 'internal error'" shouldBe loggedAsError
+        .asserting { _ =>
+          "Failed to PUT report to dashboard. Response status code: 500. Response body: 'internal error'" shouldBe loggedAsError
+        }
     }
   }
 

--- a/core/src/test/scala/stryker4s/report/HtmlReporterTest.scala
+++ b/core/src/test/scala/stryker4s/report/HtmlReporterTest.scala
@@ -5,15 +5,14 @@ import java.nio.file.{Path, Paths}
 import scala.concurrent.duration._
 
 import better.files.File
-import cats.effect.IO
+import cats.effect.{Blocker, IO}
+import fs2._
+import fs2.io.file
 import mutationtesting.{Metrics, MutationTestReport, Thresholds}
 import org.mockito.captor.ArgCaptor
 import stryker4s.files.{DiskFileIO, FileIO}
 import stryker4s.scalatest.LogMatchers
 import stryker4s.testutil.{MockitoIOSuite, Stryker4sIOSuite}
-import cats.effect.Blocker
-import fs2.io.file
-import fs2._
 
 class HtmlReporterTest extends Stryker4sIOSuite with MockitoIOSuite with LogMatchers {
 

--- a/core/src/test/scala/stryker4s/report/HtmlReporterTest.scala
+++ b/core/src/test/scala/stryker4s/report/HtmlReporterTest.scala
@@ -1,5 +1,6 @@
 package stryker4s.report
-import java.nio.file.Path
+
+import java.nio.file.{Path, Paths}
 
 import scala.concurrent.duration._
 
@@ -9,9 +10,12 @@ import mutationtesting.{Metrics, MutationTestReport, Thresholds}
 import org.mockito.captor.ArgCaptor
 import stryker4s.files.{DiskFileIO, FileIO}
 import stryker4s.scalatest.LogMatchers
-import stryker4s.testutil.{MockitoSuite, Stryker4sSuite}
+import stryker4s.testutil.{MockitoIOSuite, Stryker4sIOSuite}
+import cats.effect.Blocker
+import fs2.io.file
+import fs2._
 
-class HtmlReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
+class HtmlReporterTest extends Stryker4sIOSuite with MockitoIOSuite with LogMatchers {
 
   private val elementsLocation = "/mutation-testing-elements/mutation-test-elements.js"
 
@@ -41,9 +45,10 @@ class HtmlReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers
 
       sut
         .writeIndexHtmlTo(testFile)
-        .unsafeRunSync()
-
-      verify(mockFileIO).createAndWrite(testFile, expectedHtml)
+        .map { _ =>
+          verify(mockFileIO).createAndWrite(testFile, expectedHtml)
+        }
+        .assertNoException
     }
   }
 
@@ -57,28 +62,50 @@ class HtmlReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers
 
       sut
         .writeReportJsTo(testFile, runResults)
-        .unsafeRunSync()
-
-      val expectedJs =
-        """document.querySelector('mutation-test-report-app').report = {"$schema":"https://git.io/mutation-testing-report-schema","schemaVersion":"1","thresholds":{"high":100,"low":0},"files":{}}"""
-      verify(mockFileIO).createAndWrite(testFile, expectedJs)
+        .map { _ =>
+          val expectedJs =
+            """document.querySelector('mutation-test-report-app').report = {"$schema":"https://git.io/mutation-testing-report-schema","schemaVersion":"1","thresholds":{"high":100,"low":0},"files":{}}"""
+          verify(mockFileIO).createAndWrite(testFile, expectedJs)
+        }
+        .assertNoException
     }
   }
 
   describe("mutation-test-elements") {
     it("should write the resource") {
+      // Arrange
       val fileIO = new DiskFileIO()
 
-      File.usingTemporaryDirectory() { tmpDir =>
-        val tempFile = tmpDir / "mutation-test-elements.js"
-        val sut = new HtmlReporter(fileIO)
+      val targetPath = Paths.get("target/mte")
 
-        sut.writeMutationTestElementsJsTo(tempFile.path).attempt.unsafeRunSync()
+      Blocker[IO].use { blocker =>
+        file.createDirectories[IO](blocker, targetPath) *>
+          file.tempDirectoryResource[IO](blocker, targetPath).use { tmpDir =>
+            val tempFile = tmpDir.resolve("mutation-test-elements.js")
+            val sut = new HtmlReporter(fileIO)
 
-        val atLeastSize: Long = 100 * 1024L // 100KB
-        tempFile.size should be > atLeastSize
-        tempFile.lineIterator
-          .next() shouldEqual "/*! For license information please see mutation-test-elements.js.LICENSE.txt */"
+            // Act
+            sut
+              .writeMutationTestElementsJsTo(tempFile)
+              // Assert
+              .flatMap { _ =>
+                val atLeastSize: Long = 100 * 1024L // 100KB
+                file.size[IO](blocker, tempFile).asserting(_ should be > atLeastSize)
+              }
+              .flatMap { _ =>
+                val expectedHeader = "/*! For license information please see mutation-test-elements.js.LICENSE.txt */"
+                file
+                  // Read the first line
+                  .readRange[IO](tempFile, blocker, 256, 0, expectedHeader.getBytes().length.toLong)
+                  .through(text.utf8Decode)
+                  .head
+                  .compile
+                  .lastOrError
+                  .asserting(
+                    _ shouldBe expectedHeader
+                  )
+              }
+          }
       }
     }
   }
@@ -94,14 +121,14 @@ class HtmlReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers
 
       sut
         .reportRunFinished(FinishedRunReport(report, metrics, 0.seconds, File("target/stryker4s-report/")))
-        .unsafeRunSync()
-
-      val writtenFilesCaptor = ArgCaptor[Path]
-      verify(mockFileIO, times(2)).createAndWrite(writtenFilesCaptor, any[String])
-      verify(mockFileIO).createAndWriteFromResource(any[Path], eqTo(elementsLocation))
-      val paths = writtenFilesCaptor.values.map(_.toString())
-      all(paths) should include("/target/stryker4s-report/")
-      writtenFilesCaptor.values.map(_.getFileName().toString()) should contain.only("index.html", "report.js")
+        .asserting { _ =>
+          val writtenFilesCaptor = ArgCaptor[Path]
+          verify(mockFileIO, times(2)).createAndWrite(writtenFilesCaptor, any[String])
+          verify(mockFileIO).createAndWriteFromResource(any[Path], eqTo(elementsLocation))
+          val paths = writtenFilesCaptor.values.map(_.toString())
+          all(paths) should include("/target/stryker4s-report/")
+          writtenFilesCaptor.values.map(_.getFileName().toString()) should contain.only("index.html", "report.js")
+        }
     }
 
     it("should write the mutation-test-elements.js file to the report directory") {
@@ -114,13 +141,13 @@ class HtmlReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers
 
       sut
         .reportRunFinished(FinishedRunReport(report, metrics, 10.seconds, File("target/stryker4s-report/")))
-        .unsafeRunSync()
+        .asserting { _ =>
+          val elementsCaptor = ArgCaptor[Path]
+          verify(mockFileIO, times(2)).createAndWrite(any[Path], any[String])
+          verify(mockFileIO).createAndWriteFromResource(elementsCaptor, eqTo(elementsLocation))
 
-      val elementsCaptor = ArgCaptor[Path]
-      verify(mockFileIO, times(2)).createAndWrite(any[Path], any[String])
-      verify(mockFileIO).createAndWriteFromResource(elementsCaptor, eqTo(elementsLocation))
-
-      elementsCaptor.value.toString should endWith("/target/stryker4s-report/mutation-test-elements.js")
+          elementsCaptor.value.toString should endWith("/target/stryker4s-report/mutation-test-elements.js")
+        }
     }
 
     it("should info log a message") {
@@ -133,13 +160,13 @@ class HtmlReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers
       val reportFile = File("target/stryker4s-report/")
       sut
         .reportRunFinished(FinishedRunReport(report, metrics, 10.seconds, reportFile))
-        .unsafeRunSync()
-
-      val captor = ArgCaptor[Path]
-      verify(mockFileIO).createAndWrite(captor.capture, eqTo(expectedHtml))
-      verify(mockFileIO, times(2)).createAndWrite(any[Path], any[String])
-      verify(mockFileIO).createAndWriteFromResource(any[Path], any[String])
-      s"Written HTML report to ${reportFile.toString()}/index.html" shouldBe loggedAsInfo
+        .asserting { _ =>
+          val captor = ArgCaptor[Path]
+          verify(mockFileIO).createAndWrite(captor.capture, eqTo(expectedHtml))
+          verify(mockFileIO, times(2)).createAndWrite(any[Path], any[String])
+          verify(mockFileIO).createAndWriteFromResource(any[Path], any[String])
+          s"Written HTML report to ${reportFile.toString()}/index.html" shouldBe loggedAsInfo
+        }
     }
   }
 }

--- a/core/src/test/scala/stryker4s/report/ReporterTest.scala
+++ b/core/src/test/scala/stryker4s/report/ReporterTest.scala
@@ -9,9 +9,9 @@ import mutationtesting._
 import stryker4s.extension.mutationtype.GreaterThan
 import stryker4s.model.{Mutant, MutantRunResult}
 import stryker4s.scalatest.LogMatchers
-import stryker4s.testutil.{MockitoSuite, Stryker4sSuite}
+import stryker4s.testutil.{MockitoIOSuite, Stryker4sIOSuite}
 
-class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
+class ReporterTest extends Stryker4sIOSuite with MockitoIOSuite with LogMatchers {
   describe("reporter") {
     it("should log that the console reporter is used when a non existing reporter is configured") {
       val consoleReporterMock = mock[ConsoleReporter]
@@ -24,9 +24,10 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
 
       sut
         .reportRunFinished(runReport)
-        .unsafeRunSync()
-
-      verify(consoleReporterMock).reportRunFinished(runReport)
+        .map { _ =>
+          verify(consoleReporterMock).reportRunFinished(runReport)
+        }
+        .assertNoException
     }
 
     describe("reportMutationStart") {
@@ -39,10 +40,11 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
         val sut = new AggregateReporter(Seq(consoleReporterMock, progressReporterMock))
         sut
           .reportMutationStart(mutantMock)
-          .unsafeRunSync()
-
-        verify(consoleReporterMock).reportMutationStart(mutantMock)
-        verify(progressReporterMock).reportMutationStart(mutantMock)
+          .map { _ =>
+            verify(consoleReporterMock).reportMutationStart(mutantMock)
+            verify(progressReporterMock).reportMutationStart(mutantMock)
+          }
+          .assertNoException
       }
 
       it("Should not report to finishedRunReporters that is mutation run is started.") {
@@ -53,10 +55,11 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
         val sut = new AggregateReporter(Seq(consoleReporterMock, finishedRunReporterMock))
         sut
           .reportMutationStart(mutantMock)
-          .unsafeRunSync()
-
-        verify(consoleReporterMock).reportMutationStart(mutantMock)
-        verifyZeroInteractions(finishedRunReporterMock)
+          .map { _ =>
+            verify(consoleReporterMock).reportMutationStart(mutantMock)
+            verifyZeroInteractions(finishedRunReporterMock)
+          }
+          .assertNoException
       }
     }
 
@@ -71,10 +74,11 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
 
         sut
           .reportMutationComplete(mutantRunResultMock, 1)
-          .unsafeRunSync()
-
-        verify(consoleReporterMock).reportMutationComplete(mutantRunResultMock, 1)
-        verify(progressReporterMock).reportMutationComplete(mutantRunResultMock, 1)
+          .map { _ =>
+            verify(consoleReporterMock).reportMutationComplete(mutantRunResultMock, 1)
+            verify(progressReporterMock).reportMutationComplete(mutantRunResultMock, 1)
+          }
+          .assertNoException
       }
 
       it("should not report to finishedMutationRunReporters that a mutation run is completed") {
@@ -86,10 +90,11 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
 
         sut
           .reportMutationComplete(mutantRunResultMock, 1)
-          .unsafeRunSync()
-
-        verify(consoleReporterMock).reportMutationComplete(mutantRunResultMock, 1)
-        verifyZeroInteractions(finishedRunReporterMock)
+          .map { _ =>
+            verify(consoleReporterMock).reportMutationComplete(mutantRunResultMock, 1)
+            verifyZeroInteractions(finishedRunReporterMock)
+          }
+          .assertNoException
       }
     }
 
@@ -106,10 +111,11 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
 
         sut
           .reportRunFinished(runReport)
-          .unsafeRunSync()
-
-        verify(consoleReporterMock).reportRunFinished(runReport)
-        verify(finishedRunReporterMock).reportRunFinished(runReport)
+          .map { _ =>
+            verify(consoleReporterMock).reportRunFinished(runReport)
+            verify(finishedRunReporterMock).reportRunFinished(runReport)
+          }
+          .assertNoException
       }
 
       it("should not report a finished mutation run to a progress reporter") {
@@ -123,10 +129,11 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
 
         sut
           .reportRunFinished(runReport)
-          .unsafeRunSync()
-
-        verify(consoleReporterMock).reportRunFinished(runReport)
-        verifyZeroInteractions(progressReporterMock)
+          .map { _ =>
+            verify(consoleReporterMock).reportRunFinished(runReport)
+            verifyZeroInteractions(progressReporterMock)
+          }
+          .assertNoException
       }
 
       it("should still call other reporters if a reporter throws an exception") {
@@ -142,9 +149,10 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
 
         sut
           .reportRunFinished(runReport)
-          .unsafeRunSync()
-
-        verify(progressReporterMock).reportRunFinished(runReport)
+          .map { _ =>
+            verify(progressReporterMock).reportRunFinished(runReport)
+          }
+          .assertNoException
       }
 
       describe("logging") {
@@ -164,10 +172,10 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
 
           sut
             .reportRunFinished(runReport)
-            .unsafeRunSync()
-
-          failedToReportMessage shouldBe loggedAsWarning
-          exceptionMessage shouldBe loggedAsWarning
+            .map { _ =>
+              failedToReportMessage shouldBe loggedAsWarning
+              exceptionMessage shouldBe loggedAsWarning
+            }
         }
 
         it("should not log warnings if no exceptions occur") {
@@ -177,11 +185,11 @@ class ReporterTest extends Stryker4sSuite with MockitoSuite with LogMatchers {
 
           sut
             .reportRunFinished(runReport)
-            .unsafeRunSync()
-
-          verify(consoleReporterMock).reportRunFinished(runReport)
-          failedToReportMessage should not be loggedAsWarning
-          exceptionMessage should not be loggedAsWarning
+            .map { _ =>
+              verify(consoleReporterMock).reportRunFinished(runReport)
+              failedToReportMessage should not be loggedAsWarning
+              exceptionMessage should not be loggedAsWarning
+            }
         }
       }
     }

--- a/core/src/test/scala/stryker4s/testutil/MockitoSuite.scala
+++ b/core/src/test/scala/stryker4s/testutil/MockitoSuite.scala
@@ -1,8 +1,13 @@
 package stryker4s.testutil
+
 import org.mockito.scalatest.MockitoSugar
-import org.scalatest.Suite
 
 trait MockitoSuite extends MockitoSugar {
   // Will cause a compile error if MockitoSuite is used outside of a ScalaTest Suite
-  this: Suite =>
+  this: Stryker4sSuite =>
+}
+
+// AsyncMockitoSugar doesn't seem to work well with IO-based async tests
+trait MockitoIOSuite extends org.mockito.MockitoSugar with org.mockito.ArgumentMatchersSugar {
+  this: Stryker4sIOSuite =>
 }

--- a/core/src/test/scala/stryker4s/testutil/Stryker4sSuite.scala
+++ b/core/src/test/scala/stryker4s/testutil/Stryker4sSuite.scala
@@ -1,11 +1,15 @@
 package stryker4s.testutil
 
-import scala.concurrent.ExecutionContext
-
-import cats.effect.{ContextShift, IO}
-import org.scalatest.funspec.AnyFunSpec
+import cats.effect.testing.scalatest.{AssertingSyntax, AsyncIOSpec}
+import org.scalatest.funspec.{AnyFunSpec, AsyncFunSpec}
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.{LoneElement, OptionValues}
-abstract class Stryker4sSuite extends AnyFunSpec with Matchers with OptionValues with LoneElement {
-  implicit lazy val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
-}
+import org.scalatest.{LoneElement, OptionValues, Suite}
+
+private[testutil] trait Stryker4sBaseSuite extends Matchers with OptionValues with LoneElement { this: Suite => }
+
+abstract class Stryker4sSuite extends AnyFunSpec with Stryker4sBaseSuite
+
+/** Base suite making it easier to test IO-based code
+  * Every test is forced to return a `IO[scalatest.Assertion]`
+  */
+abstract class Stryker4sIOSuite extends AsyncFunSpec with Stryker4sBaseSuite with AsyncIOSpec with AssertingSyntax

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,6 +19,7 @@ object Dependencies {
     val scalameta = "4.3.24"
     val pureconfig = "0.14.0"
     val scalatest = "3.2.2"
+    val catsEffectScalaTest = "0.4.1"
     val mockitoScala = "1.16.0"
     val betterFiles = "3.9.1"
     val log4j = "2.13.3"
@@ -35,6 +36,8 @@ object Dependencies {
   object test {
     val scalatest = "org.scalatest" %% "scalatest" % versions.scalatest % Test
     val mockitoScala = "org.mockito" %% "mockito-scala-scalatest" % versions.mockitoScala % Test
+    // For easier testing with IO
+    val catsEffectScalaTest = "com.codecommit" %% "cats-effect-testing-scalatest" % versions.catsEffectScalaTest % Test
   }
 
   val testInterface = "org.scala-sbt" % "test-interface" % versions.testInterface

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -15,6 +15,7 @@ object Settings {
     libraryDependencies ++= Seq(
       Dependencies.test.scalatest,
       Dependencies.test.mockitoScala,
+      Dependencies.test.catsEffectScalaTest,
       Dependencies.pureconfig,
       Dependencies.pureconfigSttp,
       Dependencies.scalameta,


### PR DESCRIPTION
Sets up easier testing with cats-effect. Calling `.unsafeRunSync` is no longer required, and a test that returns an `IO` that is not an `IO[Assertion]` will cause a compile error
