### PR TITLE
 docs(sidebar): add custom sidebar

### DIFF
--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -1,0 +1,6 @@
+[
+  "stryker4s/getting-started",
+  "stryker4s/configuration",
+  "stryker4s/contributing",
+  "stryker4s/versioning"
+]


### PR DESCRIPTION
As discussed, this will be used to render the sidebar on the website.

The `sidebar.json` (or `sidebar.js` if you prefer a node module) should contain a valid [sidebar object](https://v2.docusaurus.io/docs/docs-introduction#sidebar-object). The document root is `stryker4s`, so [document ids](https://v2.docusaurus.io/docs/docs-introduction#document-id) should be prefixed with that.
