### PR TITLE
Simplest way make config file selectable

### DIFF
--- a/core/src/main/scala/stryker4s/config/ConfigReader.scala
+++ b/core/src/main/scala/stryker4s/config/ConfigReader.scala
@@ -16,7 +16,9 @@ object ConfigReader {
 
   implicit val hint: ProductHint[Config] = ProductHint[Config](allowUnknownKeys = false)
 
-  def readConfig(confSource: ConfigSource = ConfigSource.file("stryker4s.conf"))(implicit log: Logger): Config = {
+  lazy val defaultConfig = ConfigSource.file(System.getProperty("stryker4s.config.file", "stryker4s.conf"))
+
+  def readConfig(confSource: ConfigSource = defaultConfig)(implicit log: Logger): Config = {
     Reader
       .withoutRecovery[Config](confSource)
       .recoverWithReader(Failure.onUnknownKey)
@@ -25,7 +27,7 @@ object ConfigReader {
   }
 
   def readConfigOfType[T](
-      confSource: ConfigSource = ConfigSource.file("stryker4s.conf")
+      confSource: ConfigSource = defaultConfig
   )(implicit log: Logger, pureconfig: PureConfigReader[T]): Either[ConfigReaderFailures, T] =
     Reader.withoutRecovery[T](confSource).tryRead
 
@@ -75,7 +77,7 @@ object ConfigReader {
     /** Attempt to read a config
       */
     def tryRead: Reader.Result[T] = {
-      log.info(s"Attempting to read config from stryker4s.conf")
+      log.info(s"Attempting to read config from ${defaultConfig}")
       configSource
         .at("stryker4s")
         .load[T]


### PR DESCRIPTION
#### What it does

Makes the config file path less hardcoded, e.g. allows `sbt -Dstryker4s.config.file=mod-x/stryker4s.conf stryker`. Not sure if we should go the "make it a parameter of the sbt task"-route, but _at least_ this is a much less invasive fix, and is already much better than having to move config files around in the filesystem, just in order to switch between subproject runs.

#### How it works

Not sure if it works - this PR comes straight from the GitHub file editor ;) 