### PR TITLE
Replace sttp async-http-client backend with httpclient (Java 11+)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: Add back jdk 14 when it works in Dotty again. Probably 3.0.0-M2
-        # java-version: ['adopt@1.8', 'openjdk@1.11', 'openjdk@1.14']
-        java-version: ['adopt@1.8', 'openjdk@1.11']
+        java-version: ['openjdk@1.11', 'openjdk@1.14']
     runs-on: ubuntu-latest
 
     steps:

--- a/core/src/main/scala/stryker4s/run/Stryker4sRunner.scala
+++ b/core/src/main/scala/stryker4s/run/Stryker4sRunner.scala
@@ -3,7 +3,6 @@ package stryker4s.run
 import java.nio.file.Path
 
 import cats.effect.{ContextShift, IO, Resource, Timer}
-import cats.syntax.all._
 import stryker4s.Stryker4s
 import stryker4s.config._
 import stryker4s.files.DiskFileIO
@@ -16,7 +15,8 @@ import stryker4s.report._
 import stryker4s.report.dashboard.DashboardConfigProvider
 import stryker4s.run.process.ProcessRunner
 import stryker4s.run.threshold.ScoreStatus
-import sttp.client3.asynchttpclient.cats.AsyncHttpClientCatsBackend
+import sttp.client3.httpclient.fs2.HttpClientFs2Backend
+import cats.effect.Blocker
 
 abstract class Stryker4sRunner(implicit log: Logger, cs: ContextShift[IO], timer: Timer[IO]) {
   def run(): IO[ScoreStatus] = {
@@ -24,30 +24,39 @@ abstract class Stryker4sRunner(implicit log: Logger, cs: ContextShift[IO], timer
 
     val collector = new FileCollector(ProcessRunner())
 
-    resolveReporters().flatMap { reporters =>
-      val stryker4s = new Stryker4s(
-        collector,
-        new Mutator(
-          new MutantFinder(new MutantMatcher),
-          new StatementTransformer,
-          resolveMatchBuilder
-        ),
-        new MutantRunner(resolveTestRunner(_), collector, new AggregateReporter(reporters))
-      )
-      stryker4s.run()
-    }
+    val stryker4s = new Stryker4s(
+      collector,
+      new Mutator(
+        new MutantFinder(new MutantMatcher),
+        new StatementTransformer,
+        resolveMatchBuilder
+      ),
+      new MutantRunner(resolveTestRunner(_), collector, new AggregateReporter(resolveReporters()))
+    )
+    stryker4s.run()
   }
 
   def resolveReporters()(implicit config: Config) =
-    config.reporters.toList.traverse {
-      case Console => IO(new ConsoleReporter())
-      case Html    => IO(new HtmlReporter(new DiskFileIO()))
-      case Json    => IO(new JsonReporter(new DiskFileIO()))
+    config.reporters.toSeq.map {
+      case Console => new ConsoleReporter()
+      case Html    => new HtmlReporter(new DiskFileIO())
+      case Json    => new JsonReporter(new DiskFileIO())
       case Dashboard =>
-        AsyncHttpClientCatsBackend[IO]()
-          .map { implicit backend =>
-            new DashboardReporter(new DashboardConfigProvider(sys.env))
+        implicit val httpBackend = Blocker[IO]
+          // Catch if the user runs the dashboard on Java <11
+          .flatMap { b =>
+            try {
+              HttpClientFs2Backend.resource[IO](b)
+            } catch {
+              case e: BootstrapMethodError =>
+                // Wrap in a UnsupportedOperationException because BootstrapMethodError will not be caught
+                throw new UnsupportedOperationException(
+                  "Could not send results to dashboard. The dashboard reporter only supports Java 11 or above. If you are running on a lower Java version please upgrade or disable the dashboard reporter.",
+                  e
+                )
+            }
           }
+        new DashboardReporter(new DashboardConfigProvider(sys.env))
     }
 
   def resolveMatchBuilder(implicit config: Config): MatchBuilder = new MatchBuilder(mutationActivation)

--- a/core/src/main/scala/stryker4s/run/Stryker4sRunner.scala
+++ b/core/src/main/scala/stryker4s/run/Stryker4sRunner.scala
@@ -2,7 +2,7 @@ package stryker4s.run
 
 import java.nio.file.Path
 
-import cats.effect.{ContextShift, IO, Resource, Timer}
+import cats.effect.{Blocker, ContextShift, IO, Resource, Timer}
 import stryker4s.Stryker4s
 import stryker4s.config._
 import stryker4s.files.DiskFileIO
@@ -16,7 +16,6 @@ import stryker4s.report.dashboard.DashboardConfigProvider
 import stryker4s.run.process.ProcessRunner
 import stryker4s.run.threshold.ScoreStatus
 import sttp.client3.httpclient.fs2.HttpClientFs2Backend
-import cats.effect.Blocker
 
 abstract class Stryker4sRunner(implicit log: Logger, cs: ContextShift[IO], timer: Timer[IO]) {
   def run(): IO[ScoreStatus] = {

--- a/core/src/main/scala/stryker4s/run/Stryker4sRunner.scala
+++ b/core/src/main/scala/stryker4s/run/Stryker4sRunner.scala
@@ -50,7 +50,7 @@ abstract class Stryker4sRunner(implicit log: Logger, cs: ContextShift[IO], timer
               case e: BootstrapMethodError =>
                 // Wrap in a UnsupportedOperationException because BootstrapMethodError will not be caught
                 throw new UnsupportedOperationException(
-                  "Could not send results to dashboard. The dashboard reporter only supports Java 11 or above. If you are running on a lower Java version please upgrade or disable the dashboard reporter.",
+                  "Could not send results to dashboard. The dashboard reporter only supports JDK 11 or above. If you are running on a lower Java version please upgrade or disable the dashboard reporter.",
                   e
                 )
             }

--- a/core/src/test/scala/stryker4s/report/AggregateReporterTest.scala
+++ b/core/src/test/scala/stryker4s/report/AggregateReporterTest.scala
@@ -3,11 +3,11 @@ package stryker4s.report
 import scala.concurrent.duration._
 
 import better.files.File
+import cats.data.NonEmptyList
+import cats.effect.util.CompositeException
 import mutationtesting._
 import stryker4s.scalatest.LogMatchers
 import stryker4s.testutil.{MockitoIOSuite, Stryker4sIOSuite}
-import cats.effect.util.CompositeException
-import cats.data.NonEmptyList
 
 class AggregateReporterTest extends Stryker4sIOSuite with MockitoIOSuite with LogMatchers {
   describe("reporter") {

--- a/core/src/test/scala/stryker4s/report/AggregateReporterTest.scala
+++ b/core/src/test/scala/stryker4s/report/AggregateReporterTest.scala
@@ -6,8 +6,10 @@ import better.files.File
 import mutationtesting._
 import stryker4s.scalatest.LogMatchers
 import stryker4s.testutil.{MockitoIOSuite, Stryker4sIOSuite}
+import cats.effect.util.CompositeException
+import cats.data.NonEmptyList
 
-class ReporterTest extends Stryker4sIOSuite with MockitoIOSuite with LogMatchers {
+class AggregateReporterTest extends Stryker4sIOSuite with MockitoIOSuite with LogMatchers {
   describe("reporter") {
     it("should log that the console reporter is used when a non existing reporter is configured") {
       val consoleReporterMock = mock[ConsoleReporter]
@@ -58,6 +60,29 @@ class ReporterTest extends Stryker4sIOSuite with MockitoIOSuite with LogMatchers
             verifyZeroInteractions(finishedRunReporterMock)
           }
           .assertNoException
+      }
+
+      describe("logging") {
+        it("should log and continue if one  reporter throws an exception") {
+          val eventMock = mock[StartMutationEvent]
+          val consoleReporterMock = mock[ConsoleReporter]
+          val progressReporterMock = mock[ProgressReporter]
+          val sut = new AggregateReporter(Seq(consoleReporterMock, progressReporterMock))
+          val e = new RuntimeException("Something happened")
+          whenF(consoleReporterMock.onMutationStart(any[StartMutationEvent]))
+            .thenFailWith(e)
+          whenF(progressReporterMock.onMutationStart(any[StartMutationEvent])).thenReturn(())
+
+          sut
+            .onMutationStart(eventMock)
+            .map { _ =>
+              "1 reporter failed to report:" shouldBe loggedAsError
+              e.toString() shouldBe loggedAsError
+              verify(consoleReporterMock).onMutationStart(eventMock)
+              verify(progressReporterMock).onMutationStart(eventMock)
+            }
+            .assertNoException
+        }
       }
     }
 
@@ -114,19 +139,16 @@ class ReporterTest extends Stryker4sIOSuite with MockitoIOSuite with LogMatchers
           .map { _ =>
             verify(progressReporterMock).onRunFinished(runReport)
           }
-          .assertNoException
+          .assertThrows[RuntimeException]
       }
 
       describe("logging") {
-        val failedToReportMessage = "1 reporter(s) failed to report:"
-        val exceptionMessage = "java.lang.RuntimeException: Something happened"
-
         val progressReporterMock = mock[ProgressReporter]
         val report = MutationTestResult(thresholds = Thresholds(100, 0), files = Map.empty)
         val metrics = Metrics.calculateMetrics(report)
         val runReport = FinishedRunEvent(report, metrics, 10.seconds, File("target/stryker4s-report/"))
 
-        it("should log if a report throws an exception") {
+        it("should log and throw if a report throws an exception") {
           val consoleReporterMock = mock[ConsoleReporter]
           val sut = new AggregateReporter(Seq(consoleReporterMock, progressReporterMock))
           whenF(consoleReporterMock.onRunFinished(runReport))
@@ -134,9 +156,37 @@ class ReporterTest extends Stryker4sIOSuite with MockitoIOSuite with LogMatchers
 
           sut
             .onRunFinished(runReport)
-            .map { _ =>
-              failedToReportMessage shouldBe loggedAsWarning
-              exceptionMessage shouldBe loggedAsWarning
+            .attempt
+            .map {
+              case Left(e) =>
+                "1 reporter failed to report:" shouldBe loggedAsError
+                e shouldBe a[RuntimeException]
+                e.getMessage() shouldBe "Something happened"
+              case Right(r) => fail(s"Expected exception, got $r")
+            }
+        }
+
+        it("should log and combine the exceptions if multiple reporters throw an exception") {
+          val consoleReporterMock = mock[ConsoleReporter]
+          val dashboardReporterMock = mock[DashboardReporter]
+          val sut = new AggregateReporter(Seq(consoleReporterMock, dashboardReporterMock))
+          val firstExc = new RuntimeException("Something happened")
+          val secondExc = new IllegalArgumentException("Something also happened")
+          whenF(consoleReporterMock.onRunFinished(runReport))
+            .thenFailWith(firstExc)
+          whenF(dashboardReporterMock.onRunFinished(runReport))
+            .thenFailWith(secondExc)
+
+          sut
+            .onRunFinished(runReport)
+            .attempt
+            .map {
+              case Left(e) =>
+                e shouldBe a[CompositeException]
+                "2 reporters failed to report:" shouldBe loggedAsError
+                val ce = e.asInstanceOf[CompositeException]
+                ce.all shouldBe NonEmptyList(firstExc, secondExc :: Nil)
+              case Right(r) => fail(s"Expected exception, got $r")
             }
         }
 
@@ -149,8 +199,8 @@ class ReporterTest extends Stryker4sIOSuite with MockitoIOSuite with LogMatchers
             .onRunFinished(runReport)
             .map { _ =>
               verify(consoleReporterMock).onRunFinished(runReport)
-              failedToReportMessage should not be loggedAsWarning
-              exceptionMessage should not be loggedAsWarning
+              "1 reporter failed to report:" should not be loggedAsWarning
+              "java.lang.RuntimeException: Something happened" should not be loggedAsWarning
             }
         }
       }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,7 +67,7 @@ With `reporters` you can specify reporters for stryker4s to use. The following r
 - `console` will output progress and the final result to the console.
 - `html` outputs a nice HTML report to `target/stryker4s-report-$timestamp/index.html`. See the [mutation-testing-elements repo](https://github.com/stryker-mutator/mutation-testing-elements/tree/master/packages/mutation-testing-elements#mutation-testing-elements) for more information.
 - `json` writes a json of the mutation result to the same folder as the HTML reporter. The JSON is in the [mutation-testing-report-schema](https://github.com/stryker-mutator/mutation-testing-elements/tree/master/packages/mutation-testing-report-schema) format.
-- `dashboard` reporter sends a report to https://dashboard.stryker-mutator.io, enabling you to add a fancy mutation score badge to your readme, as well as hosting your HTML report on the dashboard! It uses the [dashboard.\*](#dashboard-object) configuration options. See the [dashboard docs](../General/dashboard.md) for more info.
+- `dashboard` reporter sends a report to https://dashboard.stryker-mutator.io, enabling you to add a fancy mutation score badge to your readme, as well as hosting your HTML report on the dashboard! It uses the [dashboard.\*](#dashboard-object) configuration options. See the [dashboard docs](../General/dashboard.md) for more info. The dashboard reporter only works on Java 11 or higher.
 
 ### `excluded-mutations` [`string[]`]
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,7 +67,7 @@ With `reporters` you can specify reporters for stryker4s to use. The following r
 - `console` will output progress and the final result to the console.
 - `html` outputs a nice HTML report to `target/stryker4s-report-$timestamp/index.html`. See the [mutation-testing-elements repo](https://github.com/stryker-mutator/mutation-testing-elements/tree/master/packages/mutation-testing-elements#mutation-testing-elements) for more information.
 - `json` writes a json of the mutation result to the same folder as the HTML reporter. The JSON is in the [mutation-testing-report-schema](https://github.com/stryker-mutator/mutation-testing-elements/tree/master/packages/mutation-testing-report-schema) format.
-- `dashboard` reporter sends a report to https://dashboard.stryker-mutator.io, enabling you to add a fancy mutation score badge to your readme, as well as hosting your HTML report on the dashboard! It uses the [dashboard.\*](#dashboard-object) configuration options. See the [dashboard docs](../General/dashboard.md) for more info. The dashboard reporter only works on Java 11 or higher.
+- `dashboard` reporter sends a report to https://dashboard.stryker-mutator.io, enabling you to add a fancy mutation score badge to your readme, as well as hosting your HTML report on the dashboard! It uses the [dashboard.\*](#dashboard-object) configuration options. See the [dashboard docs](../General/dashboard.md) for more info. The dashboard reporter only works on JDK 11 or higher.
 
 ### `excluded-mutations` [`string[]`]
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -51,7 +51,8 @@ object Dependencies {
   val catsEffect = "org.typelevel" %% "cats-effect" % versions.catsEffect
   val circeCore = "io.circe" %% "circe-core" % versions.circe
   val sttpCirce = "com.softwaremill.sttp.client3" %% "circe" % versions.sttp
-  val sttpCatsBackend = "com.softwaremill.sttp.client3" %% "async-http-client-backend-cats" % versions.sttp
+
+  val sttpFs2Backend = "com.softwaremill.sttp.client3" %% "httpclient-backend-fs2" % versions.sttp
   // To prevent dependency clashes, directly depend on the latest version of sttp-model
   val sttpModel = "com.softwaremill.sttp.model" %% "core" % versions.sttpModel
   val mutationTestingElements = "io.stryker-mutator" % "mutation-testing-elements" % versions.mutationTestingElements

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -51,7 +51,6 @@ object Dependencies {
   val catsEffect = "org.typelevel" %% "cats-effect" % versions.catsEffect
   val circeCore = "io.circe" %% "circe-core" % versions.circe
   val sttpCirce = "com.softwaremill.sttp.client3" %% "circe" % versions.sttp
-
   val sttpFs2Backend = "com.softwaremill.sttp.client3" %% "httpclient-backend-fs2" % versions.sttp
   // To prevent dependency clashes, directly depend on the latest version of sttp-model
   val sttpModel = "com.softwaremill.sttp.model" %% "core" % versions.sttpModel

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -31,7 +31,7 @@ object Settings {
       Dependencies.betterFiles,
       Dependencies.circeCore,
       Dependencies.sttpCirce,
-      Dependencies.sttpCatsBackend,
+      Dependencies.sttpFs2Backend,
       Dependencies.sttpModel,
       Dependencies.mutationTestingElements,
       Dependencies.mutationTestingMetrics,


### PR DESCRIPTION
Replaces the [sttp](https://github.com/softwaremill/sttp#readme) backend from [async-http-client](https://sttp.softwaremill.com/en/latest/backends/catseffect.html#cats-effect-backend) to [HttpClient](https://sttp.softwaremill.com/en/latest/backends/fs2.html#using-httpclient-java-11). This means the dashboard reporter will only work on Java 11 or higher. The upside is that Netty is no longer a transitive dependency. An error is logged and thrown when Java <11 tries to use the dashboard reporter.

Also moves around some reporting logic to have the HttpClient only initialize when sending the report, instead of initializing it when starting Stryker4s and keeping it alive the whole time. `FinishedRunReporter`s that throw an error will now also make Stryker4s fail instead of just logging a warning.
