### PR TITLE
Always read base-dir config as absolute path

### DIFF
--- a/core/src/main/scala/stryker4s/config/pure/ConfigConfigReader.scala
+++ b/core/src/main/scala/stryker4s/config/pure/ConfigConfigReader.scala
@@ -19,7 +19,7 @@ import scala.meta.dialects._
 trait ConfigConfigReader {
 
   implicit def pathReader: ConfigReader[Path] =
-    ConfigReader[JPath] map (Path.fromNioPath)
+    ConfigReader[JPath].map(Path.fromNioPath).map(_.absolute)
 
   implicit def reporterReader: ConfigReader[ReporterType] =
     deriveEnumerationReader[ReporterType]


### PR DESCRIPTION
Prevents `'other' is different type of Path` exception when defining a base-dir