### PR TITLE
Add debug configuration options

### DIFF
--- a/command-runner/src/main/scala/stryker4s/command/runner/ProcessTestRunner.scala
+++ b/command-runner/src/main/scala/stryker4s/command/runner/ProcessTestRunner.scala
@@ -2,6 +2,7 @@ package stryker4s.command.runner
 
 import cats.effect.IO
 import fs2.io.file.Path
+import stryker4s.config.Config
 import stryker4s.model._
 import stryker4s.run.TestRunner
 import stryker4s.run.process.{Command, ProcessRunner}
@@ -9,7 +10,8 @@ import stryker4s.run.process.{Command, ProcessRunner}
 import scala.concurrent.TimeoutException
 import scala.util.{Failure, Success}
 
-class ProcessTestRunner(command: Command, processRunner: ProcessRunner, tmpDir: Path) extends TestRunner {
+class ProcessTestRunner(command: Command, processRunner: ProcessRunner, tmpDir: Path)(implicit config: Config)
+    extends TestRunner {
   def initialTestRun(): IO[InitialTestRunResult] = {
     processRunner(command, tmpDir, List.empty[(String, String)]: _*).map {
       case Success(0) => NoCoverageInitialTestRun(true)

--- a/command-runner/src/test/scala/stryker4s/run/ProcessTestRunnerTest.scala
+++ b/command-runner/src/test/scala/stryker4s/run/ProcessTestRunnerTest.scala
@@ -2,6 +2,7 @@ package stryker4s.run
 
 import fs2.io.file.Path
 import stryker4s.command.runner.ProcessTestRunner
+import stryker4s.config.Config
 import stryker4s.extension.mutationtype.EmptyString
 import stryker4s.model._
 import stryker4s.run.process.{Command, ProcessRunner}
@@ -15,6 +16,7 @@ import scala.util.{Failure, Success}
 
 class ProcessTestRunnerTest extends Stryker4sIOSuite with MockitoIOSuite with LogMatchers {
 
+  implicit val config: Config = Config.default
   def processTestRunner(processRunner: ProcessRunner) =
     new ProcessTestRunner(Command("foo", "test"), processRunner, Path("."))
 

--- a/core/src/main/scala/stryker4s/config/Config.scala
+++ b/core/src/main/scala/stryker4s/config/Config.scala
@@ -20,7 +20,8 @@ final case class Config(
     maxTestRunnerReuse: Option[Int] = None,
     legacyTestRunner: Boolean = false,
     scalaDialect: Dialect = dialects.Scala3,
-    concurrency: Int = Config.defaultConcurrency
+    concurrency: Int = Config.defaultConcurrency,
+    debug: DebugOptions = DebugOptions()
 )
 
 object Config extends pure.ConfigConfigReader with circe.ConfigEncoder {

--- a/core/src/main/scala/stryker4s/config/DebugOptions.scala
+++ b/core/src/main/scala/stryker4s/config/DebugOptions.scala
@@ -1,0 +1,6 @@
+package stryker4s.config
+
+final case class DebugOptions(
+    logTestRunnerStdout: Boolean = false,
+    debugTestRunner: Boolean = false
+)

--- a/core/src/main/scala/stryker4s/config/circe/ConfigEncoder.scala
+++ b/core/src/main/scala/stryker4s/config/circe/ConfigEncoder.scala
@@ -12,7 +12,7 @@ import scala.meta.Dialect
   */
 trait ConfigEncoder {
   implicit def configEncoder: Encoder[Config] = Encoder
-    .forProduct13(
+    .forProduct14(
       "mutate",
       "test-filter",
       "base-dir",
@@ -25,7 +25,8 @@ trait ConfigEncoder {
       "timeout-factor",
       "max-test-runner-reuse",
       "legacy-test-runner",
-      "scala-dialect"
+      "scala-dialect",
+      "debug"
     )((c: Config) =>
       (
         c.mutate,
@@ -40,7 +41,8 @@ trait ConfigEncoder {
         c.timeoutFactor,
         c.maxTestRunnerReuse,
         c.legacyTestRunner,
-        c.scalaDialect
+        c.scalaDialect,
+        c.debug
       )
     )
     .mapJson(_.deepDropNullValues)
@@ -74,4 +76,6 @@ trait ConfigEncoder {
 
   implicit def dialectEncoder: Encoder[Dialect] = Encoder[String].contramap(_.toString.toLowerCase)
 
+  implicit def debugOptionsEncoder: Encoder[DebugOptions] =
+    Encoder.forProduct2("log-test-runner-stdout", "debug-test-runner")(d => (d.logTestRunnerStdout, d.debugTestRunner))
 }

--- a/core/src/main/scala/stryker4s/run/Stryker4sRunner.scala
+++ b/core/src/main/scala/stryker4s/run/Stryker4sRunner.scala
@@ -49,9 +49,11 @@ abstract class Stryker4sRunner(implicit log: Logger) {
           catch {
             case e: BootstrapMethodError =>
               // Wrap in a UnsupportedOperationException because BootstrapMethodError will not be caught
-              throw new UnsupportedOperationException(
-                "Could not send results to dashboard. The dashboard reporter only supports JDK 11 or above. If you are running on a lower Java version please upgrade or disable the dashboard reporter.",
-                e
+              Resource.raiseError[IO, Nothing, Throwable](
+                new UnsupportedOperationException(
+                  "Could not send results to dashboard. The dashboard reporter only supports JDK 11 or above. If you are running on a lower Java version please upgrade or disable the dashboard reporter.",
+                  e
+                )
               )
           }
         new DashboardReporter(new DashboardConfigProvider(sys.env))

--- a/core/src/main/scala/stryker4s/run/process/ProcessResource.scala
+++ b/core/src/main/scala/stryker4s/run/process/ProcessResource.scala
@@ -5,8 +5,8 @@ import scala.sys.process.{ProcessBuilder, ProcessLogger}
 import cats.effect.{IO, Resource}
 
 object ProcessResource {
-  def fromProcessBuilder(pb: => ProcessBuilder)(logger: String => Unit) = for {
-    startedProcess <- Resource.eval(IO(pb))
-    process <- Resource.make(IO(startedProcess.run(ProcessLogger(logger(_)))))(p => IO(p.destroy()))
-  } yield process
+  def fromProcessBuilder(pb: => ProcessBuilder)(logger: String => Unit) = {
+    val processLogger = ProcessLogger(logger(_))
+    Resource.make(IO(pb.run(processLogger)))(p => IO(p.destroy()))
+  }
 }

--- a/core/src/main/scala/stryker4s/run/process/WindowsProcessRunner.scala
+++ b/core/src/main/scala/stryker4s/run/process/WindowsProcessRunner.scala
@@ -2,16 +2,17 @@ package stryker4s.run.process
 
 import cats.effect.IO
 import fs2.io.file.Path
+import stryker4s.config.Config
 import stryker4s.log.Logger
 
 import scala.util.Try
 
 class WindowsProcessRunner(implicit log: Logger) extends ProcessRunner {
-  override def apply(command: Command, workingDir: Path): Try[Seq[String]] = {
+  override def apply(command: Command, workingDir: Path): Try[Seq[String]] =
     super.apply(Command(s"cmd /c ${command.command}", command.args), workingDir)
-  }
 
-  override def apply(command: Command, workingDir: Path, envVar: (String, String)*): IO[Try[Int]] = {
-    super.apply(Command(s"cmd /c ${command.command}", command.args), workingDir, envVar: _*)
-  }
+  override def apply(command: Command, workingDir: Path, envVar: (String, String)*)(implicit
+      config: Config
+  ): IO[Try[Int]] = super.apply(Command(s"cmd /c ${command.command}", command.args), workingDir, envVar: _*)
+
 }

--- a/core/src/test/scala/stryker4s/config/ConfigReaderTest.scala
+++ b/core/src/test/scala/stryker4s/config/ConfigReaderTest.scala
@@ -63,6 +63,7 @@ class ConfigReaderTest extends Stryker4sSuite with LogMatchers {
         module = None
       )
       result.scalaDialect shouldBe Scala3
+      result.debug shouldBe DebugOptions(false, false)
     }
 
     it("should fail on an empty config file") {

--- a/core/src/test/scala/stryker4s/config/ConfigReaderTest.scala
+++ b/core/src/test/scala/stryker4s/config/ConfigReaderTest.scala
@@ -31,6 +31,7 @@ class ConfigReaderTest extends Stryker4sSuite with LogMatchers {
           config.legacyTestRunner shouldBe true
           config.scalaDialect shouldBe Scala212
           config.concurrency shouldBe 3
+          config.debug shouldBe DebugOptions(true, true)
       }
     }
 

--- a/core/src/test/scala/stryker4s/config/circe/ConfigEncoderTest.scala
+++ b/core/src/test/scala/stryker4s/config/circe/ConfigEncoderTest.scala
@@ -16,7 +16,7 @@ class ConfigEncoderTest extends Stryker4sSuite {
         s"""{"mutate":[],"test-filter":[],"base-dir":"${workspaceLocation.replace(
           "\\",
           "\\\\"
-        )}","reporters":["console","html"],"files":[],"excluded-mutations":[],"thresholds":{"high":80,"low":60,"break":0},"dashboard":{"base-url":"https://dashboard.stryker-mutator.io","report-type":"full"},"timeout":5000,"timeout-factor":1.5,"legacy-test-runner":false,"scala-dialect":"scala3"}"""
+        )}","reporters":["console","html"],"files":[],"excluded-mutations":[],"thresholds":{"high":80,"low":60,"break":0},"dashboard":{"base-url":"https://dashboard.stryker-mutator.io","report-type":"full"},"timeout":5000,"timeout-factor":1.5,"legacy-test-runner":false,"scala-dialect":"scala3","debug":{"log-test-runner-stdout":false,"debug-test-runner":false}}"""
       )
     }
 
@@ -32,6 +32,10 @@ class ConfigEncoderTest extends Stryker4sSuite {
             project = Some("myProject"),
             version = Some("1.3.3.7"),
             module = Some("myModule")
+          ),
+          debug = DebugOptions(
+            logTestRunnerStdout = true,
+            debugTestRunner = true
           )
         ),
         defaultConfigJson.mapObject(
@@ -50,11 +54,18 @@ class ConfigEncoderTest extends Stryker4sSuite {
                 "module" -> fromString("myModule")
               )
             )
+            .add(
+              "debug",
+              obj(
+                "log-test-runner-stdout" -> fromBoolean(true),
+                "debug-test-runner" -> fromBoolean(true)
+              )
+            )
         ),
         s"""{"mutate":["**/main/scala/**.scala"],"test-filter":["foo.scala"],"base-dir":"${workspaceLocation.replace(
           "\\",
           "\\\\"
-        )}","reporters":["console","html"],"files":["file.scala"],"excluded-mutations":["bar.scala"],"thresholds":{"high":80,"low":60,"break":0},"dashboard":{"base-url":"https://dashboard.stryker-mutator.io","report-type":"full","project":"myProject","version":"1.3.3.7","module":"myModule"},"timeout":5000,"timeout-factor":1.5,"max-test-runner-reuse":2,"legacy-test-runner":false,"scala-dialect":"scala3"}"""
+        )}","reporters":["console","html"],"files":["file.scala"],"excluded-mutations":["bar.scala"],"thresholds":{"high":80,"low":60,"break":0},"dashboard":{"base-url":"https://dashboard.stryker-mutator.io","report-type":"full","project":"myProject","version":"1.3.3.7","module":"myModule"},"timeout":5000,"timeout-factor":1.5,"max-test-runner-reuse":2,"legacy-test-runner":false,"scala-dialect":"scala3","debug":{"log-test-runner-stdout":true,"debug-test-runner":true}}"""
       )
     }
   }
@@ -87,6 +98,10 @@ class ConfigEncoderTest extends Stryker4sSuite {
     "timeout" -> fromInt(5000),
     "timeout-factor" -> fromDouble(1.5).get,
     "legacy-test-runner" -> False,
-    "scala-dialect" -> fromString("scala3")
+    "scala-dialect" -> fromString("scala3"),
+    "debug" -> obj(
+      "log-test-runner-stdout" -> False,
+      "debug-test-runner" -> False
+    )
   )
 }

