### PR TITLE
Edit default concurrency algorithm to be more conservative

### DIFF
--- a/core/src/main/scala/stryker4s/config/Config.scala
+++ b/core/src/main/scala/stryker4s/config/Config.scala
@@ -26,11 +26,13 @@ final case class Config(
 
 object Config extends pure.ConfigConfigReader with circe.ConfigEncoder {
 
-  private def defaultConcurrency: Int = {
-    // Use n / 2 concurrency unless this machine has a low processor-count
-    val cpuCoreCount = Runtime.getRuntime().availableProcessors()
+  private def defaultConcurrency: Int = concurrencyFor(Runtime.getRuntime().availableProcessors())
+
+  def concurrencyFor(cpuCoreCount: Int) = {
+    // Use (n / 4 concurrency, rounded) + 1
     if (cpuCoreCount > 4) cpuCoreCount / 2
     else cpuCoreCount
+    (cpuCoreCount.toDouble / 4).round.toInt + 1
   }
 
   /** Type alias for `Set[String]` so extra validation can be done

--- a/core/src/test/scala/stryker4s/config/ConfigTest.scala
+++ b/core/src/test/scala/stryker4s/config/ConfigTest.scala
@@ -1,0 +1,29 @@
+package stryker4s.config
+
+import stryker4s.testutil.Stryker4sSuite
+
+class ConfigTest extends Stryker4sSuite {
+  describe("concurrency") {
+    val expectedConcurrencies = Map(
+      1 -> 1,
+      2 -> 2,
+      3 -> 2,
+      4 -> 2,
+      6 -> 3,
+      8 -> 3,
+      10 -> 4,
+      12 -> 4,
+      16 -> 5,
+      20 -> 6,
+      24 -> 7,
+      28 -> 8,
+      32 -> 9
+    )
+
+    expectedConcurrencies.foreach { case (cpuCoreCount, expectedConcurrency) =>
+      it(s"should give concurrency $expectedConcurrency for $cpuCoreCount cpu cores") {
+        Config.concurrencyFor(cpuCoreCount) shouldBe expectedConcurrency
+      }
+    }
+  }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -180,11 +180,11 @@ For the last two cases, please [let us know by creating an issue](https://github
 ### `concurrency` [`number`]
 
 **Config file:** `concurrency: 4`  
-**Default value:** `if (cpuCoreCount > 4) cpuCoreCount / 2 else cpuCoreCount`  
+**Default value:** `(cpuCoreCount / 4).rounded + 1`  
 **Since:** `v0.12.0`  
 **Description:**
 
-Set the concurrency of testrunners. Stryker4s will create this many testrunners to run mutants in parallel. This defaults to `n / 2` where `n` is the number of available processors on your machine, or `n` if `n <= 4`. This is a sane default for most use cases. But as always with concurrency, test it yourself to be sure of the best performance.
+Set the concurrency of testrunners. Stryker4s will create this many testrunners to run mutants in parallel. This defaults to `(cpuCoreCount / 4).rounded + 1`. `cpuCoreCount` includes virtual processors such as from hyperthreading. This is a sane default for most use cases as most test frameworks already have some form of concurrency built in. But as always with concurrency, test it yourself to be sure of the best performance.
 
 ## Process runner config
 


### PR DESCRIPTION
From testing, something around a little above 1/4th seems to give the best performance.
