### PR TITLE
Support Scala 3 syntax with configurable scala-dialect

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -7,3 +7,6 @@ rewrite.rules = [SortImports, SortModifiers, RedundantParens]
 assumeStandardLibraryStripMargin = true
 
 onTestFailure = "To fix this, run './bin/scalafmt' from the project root directory"
+
+# Syntax is backwards-compatible and we also need to be able to parse scala 3 files
+runner.dialect = dotty

--- a/core/src/main/scala/stryker4s/config/Config.scala
+++ b/core/src/main/scala/stryker4s/config/Config.scala
@@ -3,6 +3,7 @@ package stryker4s.config
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.duration.FiniteDuration
+import scala.meta.{dialects, Dialect}
 
 import better.files._
 
@@ -18,7 +19,8 @@ final case class Config(
     timeout: FiniteDuration = FiniteDuration(5000, TimeUnit.MILLISECONDS),
     timeoutFactor: Double = 1.5,
     maxTestRunnerReuse: Option[Int] = None,
-    legacyTestRunner: Boolean = false
+    legacyTestRunner: Boolean = false,
+    scalaDialect: Dialect = dialects.Scala3
 )
 
 object Config {

--- a/core/src/main/scala/stryker4s/config/implicits/ConfigReaderImplicits.scala
+++ b/core/src/main/scala/stryker4s/config/implicits/ConfigReaderImplicits.scala
@@ -2,6 +2,9 @@ package stryker4s.config.implicits
 
 import java.nio.file.Path
 
+import scala.meta.Dialect
+import scala.meta.dialects._
+
 import better.files.File
 import pureconfig.ConfigReader
 import pureconfig.error.CannotConvert
@@ -40,34 +43,57 @@ trait ConfigReaderImplicits {
 
   implicit private[config] val uriReader = pureconfig.module.sttp.reader
 
-  implicit private[config] val thresholdsReader: ConfigReader[Thresholds] = deriveReader[Thresholds] emap {
-    case Thresholds(high, _, _) if isNotPercentage(high)   => notPercentageError(high, "high")
-    case Thresholds(_, low, _) if isNotPercentage(low)     => notPercentageError(low, "low")
-    case Thresholds(_, _, break) if isNotPercentage(break) => notPercentageError(break, "break")
-    case Thresholds(high, low, _) if high < low =>
-      Left(
-        CannotConvert(
-          high.toString(),
-          "thresholds.high",
-          s"'high' ($high) must be greater than or equal to 'low' ($low)"
+  implicit private[config] val thresholdsReader: ConfigReader[Thresholds] = {
+    def isNotPercentage(n: Int) = n < 0 || n > 100
+
+    def notPercentageError(value: Int, name: String): Left[CannotConvert, Thresholds] =
+      Left(CannotConvert(value.toString(), s"thresholds.$name", "must be a percentage 0-100"))
+
+    deriveReader[Thresholds] emap {
+      case Thresholds(high, _, _) if isNotPercentage(high)   => notPercentageError(high, "high")
+      case Thresholds(_, low, _) if isNotPercentage(low)     => notPercentageError(low, "low")
+      case Thresholds(_, _, break) if isNotPercentage(break) => notPercentageError(break, "break")
+      case Thresholds(high, low, _) if high < low =>
+        Left(
+          CannotConvert(
+            high.toString(),
+            "thresholds.high",
+            s"'high' ($high) must be greater than or equal to 'low' ($low)"
+          )
         )
-      )
-    case Thresholds(_, low, break) if low <= break =>
-      Left(
-        CannotConvert(
-          low.toString(),
-          "thresholds.low",
-          s"'low' ($low) must be greater than 'break' ($break)"
+      case Thresholds(_, low, break) if low <= break =>
+        Left(
+          CannotConvert(
+            low.toString(),
+            "thresholds.low",
+            s"'low' ($low) must be greater than 'break' ($break)"
+          )
         )
-      )
-    case valid => Right(valid)
+      case valid => Right(valid)
+    }
   }
 
-  private def isNotPercentage(n: Int) = n < 0 || n > 100
-
-  /** Helper function to create a CannotConvert when a value is not a percentage
-    */
-  private def notPercentageError(value: Int, name: String): Left[CannotConvert, Thresholds] =
-    Left(CannotConvert(value.toString(), s"thresholds.$name", "must be a percentage 0-100"))
+  implicit private[config] val dialectReader: ConfigReader[Dialect] = {
+    val scalaVersions = Map(
+      List("scala211", "scala2.11", "2.11", "211") -> Scala211,
+      List("scala212", "scala2.12", "2.12", "212") -> Scala212,
+      List("scala213", "scala2.13", "2.13", "213", "2") -> Scala213,
+      List("scala3", "scala3.0", "3.0", "3", "dotty") -> Scala3
+    )
+    ConfigReader[String].emap { input =>
+      scalaVersions
+        .collectFirst { case (strings, dialect) if strings.contains(input.toLowerCase()) => dialect }
+        .toRight(
+          CannotConvert(
+            input,
+            "scalaDialect",
+            s"Unsupported scalaDialect. Leaving this configuration empty defaults to scala3 which might also work for you. Valid scalaDialects are: ${scalaVersions
+              .flatMap(_._1)
+              .map(d => s"'$d'")
+              .mkString(", ")}."
+          )
+        )
+    }
+  }
 
 }

--- a/core/src/test/resources/scalaFiles/scala3File.scala
+++ b/core/src/test/resources/scalaFiles/scala3File.scala
@@ -1,0 +1,9 @@
+// Tests support for new top-level and extension syntax
+
+object SeqOps {
+  extension[A, B](list: Seq[A]) {
+    def myFoldRight(init: B)(f: (A, B) => B): B = list.foldRight(init)(f)
+  }
+}
+
+type Foo = String

--- a/core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala
@@ -9,6 +9,7 @@ import better.files.File
 import stryker4s.config.Config
 import stryker4s.extension.FileExtensions._
 import stryker4s.extension.TreeExtensions.IsEqualExtension
+import stryker4s.log.Logger
 import stryker4s.scalatest.{FileUtil, LogMatchers}
 import stryker4s.testutil.Stryker4sSuite
 
@@ -53,6 +54,16 @@ class MutantFinderTest extends Stryker4sSuite with LogMatchers {
       lazy val result = sut.parseFile(noFile)
 
       a[NoSuchFileException] should be thrownBy result
+    }
+
+    it("should parse a scala-3 file") {
+      import scala.meta.dialects.Scala3
+
+      val scala3DialectConfig = config.copy(scalaDialect = Scala3)
+      val sut = new MutantFinder(new MutantMatcher)(scala3DialectConfig, implicitly[Logger])
+      val file = FileUtil.getResource("scalaFiles/scala3File.scala")
+
+      noException shouldBe thrownBy(sut.parseFile(file))
     }
   }
 

--- a/core/src/test/scala/stryker4s/testutil/ExampleConfigs.scala
+++ b/core/src/test/scala/stryker4s/testutil/ExampleConfigs.scala
@@ -33,6 +33,7 @@ object ExampleConfigs {
                                      |  max-test-runner-reuse=15
                                      |  legacy-test-runner=true
                                      |  timeout=5500
+                                     |  scala-dialect="scala212"
                                      |}""".stripMargin)
 
   def empty = ConfigSource.empty
@@ -78,4 +79,9 @@ object ExampleConfigs {
                                                | timeout = 6s
                                                |}
                                                |""".stripMargin)
+
+  def scalaDialect(dialect: String) = ConfigSource.string(s"""|stryker4s {
+                                                              | scala-dialect="$dialect"
+                                                              |}
+                                                              |""".stripMargin)
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -177,6 +177,17 @@ Examples would be `sbt test`, `mvn test` or any other command to run your tests,
 
 **warning** The process runner should only be used when your specific test framework is not supported. Due to performance and predictability reasons.
 
+### `scala-dialect` ['string']
+
+**Config file:** `scala-dialect: "2.13"`  
+**Default value:** `scala3`  
+**Since:** `v0.10.1`  
+**Description:**
+
+Set the Scala dialect that should be used for parsing Scala files. The default is Scala 3 as most syntax is backwards-compatible with Scala 2. If you are running into issues with parsing older unsupported Scala syntax that we forgot about you can change this value.
+
+Valid values are Scala-versions without a patch version (`scala2.12`, `212`, `2.12`, `2`). The full list can be found [here](https://github.com/stryker-mutator/stryker4s/blob/master/core/src/main/scala/stryker4s/config/implicits/ConfigReaderImplicits.scala#L77).
+
 ## Other configuration options
 
 ### `log-level` [`string`]


### PR DESCRIPTION
### Fixes #665

#### What it does

Adds support for Scala 3 syntax by adding a configurable scala dialect parsing configuration.

#### How it works

Passes the configured dialect to Scalameta. Default is Scala 3 because most syntax is backwards compatible
