### PR TITLE
Fix NumberFormatException for command-runner

### DIFF
--- a/command-runner/src/main/scala/stryker4s/command/runner/ProcessTestRunner.scala
+++ b/command-runner/src/main/scala/stryker4s/command/runner/ProcessTestRunner.scala
@@ -12,7 +12,7 @@ import stryker4s.run.{InitialTestRunResult, TestRunner}
 class ProcessTestRunner(command: Command, processRunner: ProcessRunner, tmpDir: File, blocker: Blocker)
     extends TestRunner {
   def initialTestRun(): IO[InitialTestRunResult] = {
-    processRunner(command, tmpDir, ("ACTIVE_MUTATION", "None"), blocker).map {
+    processRunner(command, tmpDir, blocker).map {
       case Success(0) => Left(true)
       case _          => Left(false)
     }
@@ -20,7 +20,7 @@ class ProcessTestRunner(command: Command, processRunner: ProcessRunner, tmpDir: 
 
   def runMutant(mutant: Mutant): IO[MutantRunResult] = {
     val id = mutant.id
-    processRunner(command, tmpDir, ("ACTIVE_MUTATION", id.toString), blocker).map {
+    processRunner(command, tmpDir, blocker, ("ACTIVE_MUTATION", id.toString)).map {
       case Success(0)                   => Survived(mutant)
       case Success(_)                   => Killed(mutant)
       case Failure(_: TimeoutException) => TimedOut(mutant)

--- a/core/src/main/scala/stryker4s/run/process/ProcessRunner.scala
+++ b/core/src/main/scala/stryker4s/run/process/ProcessRunner.scala
@@ -17,10 +17,10 @@ abstract class ProcessRunner(implicit log: Logger, cs: ContextShift[IO]) {
     }
   }
 
-  def apply(command: Command, workingDir: File, envVar: (String, String), blocker: Blocker): IO[Try[Int]] = {
+  def apply(command: Command, workingDir: File, blocker: Blocker, envVar: (String, String)*): IO[Try[Int]] = {
     ProcessResource
       .fromProcessBuilder(
-        Process(s"${command.command} ${command.args}", workingDir.toJava, envVar)
+        Process(s"${command.command} ${command.args}", workingDir.toJava, envVar: _*)
       )(m => log.debug(s"testrunner: $m"))
       .use(p => blocker.delay[IO, Int](p.exitValue()))
       .attempt

--- a/core/src/main/scala/stryker4s/run/process/WindowsProcessRunner.scala
+++ b/core/src/main/scala/stryker4s/run/process/WindowsProcessRunner.scala
@@ -11,7 +11,7 @@ class WindowsProcessRunner(implicit log: Logger, cs: ContextShift[IO]) extends P
     super.apply(Command(s"cmd /c ${command.command}", command.args), workingDir)
   }
 
-  override def apply(command: Command, workingDir: File, envVar: (String, String), blocker: Blocker): IO[Try[Int]] = {
-    super.apply(Command(s"cmd /c ${command.command}", command.args), workingDir, envVar, blocker)
+  override def apply(command: Command, workingDir: File, blocker: Blocker, envVar: (String, String)*): IO[Try[Int]] = {
+    super.apply(Command(s"cmd /c ${command.command}", command.args), workingDir, blocker, envVar: _*)
   }
 }

--- a/core/src/test/scala/stryker4s/testutil/stubs/TestProcessRunner.scala
+++ b/core/src/test/scala/stryker4s/testutil/stubs/TestProcessRunner.scala
@@ -22,12 +22,12 @@ class TestProcessRunner(initialTestRunSuccess: Boolean, testRunExitCode: Try[Int
   /** Keep track on the amount of times the function is called.
     * Also return an exit code which the test runner would do as well.
     */
-  override def apply(command: Command, workingDir: File, envVar: (String, String), blocker: Blocker): IO[Try[Int]] = {
-    if (envVar._2.equals("None")) {
+  override def apply(command: Command, workingDir: File, blocker: Blocker, envVar: (String, String)*): IO[Try[Int]] = {
+    if (envVar.isEmpty) {
       IO.pure(Success(if (initialTestRunSuccess) 0 else 1))
     } else {
       timesCalled.next()
-      IO.pure(testRunExitCode(envVar._2.toInt))
+      IO.pure(testRunExitCode(envVar.map(_._2).head.toInt))
     }
   }
 }


### PR DESCRIPTION
In a regression since 0.10.0, the command-runner would set the `"ACTIVE_MUTATION"` environment variable to `"NONE"`, which would then try to be parsed to a Int. This of course throws an exception, which fails the initial test-run. 

With this PR the environment variable is not set, which makes the mutation switch go to the default case
