### PR TITLE
Use ScalaTests ExecutionContext when running AsyncSpec

### DIFF
--- a/command-runner/src/test/scala/stryker4s/run/ProcessMutantRunnerTest.scala
+++ b/command-runner/src/test/scala/stryker4s/run/ProcessMutantRunnerTest.scala
@@ -4,7 +4,6 @@ import scala.concurrent.TimeoutException
 import scala.meta._
 import scala.util.{Failure, Success}
 
-import cats.effect.IO
 import stryker4s.command.runner.ProcessMutantRunner
 import stryker4s.config.Config
 import stryker4s.extension.exception.InitialTestRunFailedException
@@ -15,16 +14,16 @@ import stryker4s.report.{AggregateReporter, FinishedRunReport}
 import stryker4s.run.process.Command
 import stryker4s.scalatest.{FileUtil, LogMatchers}
 import stryker4s.testutil.stubs.TestProcessRunner
-import stryker4s.testutil.{MockitoSuite, Stryker4sIOSuite}
+import stryker4s.testutil.{MockitoIOSuite, Stryker4sIOSuite}
 
-class ProcessMutantRunnerTest extends Stryker4sIOSuite with MockitoSuite with LogMatchers {
+class ProcessMutantRunnerTest extends Stryker4sIOSuite with MockitoIOSuite with LogMatchers {
   implicit private val config: Config = Config(baseDir = FileUtil.getResource("scalaFiles"))
 
   private val fileCollectorMock: SourceCollector = mock[SourceCollector]
   private val reporterMock = mock[AggregateReporter]
-  when(reporterMock.reportRunFinished(any[FinishedRunReport])).thenReturn(IO.unit)
-  when(reporterMock.reportMutationComplete(any[MutantRunResult], anyInt)).thenReturn(IO.unit)
-  when(reporterMock.reportMutationStart(any[Mutant])).thenReturn(IO.unit)
+  whenF(reporterMock.reportRunFinished(any[FinishedRunReport])).thenReturn(())
+  whenF(reporterMock.reportMutationComplete(any[MutantRunResult], anyInt)).thenReturn(())
+  whenF(reporterMock.reportMutationStart(any[Mutant])).thenReturn(())
 
   describe("apply") {
     it("should return a Survived mutant on an exitcode 0 process") {

--- a/command-runner/src/test/scala/stryker4s/run/ProcessMutantRunnerTest.scala
+++ b/command-runner/src/test/scala/stryker4s/run/ProcessMutantRunnerTest.scala
@@ -15,9 +15,9 @@ import stryker4s.report.{AggregateReporter, FinishedRunReport}
 import stryker4s.run.process.Command
 import stryker4s.scalatest.{FileUtil, LogMatchers}
 import stryker4s.testutil.stubs.TestProcessRunner
-import stryker4s.testutil.{MockitoIOSuite, Stryker4sIOSuite}
+import stryker4s.testutil.{MockitoSuite, Stryker4sIOSuite}
 
-class ProcessMutantRunnerTest extends Stryker4sIOSuite with MockitoIOSuite with LogMatchers {
+class ProcessMutantRunnerTest extends Stryker4sIOSuite with MockitoSuite with LogMatchers {
   implicit private val config: Config = Config(baseDir = FileUtil.getResource("scalaFiles"))
 
   private val fileCollectorMock: SourceCollector = mock[SourceCollector]

--- a/core/src/test/scala/stryker4s/Stryker4sTest.scala
+++ b/core/src/test/scala/stryker4s/Stryker4sTest.scala
@@ -18,9 +18,9 @@ import stryker4s.run.MutantRunner
 import stryker4s.run.threshold.SuccessStatus
 import stryker4s.scalatest.{FileUtil, LogMatchers}
 import stryker4s.testutil.stubs.{TestProcessRunner, TestSourceCollector}
-import stryker4s.testutil.{MockitoIOSuite, Stryker4sIOSuite}
+import stryker4s.testutil.{MockitoSuite, Stryker4sIOSuite}
 
-class Stryker4sTest extends Stryker4sIOSuite with MockitoIOSuite with Inside with LogMatchers {
+class Stryker4sTest extends Stryker4sIOSuite with MockitoSuite with Inside with LogMatchers {
 
   case class TestTestRunnerContext() extends TestRunnerContext
   class TestMutantRunner(sourceCollector: SourceCollector, reporter: Reporter)(implicit config: Config)

--- a/core/src/test/scala/stryker4s/Stryker4sTest.scala
+++ b/core/src/test/scala/stryker4s/Stryker4sTest.scala
@@ -18,9 +18,9 @@ import stryker4s.run.MutantRunner
 import stryker4s.run.threshold.SuccessStatus
 import stryker4s.scalatest.{FileUtil, LogMatchers}
 import stryker4s.testutil.stubs.{TestProcessRunner, TestSourceCollector}
-import stryker4s.testutil.{MockitoSuite, Stryker4sIOSuite}
+import stryker4s.testutil.{MockitoIOSuite, Stryker4sIOSuite}
 
-class Stryker4sTest extends Stryker4sIOSuite with MockitoSuite with Inside with LogMatchers {
+class Stryker4sTest extends Stryker4sIOSuite with MockitoIOSuite with Inside with LogMatchers {
 
   case class TestTestRunnerContext() extends TestRunnerContext
   class TestMutantRunner(sourceCollector: SourceCollector, reporter: Reporter)(implicit config: Config)
@@ -42,9 +42,9 @@ class Stryker4sTest extends Stryker4sIOSuite with MockitoSuite with Inside with 
       val testSourceCollector = new TestSourceCollector(testFiles)
       val testProcessRunner = TestProcessRunner(Success(1), Success(1), Success(1), Success(1))
       val reporterMock = mock[AggregateReporter]
-      when(reporterMock.reportRunFinished(any[FinishedRunReport])).thenReturn(IO.unit)
-      when(reporterMock.reportMutationComplete(any[MutantRunResult], anyInt)).thenReturn(IO.unit)
-      when(reporterMock.reportMutationStart(any[Mutant])).thenReturn(IO.unit)
+      whenF(reporterMock.reportRunFinished(any[FinishedRunReport])).thenReturn(())
+      whenF(reporterMock.reportMutationComplete(any[MutantRunResult], anyInt)).thenReturn(())
+      whenF(reporterMock.reportMutationStart(any[Mutant])).thenReturn(())
 
       implicit val conf: Config = Config(baseDir = FileUtil.getResource("scalaFiles"))
 

--- a/core/src/test/scala/stryker4s/report/DashboardReporterTest.scala
+++ b/core/src/test/scala/stryker4s/report/DashboardReporterTest.scala
@@ -9,11 +9,11 @@ import stryker4s.config.{Full, MutationScoreOnly}
 import stryker4s.report.dashboard.DashboardConfigProvider
 import stryker4s.report.model.{DashboardConfig, DashboardPutResult}
 import stryker4s.scalatest.LogMatchers
-import stryker4s.testutil.{MockitoSuite, Stryker4sIOSuite}
+import stryker4s.testutil.{MockitoIOSuite, Stryker4sIOSuite}
 import sttp.client._
 import sttp.model.{Header, MediaType, Method, StatusCode}
 
-class DashboardReporterTest extends Stryker4sIOSuite with MockitoSuite with LogMatchers {
+class DashboardReporterTest extends Stryker4sIOSuite with MockitoIOSuite with LogMatchers {
   describe("buildRequest") {
     it("should compose the request") {
       implicit val backend = backendStub

--- a/core/src/test/scala/stryker4s/report/DashboardReporterTest.scala
+++ b/core/src/test/scala/stryker4s/report/DashboardReporterTest.scala
@@ -9,11 +9,11 @@ import stryker4s.config.{Full, MutationScoreOnly}
 import stryker4s.report.dashboard.DashboardConfigProvider
 import stryker4s.report.model.{DashboardConfig, DashboardPutResult}
 import stryker4s.scalatest.LogMatchers
-import stryker4s.testutil.{MockitoIOSuite, Stryker4sIOSuite}
+import stryker4s.testutil.{MockitoSuite, Stryker4sIOSuite}
 import sttp.client._
 import sttp.model.{Header, MediaType, Method, StatusCode}
 
-class DashboardReporterTest extends Stryker4sIOSuite with MockitoIOSuite with LogMatchers {
+class DashboardReporterTest extends Stryker4sIOSuite with MockitoSuite with LogMatchers {
   describe("buildRequest") {
     it("should compose the request") {
       implicit val backend = backendStub

--- a/core/src/test/scala/stryker4s/report/HtmlReporterTest.scala
+++ b/core/src/test/scala/stryker4s/report/HtmlReporterTest.scala
@@ -12,9 +12,9 @@ import mutationtesting.{Metrics, MutationTestReport, Thresholds}
 import org.mockito.captor.ArgCaptor
 import stryker4s.files.{DiskFileIO, FileIO}
 import stryker4s.scalatest.LogMatchers
-import stryker4s.testutil.{MockitoIOSuite, Stryker4sIOSuite}
+import stryker4s.testutil.{MockitoSuite, Stryker4sIOSuite}
 
-class HtmlReporterTest extends Stryker4sIOSuite with MockitoIOSuite with LogMatchers {
+class HtmlReporterTest extends Stryker4sIOSuite with MockitoSuite with LogMatchers {
 
   private val elementsLocation = "/mutation-testing-elements/mutation-test-elements.js"
 

--- a/core/src/test/scala/stryker4s/report/HtmlReporterTest.scala
+++ b/core/src/test/scala/stryker4s/report/HtmlReporterTest.scala
@@ -12,9 +12,9 @@ import mutationtesting.{Metrics, MutationTestReport, Thresholds}
 import org.mockito.captor.ArgCaptor
 import stryker4s.files.{DiskFileIO, FileIO}
 import stryker4s.scalatest.LogMatchers
-import stryker4s.testutil.{MockitoSuite, Stryker4sIOSuite}
+import stryker4s.testutil.{MockitoIOSuite, Stryker4sIOSuite}
 
-class HtmlReporterTest extends Stryker4sIOSuite with MockitoSuite with LogMatchers {
+class HtmlReporterTest extends Stryker4sIOSuite with MockitoIOSuite with LogMatchers {
 
   private val elementsLocation = "/mutation-testing-elements/mutation-test-elements.js"
 
@@ -46,7 +46,7 @@ class HtmlReporterTest extends Stryker4sIOSuite with MockitoSuite with LogMatche
   describe("indexHtml") {
     it("should contain title") {
       val mockFileIO = mock[FileIO]
-      when(mockFileIO.createAndWrite(any[Path], any[String])).thenReturn(IO.unit)
+      whenF(mockFileIO.createAndWrite(any[Path], any[String])).thenReturn(())
       val sut = new HtmlReporter(mockFileIO)
       val testFile = File("foo.bar").path
 
@@ -62,7 +62,7 @@ class HtmlReporterTest extends Stryker4sIOSuite with MockitoSuite with LogMatche
   describe("reportJs") {
     it("should contain the report") {
       val mockFileIO = mock[FileIO]
-      when(mockFileIO.createAndWrite(any[Path], any[String])).thenReturn(IO.unit)
+      whenF(mockFileIO.createAndWrite(any[Path], any[String])).thenReturn(())
       val sut = new HtmlReporter(mockFileIO)
       val testFile = File("foo.bar").path
       val runResults = MutationTestReport(thresholds = Thresholds(100, 0), files = Map.empty)
@@ -120,8 +120,8 @@ class HtmlReporterTest extends Stryker4sIOSuite with MockitoSuite with LogMatche
   describe("reportRunFinished") {
     it("should write the report files to the report directory") {
       val mockFileIO = mock[FileIO]
-      when(mockFileIO.createAndWrite(any[Path], any[String])).thenReturn(IO.unit)
-      when(mockFileIO.createAndWriteFromResource(any[Path], any[String])).thenReturn(IO.unit)
+      whenF(mockFileIO.createAndWrite(any[Path], any[String])).thenReturn(())
+      whenF(mockFileIO.createAndWriteFromResource(any[Path], any[String])).thenReturn(())
       val sut = new HtmlReporter(mockFileIO)
       val report = MutationTestReport(thresholds = Thresholds(100, 0), files = Map.empty)
       val metrics = Metrics.calculateMetrics(report)
@@ -140,8 +140,8 @@ class HtmlReporterTest extends Stryker4sIOSuite with MockitoSuite with LogMatche
 
     it("should write the mutation-test-elements.js file to the report directory") {
       val mockFileIO = mock[FileIO]
-      when(mockFileIO.createAndWrite(any[Path], any[String])).thenReturn(IO.unit)
-      when(mockFileIO.createAndWriteFromResource(any[Path], any[String])).thenReturn(IO.unit)
+      whenF(mockFileIO.createAndWrite(any[Path], any[String])).thenReturn(())
+      whenF(mockFileIO.createAndWriteFromResource(any[Path], any[String])).thenReturn(())
       val sut = new HtmlReporter(mockFileIO)
       val report = MutationTestReport(thresholds = Thresholds(100, 0), files = Map.empty)
       val metrics = Metrics.calculateMetrics(report)
@@ -159,8 +159,8 @@ class HtmlReporterTest extends Stryker4sIOSuite with MockitoSuite with LogMatche
 
     it("should info log a message") {
       val mockFileIO = mock[FileIO]
-      when(mockFileIO.createAndWrite(any[Path], any[String])).thenReturn(IO.unit)
-      when(mockFileIO.createAndWriteFromResource(any[Path], any[String])).thenReturn(IO.unit)
+      whenF(mockFileIO.createAndWrite(any[Path], any[String])).thenReturn(())
+      whenF(mockFileIO.createAndWriteFromResource(any[Path], any[String])).thenReturn(())
       val sut = new HtmlReporter(mockFileIO)
       val report = MutationTestReport(thresholds = Thresholds(100, 0), files = Map.empty)
       val metrics = Metrics.calculateMetrics(report)

--- a/core/src/test/scala/stryker4s/report/JsonReporterTest.scala
+++ b/core/src/test/scala/stryker4s/report/JsonReporterTest.scala
@@ -5,18 +5,17 @@ import java.nio.file.Path
 import scala.concurrent.duration._
 
 import better.files.File
-import cats.effect.IO
 import mutationtesting.{Metrics, MutationTestReport, Thresholds}
 import org.mockito.captor.ArgCaptor
 import stryker4s.files.FileIO
 import stryker4s.scalatest.LogMatchers
-import stryker4s.testutil.{MockitoSuite, Stryker4sIOSuite}
+import stryker4s.testutil.{MockitoIOSuite, Stryker4sIOSuite}
 
-class JsonReporterTest extends Stryker4sIOSuite with MockitoSuite with LogMatchers {
+class JsonReporterTest extends Stryker4sIOSuite with MockitoIOSuite with LogMatchers {
   describe("reportJson") {
     it("should contain the report") {
       val mockFileIO = mock[FileIO]
-      when(mockFileIO.createAndWrite(any[Path], any[String])).thenReturn(IO.unit)
+      whenF(mockFileIO.createAndWrite(any[Path], any[String])).thenReturn(())
       val sut = new JsonReporter(mockFileIO)
       val testFile = File("foo.bar").path
       val report = MutationTestReport(thresholds = Thresholds(100, 0), files = Map.empty)
@@ -33,7 +32,7 @@ class JsonReporterTest extends Stryker4sIOSuite with MockitoSuite with LogMatche
   describe("reportRunFinished") {
     it("should write the report file to the report directory") {
       val mockFileIO = mock[FileIO]
-      when(mockFileIO.createAndWrite(any[Path], any[String])).thenReturn(IO.unit)
+      whenF(mockFileIO.createAndWrite(any[Path], any[String])).thenReturn(())
       val sut = new JsonReporter(mockFileIO)
       val report = MutationTestReport(thresholds = Thresholds(100, 0), files = Map.empty)
       val metrics = Metrics.calculateMetrics(report)
@@ -50,7 +49,7 @@ class JsonReporterTest extends Stryker4sIOSuite with MockitoSuite with LogMatche
 
     it("should info log a message") {
       val mockFileIO = mock[FileIO]
-      when(mockFileIO.createAndWrite(any[Path], any[String])).thenReturn(IO.unit)
+      whenF(mockFileIO.createAndWrite(any[Path], any[String])).thenReturn(())
       val sut = new JsonReporter(mockFileIO)
       val report = MutationTestReport(thresholds = Thresholds(100, 0), files = Map.empty)
       val metrics = Metrics.calculateMetrics(report)

--- a/core/src/test/scala/stryker4s/report/JsonReporterTest.scala
+++ b/core/src/test/scala/stryker4s/report/JsonReporterTest.scala
@@ -10,9 +10,9 @@ import mutationtesting.{Metrics, MutationTestReport, Thresholds}
 import org.mockito.captor.ArgCaptor
 import stryker4s.files.FileIO
 import stryker4s.scalatest.LogMatchers
-import stryker4s.testutil.{MockitoIOSuite, Stryker4sIOSuite}
+import stryker4s.testutil.{MockitoSuite, Stryker4sIOSuite}
 
-class JsonReporterTest extends Stryker4sIOSuite with MockitoIOSuite with LogMatchers {
+class JsonReporterTest extends Stryker4sIOSuite with MockitoSuite with LogMatchers {
   describe("reportJson") {
     it("should contain the report") {
       val mockFileIO = mock[FileIO]

--- a/core/src/test/scala/stryker4s/report/ReporterTest.scala
+++ b/core/src/test/scala/stryker4s/report/ReporterTest.scala
@@ -4,18 +4,17 @@ import scala.concurrent.duration._
 import scala.meta._
 
 import better.files.File
-import cats.effect.IO
 import mutationtesting._
 import stryker4s.extension.mutationtype.GreaterThan
 import stryker4s.model.{Mutant, MutantRunResult}
 import stryker4s.scalatest.LogMatchers
-import stryker4s.testutil.{MockitoSuite, Stryker4sIOSuite}
+import stryker4s.testutil.{MockitoIOSuite, Stryker4sIOSuite}
 
-class ReporterTest extends Stryker4sIOSuite with MockitoSuite with LogMatchers {
+class ReporterTest extends Stryker4sIOSuite with MockitoIOSuite with LogMatchers {
   describe("reporter") {
     it("should log that the console reporter is used when a non existing reporter is configured") {
       val consoleReporterMock = mock[ConsoleReporter]
-      when(consoleReporterMock.reportRunFinished(any[FinishedRunReport])).thenReturn(IO.unit)
+      whenF(consoleReporterMock.reportRunFinished(any[FinishedRunReport])).thenReturn(())
 
       val report = MutationTestReport(thresholds = Thresholds(100, 0), files = Map.empty)
       val metrics = Metrics.calculateMetrics(report)
@@ -35,8 +34,8 @@ class ReporterTest extends Stryker4sIOSuite with MockitoSuite with LogMatchers {
         val mutantMock = Mutant(0, q">", q"<", GreaterThan)
         val consoleReporterMock = mock[ConsoleReporter]
         val progressReporterMock = mock[ProgressReporter]
-        when(consoleReporterMock.reportMutationStart(any[Mutant])).thenReturn(IO.unit)
-        when(progressReporterMock.reportMutationStart(any[Mutant])).thenReturn(IO.unit)
+        whenF(consoleReporterMock.reportMutationStart(any[Mutant])).thenReturn(())
+        whenF(progressReporterMock.reportMutationStart(any[Mutant])).thenReturn(())
         val sut = new AggregateReporter(Seq(consoleReporterMock, progressReporterMock))
         sut
           .reportMutationStart(mutantMock)
@@ -49,7 +48,7 @@ class ReporterTest extends Stryker4sIOSuite with MockitoSuite with LogMatchers {
 
       it("Should not report to finishedRunReporters that is mutation run is started.") {
         val consoleReporterMock = mock[ConsoleReporter]
-        when(consoleReporterMock.reportMutationStart(any[Mutant])).thenReturn(IO.unit)
+        whenF(consoleReporterMock.reportMutationStart(any[Mutant])).thenReturn(())
         val finishedRunReporterMock = mock[FinishedRunReporter]
         val mutantMock = Mutant(0, q">", q"<", GreaterThan)
         val sut = new AggregateReporter(Seq(consoleReporterMock, finishedRunReporterMock))
@@ -69,8 +68,8 @@ class ReporterTest extends Stryker4sIOSuite with MockitoSuite with LogMatchers {
         val consoleReporterMock = mock[ConsoleReporter]
         val progressReporterMock = mock[ProgressReporter]
         val sut = new AggregateReporter(Seq(consoleReporterMock, progressReporterMock))
-        when(consoleReporterMock.reportMutationComplete(any[MutantRunResult], anyInt)).thenReturn(IO.unit)
-        when(progressReporterMock.reportMutationComplete(any[MutantRunResult], anyInt)).thenReturn(IO.unit)
+        whenF(consoleReporterMock.reportMutationComplete(any[MutantRunResult], anyInt)).thenReturn(())
+        whenF(progressReporterMock.reportMutationComplete(any[MutantRunResult], anyInt)).thenReturn(())
 
         sut
           .reportMutationComplete(mutantRunResultMock, 1)
@@ -86,7 +85,7 @@ class ReporterTest extends Stryker4sIOSuite with MockitoSuite with LogMatchers {
         val finishedRunReporterMock = mock[FinishedRunReporter]
         val mutantRunResultMock = mock[MutantRunResult]
         val sut = new AggregateReporter(Seq(consoleReporterMock, finishedRunReporterMock))
-        when(consoleReporterMock.reportMutationComplete(any[MutantRunResult], anyInt)).thenReturn(IO.unit)
+        whenF(consoleReporterMock.reportMutationComplete(any[MutantRunResult], anyInt)).thenReturn(())
 
         sut
           .reportMutationComplete(mutantRunResultMock, 1)
@@ -102,8 +101,8 @@ class ReporterTest extends Stryker4sIOSuite with MockitoSuite with LogMatchers {
       it("should report to all finished mutation run reporters that a mutation run is completed") {
         val consoleReporterMock = mock[ConsoleReporter]
         val finishedRunReporterMock = mock[FinishedRunReporter]
-        when(consoleReporterMock.reportRunFinished(any[FinishedRunReport])).thenReturn(IO.unit)
-        when(finishedRunReporterMock.reportRunFinished(any[FinishedRunReport])).thenReturn(IO.unit)
+        whenF(consoleReporterMock.reportRunFinished(any[FinishedRunReport])).thenReturn(())
+        whenF(finishedRunReporterMock.reportRunFinished(any[FinishedRunReport])).thenReturn(())
         val report = MutationTestReport(thresholds = Thresholds(100, 0), files = Map.empty)
         val metrics = Metrics.calculateMetrics(report)
         val runReport = FinishedRunReport(report, metrics, 10.seconds, File("target/stryker4s-report/"))
@@ -121,7 +120,7 @@ class ReporterTest extends Stryker4sIOSuite with MockitoSuite with LogMatchers {
       it("should not report a finished mutation run to a progress reporter") {
         val consoleReporterMock = mock[ConsoleReporter]
         val progressReporterMock = mock[ProgressReporter]
-        when(consoleReporterMock.reportRunFinished(any[FinishedRunReport])).thenReturn(IO.unit)
+        whenF(consoleReporterMock.reportRunFinished(any[FinishedRunReport])).thenReturn(())
         val report = MutationTestReport(thresholds = Thresholds(100, 0), files = Map.empty)
         val metrics = Metrics.calculateMetrics(report)
         val runReport = FinishedRunReport(report, metrics, 10.seconds, File("target/stryker4s-report/"))
@@ -139,13 +138,12 @@ class ReporterTest extends Stryker4sIOSuite with MockitoSuite with LogMatchers {
       it("should still call other reporters if a reporter throws an exception") {
         val consoleReporterMock = mock[ConsoleReporter]
         val progressReporterMock = mock[FinishedRunReporter]
-        when(progressReporterMock.reportRunFinished(any[FinishedRunReport])).thenReturn(IO.unit)
+        whenF(progressReporterMock.reportRunFinished(any[FinishedRunReport])).thenReturn(())
         val report = MutationTestReport(thresholds = Thresholds(100, 0), files = Map.empty)
         val metrics = Metrics.calculateMetrics(report)
         val runReport = FinishedRunReport(report, metrics, 10.seconds, File("target/stryker4s-report/"))
         val sut = new AggregateReporter(Seq(consoleReporterMock, progressReporterMock))
-        when(consoleReporterMock.reportRunFinished(runReport))
-          .thenReturn(IO.raiseError(new RuntimeException("Something happened")))
+        whenF(consoleReporterMock.reportRunFinished(runReport)).thenFailWith(new RuntimeException("Something happened"))
 
         sut
           .reportRunFinished(runReport)
@@ -167,8 +165,8 @@ class ReporterTest extends Stryker4sIOSuite with MockitoSuite with LogMatchers {
         it("should log if a report throws an exception") {
           val consoleReporterMock = mock[ConsoleReporter]
           val sut = new AggregateReporter(Seq(consoleReporterMock, progressReporterMock))
-          when(consoleReporterMock.reportRunFinished(runReport))
-            .thenReturn(IO.raiseError(new RuntimeException("Something happened")))
+          whenF(consoleReporterMock.reportRunFinished(runReport))
+            .thenFailWith(new RuntimeException("Something happened"))
 
           sut
             .reportRunFinished(runReport)
@@ -180,7 +178,7 @@ class ReporterTest extends Stryker4sIOSuite with MockitoSuite with LogMatchers {
 
         it("should not log warnings if no exceptions occur") {
           val consoleReporterMock = mock[ConsoleReporter]
-          when(consoleReporterMock.reportRunFinished(any[FinishedRunReport])).thenReturn(IO.unit)
+          whenF(consoleReporterMock.reportRunFinished(any[FinishedRunReport])).thenReturn(())
           val sut = new AggregateReporter(Seq(consoleReporterMock, progressReporterMock))
 
           sut

--- a/core/src/test/scala/stryker4s/report/ReporterTest.scala
+++ b/core/src/test/scala/stryker4s/report/ReporterTest.scala
@@ -9,9 +9,9 @@ import mutationtesting._
 import stryker4s.extension.mutationtype.GreaterThan
 import stryker4s.model.{Mutant, MutantRunResult}
 import stryker4s.scalatest.LogMatchers
-import stryker4s.testutil.{MockitoIOSuite, Stryker4sIOSuite}
+import stryker4s.testutil.{MockitoSuite, Stryker4sIOSuite}
 
-class ReporterTest extends Stryker4sIOSuite with MockitoIOSuite with LogMatchers {
+class ReporterTest extends Stryker4sIOSuite with MockitoSuite with LogMatchers {
   describe("reporter") {
     it("should log that the console reporter is used when a non existing reporter is configured") {
       val consoleReporterMock = mock[ConsoleReporter]

--- a/core/src/test/scala/stryker4s/testutil/MockitoSuite.scala
+++ b/core/src/test/scala/stryker4s/testutil/MockitoSuite.scala
@@ -1,13 +1,9 @@
 package stryker4s.testutil
 
 import org.mockito.scalatest.MockitoSugar
+import org.scalatest.Suite
 
 trait MockitoSuite extends MockitoSugar {
   // Will cause a compile error if MockitoSuite is used outside of a ScalaTest Suite
-  this: Stryker4sSuite =>
-}
-
-// AsyncMockitoSugar doesn't seem to work well with IO-based async tests
-trait MockitoIOSuite extends org.mockito.MockitoSugar with org.mockito.ArgumentMatchersSugar {
-  this: Stryker4sIOSuite =>
+  this: Suite =>
 }

--- a/core/src/test/scala/stryker4s/testutil/MockitoSuite.scala
+++ b/core/src/test/scala/stryker4s/testutil/MockitoSuite.scala
@@ -8,7 +8,6 @@ trait MockitoSuite extends MockitoSugar {
   this: Stryker4sSuite =>
 }
 
-// AsyncMockitoSugar doesn't seem to work well with IO-based async tests
 trait MockitoIOSuite extends AsyncMockitoSugar with MockitoCats {
   this: Stryker4sIOSuite =>
 }

--- a/core/src/test/scala/stryker4s/testutil/MockitoSuite.scala
+++ b/core/src/test/scala/stryker4s/testutil/MockitoSuite.scala
@@ -1,9 +1,14 @@
 package stryker4s.testutil
 
-import org.mockito.scalatest.MockitoSugar
-import org.scalatest.Suite
+import org.mockito.cats.MockitoCats
+import org.mockito.scalatest.{AsyncMockitoSugar, MockitoSugar}
 
 trait MockitoSuite extends MockitoSugar {
   // Will cause a compile error if MockitoSuite is used outside of a ScalaTest Suite
-  this: Suite =>
+  this: Stryker4sSuite =>
+}
+
+// AsyncMockitoSugar doesn't seem to work well with IO-based async tests
+trait MockitoIOSuite extends AsyncMockitoSugar with MockitoCats {
+  this: Stryker4sIOSuite =>
 }

--- a/core/src/test/scala/stryker4s/testutil/Stryker4sSuite.scala
+++ b/core/src/test/scala/stryker4s/testutil/Stryker4sSuite.scala
@@ -1,9 +1,10 @@
 package stryker4s.testutil
 
-import cats.effect.testing.scalatest.{AssertingSyntax, AsyncIOSpec}
+import cats.effect.testing.scalatest.{AssertingSyntax, EffectTestSupport}
+import cats.effect.{ContextShift, IO, Timer}
 import org.scalatest.funspec.{AnyFunSpec, AsyncFunSpec}
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.{LoneElement, OptionValues, Suite}
+import org.scalatest.{AsyncTestSuite, LoneElement, OptionValues, Suite}
 
 private[testutil] trait Stryker4sBaseSuite extends Matchers with OptionValues with LoneElement { this: Suite => }
 
@@ -12,4 +13,11 @@ abstract class Stryker4sSuite extends AnyFunSpec with Stryker4sBaseSuite
 /** Base suite making it easier to test IO-based code
   * Every test is forced to return a `IO[scalatest.Assertion]`
   */
-abstract class Stryker4sIOSuite extends AsyncFunSpec with Stryker4sBaseSuite with AsyncIOSpec with AssertingSyntax
+abstract class Stryker4sIOSuite extends AsyncFunSpec with Stryker4sBaseSuite with AsyncIOSpec
+
+// Same as cats.effect.testing.scalatest.AsyncIOSpec but without overriding the ExecutionContext
+// We want to keep ScalaTests default single-threaded EC to prevent any issues with concurrent tests
+trait AsyncIOSpec extends AssertingSyntax with EffectTestSupport { asyncTestSuite: AsyncTestSuite =>
+  implicit val ioContextShift: ContextShift[IO] = IO.contextShift(executionContext)
+  implicit val ioTimer: Timer[IO] = IO.timer(executionContext)
+}

--- a/core/src/test/scala/stryker4s/testutil/Stryker4sSuite.scala
+++ b/core/src/test/scala/stryker4s/testutil/Stryker4sSuite.scala
@@ -15,6 +15,7 @@ abstract class Stryker4sSuite extends AnyFunSpec with Stryker4sBaseSuite
   */
 abstract class Stryker4sIOSuite extends AsyncFunSpec with Stryker4sBaseSuite with AsyncIOSpec
 
+// https://github.com/djspiewak/cats-effect-testing/blob/master/scalatest/src/main/scala/cats/effect/testing/scalatest/AsyncIOSpec.scala
 // Same as cats.effect.testing.scalatest.AsyncIOSpec but without overriding the ExecutionContext
 // We want to keep ScalaTests default single-threaded EC to prevent any issues with concurrent tests
 trait AsyncIOSpec extends AssertingSyntax with EffectTestSupport { asyncTestSuite: AsyncTestSuite =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,6 +35,7 @@ object Dependencies {
   object test {
     val scalatest = "org.scalatest" %% "scalatest" % versions.scalatest % Test
     val mockitoScala = "org.mockito" %% "mockito-scala-scalatest" % versions.mockitoScala % Test
+    val mockitoScalaCats = "org.mockito" %% "mockito-scala-cats" % versions.mockitoScala % Test
     // For easier testing with IO
     val catsEffectScalaTest = "com.codecommit" %% "cats-effect-testing-scalatest" % versions.catsEffectScalaTest % Test
   }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -15,6 +15,7 @@ object Settings {
     libraryDependencies ++= Seq(
       Dependencies.test.scalatest,
       Dependencies.test.mockitoScala,
+      Dependencies.test.mockitoScalaCats,
       Dependencies.test.catsEffectScalaTest,
       Dependencies.pureconfig,
       Dependencies.pureconfigSttp,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -11,6 +11,7 @@ object Settings {
   )
 
   lazy val coreSettings: Seq[Setting[_]] = Seq(
+    parallelExecution in Test := false,
     libraryDependencies ++= Seq(
       Dependencies.test.scalatest,
       Dependencies.test.mockitoScala,


### PR DESCRIPTION
AsyncIOSpec from cats-effect-testing overrides the implicit executioncontext from ScalaTests single-threaded one. This means that multiple tests in the same suite are started concurrently. This doesn't really provide a speed benefit, but it does mean that Mockito-Scala will complain about mocks from other tests that aren't disposed properly (because they are still running). 