--- a/core/src/test/scala/stryker4s/testutil/ExampleConfigs.scala
+++ b/core/src/test/scala/stryker4s/testutil/ExampleConfigs.scala
@@ -35,6 +35,10 @@ object ExampleConfigs {
                                      |  timeout=5500
                                      |  scala-dialect="scala212"
                                      |  concurrency = 3
+                                     |  debug {
+                                     |    log-test-runner-stdout=true
+                                     |    debug-test-runner=true
+                                     |  }
                                      |}""".stripMargin)
 
   def empty = ConfigSource.empty

--- a/core/src/test/scala/stryker4s/testutil/stubs/TestProcessRunner.scala
+++ b/core/src/test/scala/stryker4s/testutil/stubs/TestProcessRunner.scala
@@ -2,6 +2,7 @@ package stryker4s.testutil.stubs
 
 import cats.effect.IO
 import fs2.io.file.Path
+import stryker4s.config.Config
 import stryker4s.log.Logger
 import stryker4s.run.process.{Command, ProcessRunner}
 
@@ -21,7 +22,9 @@ class TestProcessRunner(initialTestRunSuccess: Boolean, testRunExitCode: Try[Int
     *
     * Also return an exit code which the test runner would do as well.
     */
-  override def apply(command: Command, workingDir: Path, envVar: (String, String)*): IO[Try[Int]] = {
+  override def apply(command: Command, workingDir: Path, envVar: (String, String)*)(implicit
+      config: Config
+  ): IO[Try[Int]] = {
     if (envVar.isEmpty) {
       IO.pure(Success(if (initialTestRunSuccess) 0 else 1))
     } else {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -186,6 +186,50 @@ For the last two cases, please [let us know by creating an issue](https://github
 
 Set the concurrency of testrunners. Stryker4s will create this many testrunners to run mutants in parallel. This defaults to `(cpuCoreCount / 4).rounded + 1`. `cpuCoreCount` includes virtual processors such as from hyperthreading. This is a sane default for most use cases as most test frameworks already have some form of concurrency built in. But as always with concurrency, test it yourself to be sure of the best performance.
 
+### `debug` [`object`]
+
+Describes the `debug` config field
+
+#### `debug-test-runner` [`boolean`]
+**Config file:** `debug { debug-test-runner: true }`  
+**Default value:** `false`  
+**Since:** `v0.14.0`  
+**Description:**
+
+Passes additional JVM options to the created testrunner which debuggers can use to attach and debug. Debugging is opened on port 8000. Also limits concurrency to 1. How to debug is specific to your IDE. The used JVM debug argument is:
+
+```
+-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=127.0.0.1:8000
+```
+
+To debug in VS Code, you can use (and edit) this `launch.json`:
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "scala",
+      "name": "Attach to sbt test-runner",
+      "request": "attach",
+      "hostName": "127.0.0.1",
+      "port": 8000,
+      "buildTarget": "sbt-stryker4s-testrunner"
+    }
+  ]
+}
+```
+
+
+#### `log-test-runner-stdout` [`boolean`]
+
+**Config file:** `debug { log-test-runner-stdout: true }`  
+**Default value:** `false`  
+**Since:** `v0.14.0`  
+**Description:**
+
+By default, stdout from testrunners is not logged. With this option, stdout is sent to debug logging. Enabling this can be useful when debugging the testrunners, but is disabled by default because the output can be too much for normal debug logging.
+
 ## Process runner config
 
 ### `test-runner` [`object`]

--- a/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
+++ b/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
@@ -101,9 +101,18 @@ class Stryker4sSbtRunner(
         }
       }
 
-      log.info(s"Creating ${config.concurrency} test-runners")
+      val concurrency = if (config.debug.debugTestRunner) {
+        log.warn(
+          "'debug.debug-test-runner' config is 'true', creating 1 test-runner with debug arguments enabled on port 8000."
+        )
+        1
+      } else {
+        log.info(s"Creating ${config.concurrency} test-runners")
+        config.concurrency
+      }
+
       val portStart = 13336
-      val portRanges = NonEmptyList.fromListUnsafe((1 to config.concurrency).map(_ + portStart).toList)
+      val portRanges = NonEmptyList.fromListUnsafe((1 to concurrency).map(_ + portStart).toList)
 
       portRanges.map { port =>
         SbtTestRunner.create(classpath, javaOpts, frameworks, testGroups, port, sharedTimeout)


### PR DESCRIPTION
Adds two new options in a `debug` config field:
- `debug.log-test-runner-stdout`: stdout from the testrunner is no longer logged to debug by default, but only when this option is enabled
- `debug.debug-test-runner`: Limit concurrency to 1 and adds JVM debug arguments to the testrunner so debuggers can attach to it
