### PR TITLE
Fix [SomeClass] is already defined as [SomeClass]

### DIFF
--- a/sbt/src/sbt-test/sbt-stryker4s/test-1/build.sbt
+++ b/sbt/src/sbt-test/sbt-stryker4s/test-1/build.sbt
@@ -1,3 +1,7 @@
 scalaVersion := "2.12.14"
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.2" % Test // scala-steward:off
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.9" % Test // scala-steward:off
+
+// Reproduce https://github.com/stryker-mutator/stryker4s/issues/726
+(Compile / scalaSource) := baseDirectory.value / "src" / "main" / "scala"
+(Compile / javaSource) := baseDirectory.value / "src" / "main" / "scala"


### PR DESCRIPTION
Fixes #726

Sbt has two settings to control where source code is: one for Java and one for Scala (`javaSource` and `scalaSource` respectively). In some cases, like in Play Framework, both of those settings point to the same directory:

https://github.com/playframework/playframework/blob/c5a0193afe2069fd16feba29960638609bd2eaa8/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayLayoutPlugin.scala#L30-L31

This means that when Stryker4s sets the `scalaSource` to the new directory with mutated code, the `javaSource` still points to the old directory, giving sbt two directories with the same filenames and code (one mutated, one not mutated).

This PR fixes this by setting the `javaSource` to the new directory that Stryker4s created. For Play Framework, this works because both source settings now point to the same files again. And it works for any projects with Java code because all non-mutated code (such as Java files) are also copied to `target/stryker4s-*`.

Thanks very much to @cbrunnkvist for the reproducible repo and information!