### PR TITLE
Mutate regular expressions using weapon-regex

### DIFF
--- a/core/src/main/scala/stryker4s/extension/PartialFunctionOps.scala
+++ b/core/src/main/scala/stryker4s/extension/PartialFunctionOps.scala
@@ -1,0 +1,21 @@
+package stryker4s.extension
+
+import cats.{Monoid, Semigroup}
+import cats.syntax.semigroup._
+
+object PartialFunctionOps {
+
+  /** Monoid to combine two `PartialFunctions`s into one.
+    * Instead of stopping after the first PartialFunction matches, combining will try to match both PartialFunctions, and combine the result
+    */
+  implicit def partialFunctionMonoid[A, B: Semigroup]: Monoid[PartialFunction[A, B]] =
+    new Monoid[PartialFunction[A, B]] {
+
+      def combine(x: PartialFunction[A, B], y: PartialFunction[A, B]): PartialFunction[A, B] =
+        Function.unlift(x.lift.combine(y.lift))
+
+      def empty: PartialFunction[A, B] = PartialFunction.empty
+
+    }
+
+}

--- a/core/src/main/scala/stryker4s/extension/mutationtype/MutationTypes.scala
+++ b/core/src/main/scala/stryker4s/extension/mutationtype/MutationTypes.scala
@@ -18,7 +18,8 @@ object Mutation {
     classOf[ConditionalExpression].getSimpleName,
     classOf[LogicalOperator].getSimpleName,
     classOf[StringLiteral[_]].getSimpleName,
-    classOf[MethodExpression].getSimpleName
+    classOf[MethodExpression].getSimpleName,
+    classOf[RegularExpression].getSimpleName()
   )
 }
 

--- a/core/src/main/scala/stryker4s/extension/mutationtype/RegexMutator.scala
+++ b/core/src/main/scala/stryker4s/extension/mutationtype/RegexMutator.scala
@@ -1,0 +1,54 @@
+package stryker4s.extension.mutationtype
+
+import scala.meta.{Init, Term, _}
+import scala.util.{Failure, Success}
+
+import stryker4s.model.RegexParseError
+
+/** Matches on `new scala.util.matching.Regex("[a-z]", _*)`
+  */
+case object RegexConstructor {
+  // Two parents up is the full constructor
+  def unapply(arg: Lit.String): Option[Lit.String] = arg.parent
+    .flatMap(_.parent)
+    .collect {
+      case Term.New(Init(Type.Name("Regex"), _, exprss))           => exprss
+      case Term.New(Init(t"scala.util.matching.Regex", _, exprss)) => exprss
+    }
+    .collect { case (`arg` :: _) :: _ => arg }
+}
+
+/** Matches on `"[a-z]".r`
+  */
+case object RegexStringOps {
+
+  def unapply(arg: Lit.String): Option[Lit.String] = arg.parent
+    .collect { case Term.Select(`arg`, Term.Name("r")) => arg }
+
+}
+
+/** Matches on `Pattern.compile("[a-z]", _*)`
+  */
+case object PatternConstructor {
+  def unapply(arg: Lit.String): Option[Lit.String] = arg.parent.collect {
+    case Term.Apply(q"Pattern.compile", `arg` :: _)                 => arg
+    case Term.Apply(q"java.util.regex.Pattern.compile", `arg` :: _) => arg
+  }
+}
+
+object RegexMutations {
+  def apply(pattern: String): Either[RegexParseError, Seq[RegularExpression]] = {
+    weaponregex.WeaponRegeX.mutate(pattern, mutationLevels = Seq(1)) match {
+      case Failure(e)     => Left(RegexParseError(pattern, e))
+      case Success(value) => Right(value.map(r => RegularExpression(r.pattern)))
+    }
+  }
+}
+
+final case class RegularExpression(pattern: String) extends SubstitutionMutation[Lit.String] {
+
+  def mutationName: String = classOf[RegularExpression].getSimpleName
+
+  override def tree: Lit.String = Lit.String(pattern)
+
+}

