### PR TITLE
HTML report body changes with theme

### DIFF
--- a/core/src/main/scala/stryker4s/report/HtmlReporter.scala
+++ b/core/src/main/scala/stryker4s/report/HtmlReporter.scala
@@ -28,6 +28,14 @@ class HtmlReporter(fileIO: FileIO)(implicit p: Parallel[IO]) extends FinishedRun
        |    Your browser doesn't support <a href="https://caniuse.com/#search=custom%20elements">custom elements</a>.
        |    Please use a latest version of an evergreen browser (Firefox, Chrome, Safari, Opera, etc).
        |  </mutation-test-report-app>
+       |  <script>
+       |    const app = document.getElementsByTagName('mutation-test-report-app').item(0)
+       |    function updateTheme() {
+       |      document.body.style.backgroundColor = app.theme === 'dark' ? '#222' : '#fff';
+       |    }
+       |    app.addEventListener('theme-changed', updateTheme);
+       |    updateTheme();
+       |  </script>
        |  <script src="$reportFilename"></script>
        |</body>
        |</html>""".stripMargin

--- a/core/src/test/scala/stryker4s/report/HtmlReporterTest.scala
+++ b/core/src/test/scala/stryker4s/report/HtmlReporterTest.scala
@@ -31,6 +31,14 @@ class HtmlReporterTest extends Stryker4sIOSuite with MockitoIOSuite with LogMatc
       |    Your browser doesn't support <a href="https://caniuse.com/#search=custom%20elements">custom elements</a>.
       |    Please use a latest version of an evergreen browser (Firefox, Chrome, Safari, Opera, etc).
       |  </mutation-test-report-app>
+      |  <script>
+      |    const app = document.getElementsByTagName('mutation-test-report-app').item(0)
+      |    function updateTheme() {
+      |      document.body.style.backgroundColor = app.theme === 'dark' ? '#222' : '#fff';
+      |    }
+      |    app.addEventListener('theme-changed', updateTheme);
+      |    updateTheme();
+      |  </script>
       |  <script src="report.js"></script>
       |</body>
       |</html>""".stripMargin


### PR DESCRIPTION
<!---
Thanks for your pull request 😄! Please fill in the information below so we can quickly review and merge your PR.

If you feel the template doesn't apply to your PR, feel free to ignore it
-->

### Fixes HTML report container not changing with the theme

#### What it does
When you change the theme of the HTML report, the background of the parent HTML page changes also.

#### How it works
The HTML report component dispatches a theme-changed event when the theme has changed. This solution listens for that event and changes the background of the body accordingly.