### PR TITLE
Don't mutate xml literals

### DIFF
--- a/core/src/test/scala/stryker4s/mutants/findmutants/MutantMatcherTest.scala
+++ b/core/src/test/scala/stryker4s/mutants/findmutants/MutantMatcherTest.scala
@@ -412,6 +412,47 @@ class MutantMatcherTest extends Stryker4sSuite {
         Lit.String("")
       )
     }
+
+    it("should not match xml literals") {
+      val tree = source"""class Foo {
+        def bar = ${Term.Xml(List(Lit.String("<foo>"), Lit.String("</foo>")), List(q"foo"))}
+      }"""
+
+      val result = tree collect sut.allMatchers
+
+      result should be(empty)
+    }
+
+    it("should not match empty strings on xml literals") {
+      val tree = source"""class Foo {
+        def bar = ${Term.Xml(List(Lit.String("<foo>"), Lit.String("")), List(q"foo"))}
+      }"""
+
+      val result = tree collect sut.allMatchers
+
+      result should be(empty)
+    }
+
+    it("should match inside xml literal args") {
+      val str = Lit.String("str")
+      val tree = source"""class Foo {
+        def bar = ${Term.Xml(List(Lit.String("<foo>"), Lit.String("</foo>")), List(str))}
+      }"""
+      expectMutations(
+        sut.matchStringLiteral,
+        tree,
+        str,
+        Lit.String("")
+      )
+    }
+
+    it("should not match xml interpolation") {
+      val tree = Pat.Xml(List(Lit.String("<foo></xml>")), List.empty)
+
+      val result = tree collect sut.allMatchers
+
+      result should be(empty)
+    }
   }
 
   describe("regexMutator") {


### PR DESCRIPTION
### Fixes #928

#### What it does

XML literals are no longer mutated. Fixes a bug where xml literals would be mutated, resulting in invalid code.

#### How it works

The string literal mutator now checks if it is not part of a xml literal. Mutations interpolated inside xml literals still mutate:

```scala
val p = <p>${"foo"}</p> // Mutates "foo"
val h1 = <h1>foo</h1> // No mutations
```