--- a/core/src/main/scala/stryker4s/model/IgnoredMutationReason.scala
+++ b/core/src/main/scala/stryker4s/model/IgnoredMutationReason.scala
@@ -1,0 +1,13 @@
+package stryker4s.model
+
+/** Reason why a mutator did not produce a mutant
+  */
+sealed trait IgnoredMutationReason
+
+/** A mutation was excluded through user configuration
+  */
+final case class MutationExcluded() extends IgnoredMutationReason
+
+/** Weapon-regeX gave a failure when parsing a regular expression
+  */
+final case class RegexParseError(original: String, exception: Throwable) extends IgnoredMutationReason

--- a/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
+++ b/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
@@ -2,8 +2,8 @@ package stryker4s.mutants.findmutants
 
 import scala.meta._
 
-import cats.Semigroup
-import cats.implicits._
+import cats.syntax.either._
+import cats.syntax.semigroup._
 import stryker4s.config.Config
 import stryker4s.extension.PartialFunctionOps._
 import stryker4s.extension.TreeExtensions.{GetMods, PathToRoot, TreeIsInExtension}
@@ -76,7 +76,7 @@ class MutantMatcher()(implicit config: Config) {
 
   /** Match both strings and regexes instead of stopping when one of them gives a match
     */
-  def matchStringsAndRegex: MutationMatcher = Semigroup[MutationMatcher].combine(matchStringLiteral, matchRegex)
+  def matchStringsAndRegex: MutationMatcher = matchStringLiteral combine matchRegex
 
   def matchStringLiteral: MutationMatcher = {
     case EmptyString(orig)         => orig ~~> StrykerWasHereString

--- a/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
+++ b/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
@@ -32,10 +32,10 @@ class MutantMatcher()(implicit config: Config) {
   }
 
   def matchEqualityOperator: MutationMatcher = {
-    case GreaterThanEqualTo(orig) => orig ~~> (GreaterThan, LesserThan, EqualTo)
-    case GreaterThan(orig)        => orig ~~> (GreaterThanEqualTo, LesserThan, EqualTo)
-    case LesserThanEqualTo(orig)  => orig ~~> (LesserThan, GreaterThanEqualTo, EqualTo)
-    case LesserThan(orig)         => orig ~~> (LesserThanEqualTo, GreaterThan, EqualTo)
+    case GreaterThanEqualTo(orig) => orig.~~>(GreaterThan, LesserThan, EqualTo)
+    case GreaterThan(orig)        => orig.~~>(GreaterThanEqualTo, LesserThan, EqualTo)
+    case LesserThanEqualTo(orig)  => orig.~~>(LesserThan, GreaterThanEqualTo, EqualTo)
+    case LesserThan(orig)         => orig.~~>(LesserThanEqualTo, GreaterThan, EqualTo)
     case EqualTo(orig)            => orig ~~> NotEqualTo
     case NotEqualTo(orig)         => orig ~~> EqualTo
     case TypedEqualTo(orig)       => orig ~~> TypedNotEqualTo
@@ -48,30 +48,30 @@ class MutantMatcher()(implicit config: Config) {
   }
 
   def matchConditionalExpression: MutationMatcher = {
-    case If(condition)      => condition ~~> (ConditionalTrue, ConditionalFalse)
+    case If(condition)      => condition.~~>(ConditionalTrue, ConditionalFalse)
     case While(condition)   => condition ~~> ConditionalFalse
     case DoWhile(condition) => condition ~~> ConditionalFalse
   }
 
   def matchMethodExpression: MutationMatcher = {
-    case Filter(orig, f)      => orig ~~> (f, FilterNot)
-    case FilterNot(orig, f)   => orig ~~> (f, Filter)
-    case Exists(orig, f)      => orig ~~> (f, Forall)
-    case Forall(orig, f)      => orig ~~> (f, Exists)
-    case Take(orig, f)        => orig ~~> (f, Drop)
-    case Drop(orig, f)        => orig ~~> (f, Take)
-    case TakeRight(orig, f)   => orig ~~> (f, DropRight)
-    case DropRight(orig, f)   => orig ~~> (f, TakeRight)
-    case TakeWhile(orig, f)   => orig ~~> (f, DropWhile)
-    case DropWhile(orig, f)   => orig ~~> (f, TakeWhile)
-    case IsEmpty(orig, f)     => orig ~~> (f, NonEmpty)
-    case NonEmpty(orig, f)    => orig ~~> (f, IsEmpty)
-    case IndexOf(orig, f)     => orig ~~> (f, LastIndexOf)
-    case LastIndexOf(orig, f) => orig ~~> (f, IndexOf)
-    case Max(orig, f)         => orig ~~> (f, Min)
-    case Min(orig, f)         => orig ~~> (f, Max)
-    case MaxBy(orig, f)       => orig ~~> (f, MinBy)
-    case MinBy(orig, f)       => orig ~~> (f, MaxBy)
+    case Filter(orig, f)      => orig.~~>(f, FilterNot)
+    case FilterNot(orig, f)   => orig.~~>(f, Filter)
+    case Exists(orig, f)      => orig.~~>(f, Forall)
+    case Forall(orig, f)      => orig.~~>(f, Exists)
+    case Take(orig, f)        => orig.~~>(f, Drop)
+    case Drop(orig, f)        => orig.~~>(f, Take)
+    case TakeRight(orig, f)   => orig.~~>(f, DropRight)
+    case DropRight(orig, f)   => orig.~~>(f, TakeRight)
+    case TakeWhile(orig, f)   => orig.~~>(f, DropWhile)
+    case DropWhile(orig, f)   => orig.~~>(f, TakeWhile)
+    case IsEmpty(orig, f)     => orig.~~>(f, NonEmpty)
+    case NonEmpty(orig, f)    => orig.~~>(f, IsEmpty)
+    case IndexOf(orig, f)     => orig.~~>(f, LastIndexOf)
+    case LastIndexOf(orig, f) => orig.~~>(f, IndexOf)
+    case Max(orig, f)         => orig.~~>(f, Min)
+    case Min(orig, f)         => orig.~~>(f, Max)
+    case MaxBy(orig, f)       => orig.~~>(f, MinBy)
+    case MinBy(orig, f)       => orig.~~>(f, MaxBy)
   }
 
   /** Match both strings and regexes instead of stopping when one of them gives a match

--- a/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
+++ b/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
@@ -2,98 +2,125 @@ package stryker4s.mutants.findmutants
 
 import scala.meta._
 
+import cats.Semigroup
+import cats.implicits._
 import stryker4s.config.Config
+import stryker4s.extension.PartialFunctionOps._
 import stryker4s.extension.TreeExtensions.{GetMods, PathToRoot, TreeIsInExtension}
 import stryker4s.extension.mutationtype._
-import stryker4s.model.Mutant
+import stryker4s.model.{IgnoredMutationReason, Mutant, MutationExcluded}
 
 class MutantMatcher()(implicit config: Config) {
   private[this] val ids = Iterator.from(0)
 
-  def allMatchers: PartialFunction[Tree, Seq[Option[Mutant]]] =
+  /** A PartialFunction that can match on a ScalaMeta tree and return a `List[Either[IgnoredMutationReason, Mutant]]`
+    * If the result is a `Left`, it means a mutant was found, but ignored. The ADT [[stryker4s.model.IgnoredMutationReason]] shows the possible reasons
+    */
+  type MutationMatcher = PartialFunction[Tree, List[Either[IgnoredMutationReason, Mutant]]]
+
+  def allMatchers: MutationMatcher =
     matchBooleanLiteral orElse
       matchEqualityOperator orElse
       matchLogicalOperator orElse
       matchConditionalExpression orElse
       matchMethodExpression orElse
-      matchStringLiteral
+      matchStringsAndRegex
 
-  def matchBooleanLiteral: PartialFunction[Tree, Seq[Option[Mutant]]] = {
+  def matchBooleanLiteral: MutationMatcher = {
     case True(orig)  => orig ~~> False
     case False(orig) => orig ~~> True
   }
 
-  def matchEqualityOperator: PartialFunction[Tree, Seq[Option[Mutant]]] = {
-    case GreaterThanEqualTo(orig) => orig.~~>(GreaterThan, LesserThan, EqualTo)
-    case GreaterThan(orig)        => orig.~~>(GreaterThanEqualTo, LesserThan, EqualTo)
-    case LesserThanEqualTo(orig)  => orig.~~>(LesserThan, GreaterThanEqualTo, EqualTo)
-    case LesserThan(orig)         => orig.~~>(LesserThanEqualTo, GreaterThan, EqualTo)
+  def matchEqualityOperator: MutationMatcher = {
+    case GreaterThanEqualTo(orig) => orig ~~> (GreaterThan, LesserThan, EqualTo)
+    case GreaterThan(orig)        => orig ~~> (GreaterThanEqualTo, LesserThan, EqualTo)
+    case LesserThanEqualTo(orig)  => orig ~~> (LesserThan, GreaterThanEqualTo, EqualTo)
+    case LesserThan(orig)         => orig ~~> (LesserThanEqualTo, GreaterThan, EqualTo)
     case EqualTo(orig)            => orig ~~> NotEqualTo
     case NotEqualTo(orig)         => orig ~~> EqualTo
     case TypedEqualTo(orig)       => orig ~~> TypedNotEqualTo
     case TypedNotEqualTo(orig)    => orig ~~> TypedEqualTo
   }
 
-  def matchLogicalOperator: PartialFunction[Tree, Seq[Option[Mutant]]] = {
+  def matchLogicalOperator: MutationMatcher = {
     case And(orig) => orig ~~> Or
     case Or(orig)  => orig ~~> And
   }
 
-  def matchConditionalExpression: PartialFunction[Tree, Seq[Option[Mutant]]] = {
-    case If(condition)      => condition.~~>(ConditionalTrue, ConditionalFalse)
+  def matchConditionalExpression: MutationMatcher = {
+    case If(condition)      => condition ~~> (ConditionalTrue, ConditionalFalse)
     case While(condition)   => condition ~~> ConditionalFalse
     case DoWhile(condition) => condition ~~> ConditionalFalse
   }
 
-  def matchMethodExpression: PartialFunction[Tree, Seq[Option[Mutant]]] = {
-    case Filter(orig, f)      => orig.~~>(f, FilterNot)
-    case FilterNot(orig, f)   => orig.~~>(f, Filter)
-    case Exists(orig, f)      => orig.~~>(f, Forall)
-    case Forall(orig, f)      => orig.~~>(f, Exists)
-    case Take(orig, f)        => orig.~~>(f, Drop)
-    case Drop(orig, f)        => orig.~~>(f, Take)
-    case TakeRight(orig, f)   => orig.~~>(f, DropRight)
-    case DropRight(orig, f)   => orig.~~>(f, TakeRight)
-    case TakeWhile(orig, f)   => orig.~~>(f, DropWhile)
-    case DropWhile(orig, f)   => orig.~~>(f, TakeWhile)
-    case IsEmpty(orig, f)     => orig.~~>(f, NonEmpty)
-    case NonEmpty(orig, f)    => orig.~~>(f, IsEmpty)
-    case IndexOf(orig, f)     => orig.~~>(f, LastIndexOf)
-    case LastIndexOf(orig, f) => orig.~~>(f, IndexOf)
-    case Max(orig, f)         => orig.~~>(f, Min)
-    case Min(orig, f)         => orig.~~>(f, Max)
-    case MaxBy(orig, f)       => orig.~~>(f, MinBy)
-    case MinBy(orig, f)       => orig.~~>(f, MaxBy)
+  def matchMethodExpression: MutationMatcher = {
+    case Filter(orig, f)      => orig ~~> (f, FilterNot)
+    case FilterNot(orig, f)   => orig ~~> (f, Filter)
+    case Exists(orig, f)      => orig ~~> (f, Forall)
+    case Forall(orig, f)      => orig ~~> (f, Exists)
+    case Take(orig, f)        => orig ~~> (f, Drop)
+    case Drop(orig, f)        => orig ~~> (f, Take)
+    case TakeRight(orig, f)   => orig ~~> (f, DropRight)
+    case DropRight(orig, f)   => orig ~~> (f, TakeRight)
+    case TakeWhile(orig, f)   => orig ~~> (f, DropWhile)
+    case DropWhile(orig, f)   => orig ~~> (f, TakeWhile)
+    case IsEmpty(orig, f)     => orig ~~> (f, NonEmpty)
+    case NonEmpty(orig, f)    => orig ~~> (f, IsEmpty)
+    case IndexOf(orig, f)     => orig ~~> (f, LastIndexOf)
+    case LastIndexOf(orig, f) => orig ~~> (f, IndexOf)
+    case Max(orig, f)         => orig ~~> (f, Min)
+    case Min(orig, f)         => orig ~~> (f, Max)
+    case MaxBy(orig, f)       => orig ~~> (f, MinBy)
+    case MinBy(orig, f)       => orig ~~> (f, MaxBy)
   }
 
-  def matchStringLiteral: PartialFunction[Tree, Seq[Option[Mutant]]] = {
+  /** Match both strings and regexes instead of stopping when one of them gives a match
+    */
+  def matchStringsAndRegex: MutationMatcher = Semigroup[MutationMatcher].combine(matchStringLiteral, matchRegex)
+
+  def matchStringLiteral: MutationMatcher = {
     case EmptyString(orig)         => orig ~~> StrykerWasHereString
     case NonEmptyString(orig)      => orig ~~> EmptyString
     case StringInterpolation(orig) => orig ~~> EmptyString
   }
 
-  implicit class TermExtensions(original: Term) {
-    def ~~>[T <: Term](mutated: SubstitutionMutation[T]*): Seq[Option[Mutant]] =
-      createMutants[SubstitutionMutation[T]](mutated, _.tree)
+  def matchRegex: MutationMatcher = {
+    case RegexConstructor(orig)   => orig ~~> RegexMutations(orig.value)
+    case RegexStringOps(orig)     => orig ~~> RegexMutations(orig.value)
+    case PatternConstructor(orig) => orig ~~> RegexMutations(orig.value)
+  }
 
-    def ~~>(f: String => Term, mutated: MethodExpression*): Seq[Option[Mutant]] =
-      createMutants[MethodExpression](mutated, _(f))
+  implicit class TermExtensions(original: Term) {
+    def ~~>[T <: Term](mutated: SubstitutionMutation[T]*): List[Either[IgnoredMutationReason, Mutant]] =
+      createMutants[SubstitutionMutation[T]](mutated.toList, _.tree)
+
+    def ~~>[T <: Term](
+        mutated: Either[IgnoredMutationReason, Seq[SubstitutionMutation[T]]]
+    ): List[Either[IgnoredMutationReason, Mutant]] = mutated match {
+      case Left(v)      => List(v.asLeft)
+      case Right(value) => ~~>(value: _*)
+    }
+
+    def ~~>(f: String => Term, mutated: MethodExpression*): List[Either[IgnoredMutationReason, Mutant]] =
+      createMutants[MethodExpression](mutated.toList, _(f))
 
     private def createMutants[T <: Mutation[_ <: Tree]](
-        mutations: Seq[T],
+        mutations: List[T],
         mutationToTerm: T => Term
-    ): Seq[Option[Mutant]] =
+    ): List[Either[IgnoredMutationReason, Mutant]] =
       ifNotInAnnotation {
         mutations
           .map { mutated =>
             if (matchExcluded(mutated) || isSuppressedByAnnotation(mutated, original))
-              None
+              Left(MutationExcluded())
             else
-              Some(Mutant(ids.next(), original, mutationToTerm(mutated), mutated))
+              Right(Mutant(ids.next(), original, mutationToTerm(mutated), mutated))
           }
       }
 
-    private def ifNotInAnnotation(maybeMutants: => Seq[Option[Mutant]]): Seq[Option[Mutant]] = {
+    private def ifNotInAnnotation(
+        maybeMutants: => List[Either[IgnoredMutationReason, Mutant]]
+    ): List[Either[IgnoredMutationReason, Mutant]] = {
       if (original.isIn[Mod.Annot])
         Nil
       else

--- a/core/src/test/scala/stryker4s/config/ConfigReaderTest.scala
+++ b/core/src/test/scala/stryker4s/config/ConfigReaderTest.scala
@@ -127,7 +127,7 @@ class ConfigReaderTest extends Stryker4sSuite with LogMatchers with ConfigReader
       val head = exc.failures.head
       head shouldBe a[ConvertFailure]
       val errorMessage =
-        "Cannot convert 'Invalid, StillInvalid, BooleanLiteral' to excluded-mutations: invalid option(s) 'Invalid, StillInvalid'. Valid exclusions are 'EqualityOperator, BooleanLiteral, ConditionalExpression, LogicalOperator, StringLiteral, MethodExpression'."
+        "Cannot convert 'Invalid, StillInvalid, BooleanLiteral' to excluded-mutations: invalid option(s) 'Invalid, StillInvalid'. Valid exclusions are 'EqualityOperator, BooleanLiteral, ConditionalExpression, LogicalOperator, StringLiteral, MethodExpression, RegularExpression'."
       errorMessage shouldBe loggedAsError
     }
 

--- a/core/src/test/scala/stryker4s/extension/PartialFunctionOpsTest.scala
+++ b/core/src/test/scala/stryker4s/extension/PartialFunctionOpsTest.scala
@@ -1,0 +1,56 @@
+package stryker4s.extension
+
+import stryker4s.testutil.Stryker4sSuite
+
+import PartialFunctionOps._
+import cats.syntax.monoid._
+import cats.kernel.Monoid
+import scala.meta.Lit
+
+class PartialFunctionOpsTest extends Stryker4sSuite {
+
+  type TestPF = PartialFunction[Int, List[String]]
+  describe("Monoid") {
+    val result1 = List("foo", "bar")
+    val result2 = List("baz", "qux")
+
+    it("when combined still calls the first PF") {
+      val pf1: TestPF = { case 1 => result1 }
+      val pf2: TestPF = { case 2 => result2 }
+
+      pf1.combine(pf2)(1) shouldBe result1
+    }
+
+    it("when combined still calls the second PF") {
+      val pf1: TestPF = { case 1 => result1 }
+      val pf2: TestPF = { case 2 => result2 }
+
+      pf1.combine(pf2)(2) shouldBe result2
+    }
+
+    it("combines the result when both PFs match") {
+      val pf1: TestPF = { case 1 => result1 }
+      val pf2: TestPF = { case 1 => result2 }
+
+      pf1.combine(pf2)(1) shouldBe result1 ++ result2
+    }
+
+    it("combines the result multiple times with combineN") {
+      val pf1: TestPF = { case 1 => result1 }
+
+      pf1.combineN(3)(1) shouldBe result1 ++ result1 ++ result1
+    }
+
+    it("Empty Monoid is equal to empty PartialFunction") {
+      PartialFunction.empty shouldBe Monoid[TestPF].empty
+    }
+
+    it("Empty Monoid should not match on anything equal to empty PartialFunction") {
+      Monoid[TestPF].empty.isDefinedAt(0) shouldBe false
+    }
+
+    it("should not be able to combine PF's that can't combine the result") {
+      "Monoid[PartialFunction[Int, Lit.String]]" shouldNot compile
+    }
+  }
+}

--- a/core/src/test/scala/stryker4s/mutants/AddAllMutationsTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/AddAllMutationsTest.scala
@@ -33,7 +33,7 @@ class AddAllMutationsTest extends Stryker4sSuite with LogMatchers {
 
     def checkAllMutationsAreAdded(tree: Stat)(implicit pos: Position) = {
       val source = source"class Foo { $tree }"
-      val foundMutants = source.collect(new MutantMatcher().allMatchers).flatten.flatten
+      val foundMutants = source.collect(new MutantMatcher().allMatchers).flatten.collect { case Right(v) => v }
       val transformed = new StatementTransformer().transformSource(source, foundMutants)
       val mutatedTree = new MatchBuilder(ActiveMutationContext.envVar).buildNewSource(transformed)
       transformed.transformedStatements.foreach(transformedMutants =>

--- a/core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala
@@ -170,6 +170,28 @@ class MutantFinderTest extends Stryker4sSuite with LogMatchers {
       excluded shouldBe 3
       result should have length 3
     }
+
+    it("should log unparsable regular expressions") {
+      implicit val config: Config = Config.default
+
+      val sut = new MutantFinder(new MutantMatcher)
+      val regex = Lit.String("[[]]")
+      val source =
+        source"""case class Bar() {
+                    def foobar = new Regex($regex)
+                  }"""
+
+      val result = sut.findMutants(source)
+
+      // 1 empty-string found
+      val mutant = result._1.loneElement
+      assert(mutant.original.isEqual(regex))
+      assert(mutant.mutated.isEqual(Lit.String("")))
+      // 0 excluded
+      result._2 shouldBe 0
+
+      "[RegexMutator]: The Regex parser of weapon-regex couldn't parse this regex pattern: '[[]]'. Please report this issue at https://github.com/stryker-mutator/weapon-regex/issues. Inner error:" shouldBe loggedAsError
+    }
   }
 
   describe("mutantsInFile") {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,48 +15,53 @@ object Dependencies {
       */
     val fullCrossScalaVersions = crossScalaVersions ++ Seq(scala211, scala3)
 
-    val testInterface = "1.0"
-    val scalameta = "4.4.7"
-    val pureconfig = "0.14.0"
-    val scalatest = "3.2.3"
+    // Test dependencies
     val catsEffectScalaTest = "0.5.0"
     val mockitoScala = "1.16.15"
+    val scalatest = "3.2.3"
+
+    // Direct dependencies
     val betterFiles = "3.9.1"
-    val log4j = "2.14.0"
     val catsCore = "2.3.1"
     val catsEffect = "2.3.1"
     val circe = "0.13.0"
+    val fs2 = "2.5.0"
+    val log4j = "2.14.0"
     val mutationTestingElements = "1.5.2"
     val mutationTestingMetrics = "1.5.1"
+    val pureconfig = "0.14.0"
+    val scalameta = "4.4.7"
     val sttp = "3.0.0"
     val sttpModel = "1.2.0"
-    val fs2 = "2.5.0"
+    val testInterface = "1.0"
+    val weaponRegeX = "0.3.0"
   }
 
   object test {
-    val scalatest = "org.scalatest" %% "scalatest" % versions.scalatest % Test
+    val catsEffectScalaTest = "com.codecommit" %% "cats-effect-testing-scalatest" % versions.catsEffectScalaTest % Test
     val mockitoScala = "org.mockito" %% "mockito-scala-scalatest" % versions.mockitoScala % Test
     val mockitoScalaCats = "org.mockito" %% "mockito-scala-cats" % versions.mockitoScala % Test
-    // For easier testing with IO
-    val catsEffectScalaTest = "com.codecommit" %% "cats-effect-testing-scalatest" % versions.catsEffectScalaTest % Test
+    val scalatest = "org.scalatest" %% "scalatest" % versions.scalatest % Test
   }
 
-  val testInterface = "org.scala-sbt" % "test-interface" % versions.testInterface
-  val pureconfig = "com.github.pureconfig" %% "pureconfig" % versions.pureconfig
-  val pureconfigSttp = "com.github.pureconfig" %% "pureconfig-sttp" % versions.pureconfig
-  val scalameta = "org.scalameta" %% "scalameta" % versions.scalameta
   val betterFiles = "com.github.pathikrit" %% "better-files" % versions.betterFiles
-  val log4j = "org.apache.logging.log4j" % "log4j-slf4j-impl" % versions.log4j
   val catsCore = "org.typelevel" %% "cats-core" % versions.catsCore
   val catsEffect = "org.typelevel" %% "cats-effect" % versions.catsEffect
   val circeCore = "io.circe" %% "circe-core" % versions.circe
-  val sttpCirce = "com.softwaremill.sttp.client3" %% "circe" % versions.sttp
-  val sttpFs2Backend = "com.softwaremill.sttp.client3" %% "httpclient-backend-fs2" % versions.sttp
-  // To prevent dependency clashes, directly depend on the latest version of sttp-model
-  val sttpModel = "com.softwaremill.sttp.model" %% "core" % versions.sttpModel
+  val fs2Core = "co.fs2" %% "fs2-core" % versions.fs2
+  val fs2IO = "co.fs2" %% "fs2-io" % versions.fs2
+  val log4j = "org.apache.logging.log4j" % "log4j-slf4j-impl" % versions.log4j
   val mutationTestingElements = "io.stryker-mutator" % "mutation-testing-elements" % versions.mutationTestingElements
   val mutationTestingMetrics =
     "io.stryker-mutator" %% "mutation-testing-metrics-circe" % versions.mutationTestingMetrics
-  val fs2Core = "co.fs2" %% "fs2-core" % versions.fs2
-  val fs2IO = "co.fs2" %% "fs2-io" % versions.fs2
+  val pureconfig = "com.github.pureconfig" %% "pureconfig" % versions.pureconfig
+  val pureconfigSttp = "com.github.pureconfig" %% "pureconfig-sttp" % versions.pureconfig
+  val scalameta = "org.scalameta" %% "scalameta" % versions.scalameta
+  val sttpCirce = "com.softwaremill.sttp.client3" %% "circe" % versions.sttp
+  val sttpFs2Backend = "com.softwaremill.sttp.client3" %% "httpclient-backend-fs2" % versions.sttp
+  // To prevent dependency resolvement getting a lower version, directly depend on the latest version of sttp-model
+  val sttpModel = "com.softwaremill.sttp.model" %% "core" % versions.sttpModel
+  val testInterface = "org.scala-sbt" % "test-interface" % versions.testInterface
+  val weaponRegeX = "io.stryker-mutator" %% "weapon-regex" % versions.weaponRegeX
+
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -21,24 +21,25 @@ object Settings {
   lazy val coreSettings: Seq[Setting[_]] = Seq(
     parallelExecution in Test := false,
     libraryDependencies ++= Seq(
-      Dependencies.test.scalatest,
-      Dependencies.test.mockitoScala,
-      Dependencies.test.mockitoScalaCats,
-      Dependencies.test.catsEffectScalaTest,
+      Dependencies.betterFiles,
+      Dependencies.catsCore,
+      Dependencies.catsEffect,
+      Dependencies.circeCore,
+      Dependencies.fs2Core,
+      Dependencies.fs2IO,
+      Dependencies.mutationTestingElements,
+      Dependencies.mutationTestingMetrics,
       Dependencies.pureconfig,
       Dependencies.pureconfigSttp,
       Dependencies.scalameta,
-      Dependencies.betterFiles,
-      Dependencies.circeCore,
       Dependencies.sttpCirce,
       Dependencies.sttpFs2Backend,
       Dependencies.sttpModel,
-      Dependencies.mutationTestingElements,
-      Dependencies.mutationTestingMetrics,
-      Dependencies.catsCore,
-      Dependencies.catsEffect,
-      Dependencies.fs2Core,
-      Dependencies.fs2IO
+      Dependencies.weaponRegeX,
+      Dependencies.test.catsEffectScalaTest,
+      Dependencies.test.mockitoScala,
+      Dependencies.test.mockitoScalaCats,
+      Dependencies.test.scalatest
     )
   )
 


### PR DESCRIPTION
Implements weapon-regex to mutate regular expressions. Can recognize regular expressions on 3 patterns:

```scala
// Option 1: Scala regex constructor
def regex1 = new Regex("[a-z]")
def regex1 = new scala.util.matching.Regex("[a-z]")
// Option 2: Java regex constructor
def regex2 = Pattern.compile("[a-z]")
def regex2 = java.util.regex.Pattern.compile("[a-z]")
// Option 3: `.r` op on String
def regex3 = "[a-z]".r
```

For now, only regex level 1 is enabled. Once we agree on what levels mean what for mutation testing we can add more fine-grained control over regular expression mutators.
