### PR TITLE
Fix pattern interpolation matching on string mutations

### DIFF
--- a/core/src/main/scala/stryker4s/extension/mutationtype/StringLiteral.scala
+++ b/core/src/main/scala/stryker4s/extension/mutationtype/StringLiteral.scala
@@ -1,6 +1,6 @@
 package stryker4s.extension.mutationtype
 
-import scala.meta.{Lit, Term}
+import scala.meta.{Lit, Pat, Term}
 
 case object EmptyString extends StringLiteral[Lit.String] {
   override val tree: Lit.String = Lit.String("")
@@ -36,6 +36,7 @@ private object ParentIsInterpolatedString {
     arg.parent match {
       // Do not mutate interpolated strings
       case Some(_: Term.Interpolate) => true
+      case Some(_: Pat.Interpolate)  => true
       case _                         => false
     }
 }

--- a/core/src/test/scala/stryker4s/extension/mutationtype/MutationTypesTest.scala
+++ b/core/src/test/scala/stryker4s/extension/mutationtype/MutationTypesTest.scala
@@ -73,6 +73,12 @@ class MutationTypesTest extends Stryker4sSuite {
         case StringInterpolation(_) =>
       }
     }
+
+    it("t interpolation should not match StringInterpolation") {
+      Term.Interpolate(q"t", List(Lit.String("scala.util.matching.Regex")), List.empty) should not matchPattern {
+        case StringInterpolation(_) =>
+      }
+    }
   }
 
   describe("other cases") {

--- a/core/src/test/scala/stryker4s/mutants/findmutants/MutantMatcherTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/MutantMatcherTest.scala
@@ -385,6 +385,33 @@ class MutantMatcherTest extends Stryker4sSuite {
       interpolated.syntax should equal("q\"interpolate $foo\"")
       result should be(empty)
     }
+
+    it("should not match pattern interpolation") {
+      val tree = source"""class Foo {
+        def bar = {
+          case t"interpolate" => _
+        }
+      }"""
+
+      val result = tree collect sut.allMatchers
+
+      result should be(empty)
+    }
+
+    it("should match pattern in string") {
+      val str = Lit.String("str")
+      val tree = source"""class Foo {
+        def bar = {
+          case "str" => 4
+        }
+      }"""
+      expectMutations(
+        sut.matchStringLiteral,
+        tree,
+        str,
+        Lit.String("")
+      )
+    }
   }
 
   describe("regexMutator") {


### PR DESCRIPTION
Pattern interpolation would be matched and mutated, even if it would create compile errors:

```scala
a match {
  case q"foo.bar" => _
}
```

Would be mutated to:

```scala
a match {
  case q"" => _
}
```

And create a compile error. This PR fixes string mutators matching on Pattern interpolation
