### PR TITLE
Fix per-test coverage analysis

### DIFF
--- a/api/src/main/protobuf/stryker4s/api/testprocess.proto
+++ b/api/src/main/protobuf/stryker4s/api/testprocess.proto
@@ -19,7 +19,7 @@ message Request {
 
 message StartTestRun {
   int32 mutation = 1;
-  repeated Fingerprint fingerprints = 2;
+  repeated string test_names = 3;
 }
 message StartInitialTestRun {}
 
@@ -87,19 +87,19 @@ message ErrorDuringTestRun {
 }
 message CoverageTestRunResult {
   bool is_successful = 1;
-  CoverageTestRunMap coverage_test_run_map = 2;
+  CoverageTestNameMap coverage_test_run_map = 3;
 }
 
-/** Convert to a flat structure to save space of duplicate Fingerprint items when serializing.
+/** Convert to a flat structure to save space of duplicate test name items when serializing.
   * Without it, the size grows exponentially with the number of tests and mutants
   */
-message CoverageTestRunMap {
-  map<int32, Fingerprint> fingerprint_ids = 1;
-  map<int32, Fingerprints> fingerprints = 2;
+message CoverageTestNameMap {
+  map<int32, string> test_name_ids = 1;
+  map<int32, TestNames> test_names = 2;
 }
 
-message Fingerprints {
-  repeated int32 fingerprint = 1;
+message TestNames {
+  repeated int32 test_name = 1;
 }
 
 message Fingerprint {

--- a/api/src/main/protobuf/stryker4s/api/testprocess.proto
+++ b/api/src/main/protobuf/stryker4s/api/testprocess.proto
@@ -87,7 +87,7 @@ message ErrorDuringTestRun {
 }
 message CoverageTestRunResult {
   bool is_successful = 1;
-  CoverageTestNameMap coverage_test_run_map = 3;
+  CoverageTestNameMap coverage_test_name_map = 3;
 }
 
 /** Convert to a flat structure to save space of duplicate test name items when serializing.

--- a/api/src/main/scala/stryker4s/api/testprocess/CoverageReport.scala
+++ b/api/src/main/scala/stryker4s/api/testprocess/CoverageReport.scala
@@ -1,11 +1,11 @@
 package stryker4s.api.testprocess
 
-case class CoverageReport(report: Map[Int, Seq[Fingerprint]]) extends AnyVal
+case class CoverageReport(report: Map[Int, Seq[String]]) extends AnyVal
 
 object CoverageReport {
-  def apply(testRunMap: CoverageTestRunMap): CoverageReport = {
-    val map = testRunMap.fingerprints.map { case (id, Fingerprints(fingerPrintIds)) =>
-      id -> fingerPrintIds.map(testRunMap.fingerprintIds)
+  def apply(testRunMap: CoverageTestNameMap): CoverageReport = {
+    val map = testRunMap.testNames.map { case (id, TestNames(testNameIds)) =>
+      id -> testNameIds.map(testRunMap.testNameIds)
     }
     CoverageReport(map)
   }

--- a/command-runner/src/main/scala/stryker4s/command/runner/ProcessTestRunner.scala
+++ b/command-runner/src/main/scala/stryker4s/command/runner/ProcessTestRunner.scala
@@ -9,7 +9,6 @@ import stryker4s.run.process.{Command, ProcessRunner}
 
 import scala.concurrent.TimeoutException
 import scala.util.{Failure, Success}
-import stryker4s.api.testprocess.Fingerprint
 
 class ProcessTestRunner(command: Command, processRunner: ProcessRunner, tmpDir: Path)(implicit config: Config)
     extends TestRunner {
@@ -20,7 +19,7 @@ class ProcessTestRunner(command: Command, processRunner: ProcessRunner, tmpDir: 
     }
   }
 
-  def runMutant(mutant: Mutant, fingerprints: Seq[Fingerprint]): IO[MutantRunResult] = {
+  def runMutant(mutant: Mutant, testNames: Seq[String]): IO[MutantRunResult] = {
     val id = mutant.id.globalId
     processRunner(command, tmpDir, ("ACTIVE_MUTATION", id.toString)).map {
       case Success(0)                   => Survived(mutant)

--- a/core/src/main/scala/stryker4s/run/MutantRunner.scala
+++ b/core/src/main/scala/stryker4s/run/MutantRunner.scala
@@ -20,7 +20,6 @@ import stryker4s.report.{FinishedRunEvent, MutantTestedEvent, Reporter}
 import java.nio
 import scala.collection.immutable.SortedMap
 import scala.concurrent.duration._
-import stryker4s.api.testprocess.Fingerprint
 
 class MutantRunner(
     createTestRunnerPool: Path => Either[NonEmptyList[CompilerErrMsg], Resource[IO, TestRunnerPool]],
@@ -228,7 +227,7 @@ class MutantRunner(
 
   case class CoverageExclusions(
       hasCoverage: Boolean,
-      coveredMutants: Map[Int, Seq[Fingerprint]],
+      coveredMutants: Map[Int, Seq[String]],
       staticMutants: Seq[Int]
   )
 

--- a/core/src/test/scala/stryker4s/testutil/stubs/TestRunnerStub.scala
+++ b/core/src/test/scala/stryker4s/testutil/stubs/TestRunnerStub.scala
@@ -9,14 +9,13 @@ import stryker4s.model._
 import stryker4s.run.{ResourcePool, TestRunner, TestRunnerPool}
 
 import scala.meta._
-import stryker4s.api.testprocess.Fingerprint
 
 class TestRunnerStub(results: Seq[() => MutantRunResult]) extends TestRunner {
   private val stream = Iterator.from(0)
 
   def initialTestRun(): IO[InitialTestRunResult] = IO.pure(NoCoverageInitialTestRun(true))
 
-  def runMutant(mutant: Mutant, fingerprints: Seq[Fingerprint]): IO[MutantRunResult] = {
+  def runMutant(mutant: Mutant, testNames: Seq[String]): IO[MutantRunResult] = {
     // Ensure runMutant can always continue
     IO(results.applyOrElse(stream.next(), (_: Int) => results.head)())
       .recover { case _: ArrayIndexOutOfBoundsException => results.head() }

--- a/maven/src/main/scala/stryker4s/maven/runner/MavenTestRunner.scala
+++ b/maven/src/main/scala/stryker4s/maven/runner/MavenTestRunner.scala
@@ -3,7 +3,6 @@ package stryker4s.maven.runner
 import cats.effect.IO
 import org.apache.maven.project.MavenProject
 import org.apache.maven.shared.invoker.{DefaultInvocationRequest, InvocationRequest, Invoker}
-import stryker4s.api.testprocess._
 import stryker4s.log.Logger
 import stryker4s.model._
 import stryker4s.run.TestRunner

--- a/maven/src/main/scala/stryker4s/maven/runner/MavenTestRunner.scala
+++ b/maven/src/main/scala/stryker4s/maven/runner/MavenTestRunner.scala
@@ -21,7 +21,7 @@ class MavenTestRunner(project: MavenProject, invoker: Invoker, val properties: P
     IO(invoker.execute(request)).map(_.getExitCode() == 0).map(NoCoverageInitialTestRun(_))
   }
 
-  def runMutant(mutant: Mutant, fingerprints: Seq[Fingerprint]): IO[MutantRunResult] = {
+  def runMutant(mutant: Mutant, testNames: Seq[String]): IO[MutantRunResult] = {
     val request = createRequestWithMutation(mutant)
 
     IO(invoker.execute(request)).map { result =>

--- a/maven/src/test/scala/stryker4s/maven/runner/MavenTestRunnerTest.scala
+++ b/maven/src/test/scala/stryker4s/maven/runner/MavenTestRunnerTest.scala
@@ -7,7 +7,6 @@ import org.apache.maven.project.MavenProject
 import org.apache.maven.shared.invoker.{InvocationRequest, InvocationResult, Invoker}
 import org.mockito.captor.ArgCaptor
 import org.mockito.scalatest.MockitoSugar
-import stryker4s.api.testprocess._
 import stryker4s.config.Config
 import stryker4s.extension.mutationtype.LesserThan
 import stryker4s.model.{Killed, Mutant, MutantId, NoCoverageInitialTestRun, Survived}
@@ -21,7 +20,7 @@ class MavenTestRunnerTest extends Stryker4sSuite with MockitoSugar {
   implicit val config: Config = Config.default
 
   val tmpDir = Path("/home/user/tmpDir")
-  val fingerprints = Seq.empty[Fingerprint]
+  val coverageTestNames = Seq.empty[String]
   def properties = new ju.Properties()
   def goals = Seq("test")
 
@@ -83,7 +82,7 @@ class MavenTestRunnerTest extends Stryker4sSuite with MockitoSugar {
       when(invokerMock.execute(any[InvocationRequest])).thenReturn(mockResult)
       val sut = new MavenTestRunner(new MavenProject(), invokerMock, properties, goals)
 
-      val result = sut.runMutant(Mutant(MutantId(1), q">", q"<", LesserThan), fingerprints).unsafeRunSync()
+      val result = sut.runMutant(Mutant(MutantId(1), q">", q"<", LesserThan), coverageTestNames).unsafeRunSync()
 
       result shouldBe a[Killed]
     }
@@ -95,7 +94,7 @@ class MavenTestRunnerTest extends Stryker4sSuite with MockitoSugar {
       when(invokerMock.execute(any[InvocationRequest])).thenReturn(mockResult)
       val sut = new MavenTestRunner(new MavenProject(), invokerMock, properties, goals)
 
-      val result = sut.runMutant(Mutant(MutantId(1), q">", q"<", LesserThan), fingerprints).unsafeRunSync()
+      val result = sut.runMutant(Mutant(MutantId(1), q">", q"<", LesserThan), coverageTestNames).unsafeRunSync()
 
       result shouldBe a[Survived]
     }
@@ -111,7 +110,7 @@ class MavenTestRunnerTest extends Stryker4sSuite with MockitoSugar {
 
       val sut = new MavenTestRunner(project, invokerMock, project.getProperties(), goals)
 
-      sut.runMutant(Mutant(MutantId(1), q">", q"<", LesserThan), fingerprints).unsafeRunSync()
+      sut.runMutant(Mutant(MutantId(1), q">", q"<", LesserThan), coverageTestNames).unsafeRunSync()
 
       verify(invokerMock).execute(captor)
       val invokedRequest = captor.value
@@ -134,7 +133,7 @@ class MavenTestRunnerTest extends Stryker4sSuite with MockitoSugar {
       mavenProject.getActiveProfiles.add(profile)
       val sut = new MavenTestRunner(mavenProject, invokerMock, properties, goals)
 
-      sut.runMutant(Mutant(MutantId(1), q">", q"<", LesserThan), fingerprints).unsafeRunSync()
+      sut.runMutant(Mutant(MutantId(1), q">", q"<", LesserThan), coverageTestNames).unsafeRunSync()
 
       verify(invokerMock).execute(captor)
       val invokedRequest = captor.value

--- a/sbt-testrunner/src/main/scala/stryker4s/sbt/testrunner/MessageHandler.scala
+++ b/sbt-testrunner/src/main/scala/stryker4s/sbt/testrunner/MessageHandler.scala
@@ -14,9 +14,9 @@ final class TestRunnerMessageHandler() extends MessageHandler {
 
   def handleMessage(req: Request): Response =
     req match {
-      case StartTestRun(mutation, fingerprints) =>
+      case StartTestRun(mutation, testNames) =>
         try {
-          val status = testRunner.runMutation(mutation, fingerprints)
+          val status = testRunner.runMutation(mutation, testNames)
           toTestResult(status)
         } catch {
           case NonFatal(e) => ErrorDuringTestRun(e.toString())
@@ -40,7 +40,7 @@ final class TestRunnerMessageHandler() extends MessageHandler {
       case _              => TestsUnsuccessful()
     }
 
-  def toInitialTestResult(status: Status, coverage: CoverageTestRunMap): Response =
+  def toInitialTestResult(status: Status, coverage: CoverageTestNameMap): Response =
     CoverageTestRunResult(status == Status.Success, Some(coverage))
 
 }

--- a/sbt-testrunner/src/main/scala/stryker4s/sbt/testrunner/TestRunner.scala
+++ b/sbt-testrunner/src/main/scala/stryker4s/sbt/testrunner/TestRunner.scala
@@ -18,12 +18,12 @@ class SbtTestInterfaceRunner(context: TestProcessContext) extends TestRunner wit
   val testFunctions: Option[(Int, Seq[String])] => Status = {
     val tasks = {
       val cl = getClass().getClassLoader()
-      context.testGroups.flatMap(testGroup => {
+      context.testGroups.flatMap { testGroup =>
         val RunnerOptions(args, remoteArgs) = testGroup.runnerOptions.get
         val framework = cl.loadClass(testGroup.frameworkClass).getConstructor().newInstance().asInstanceOf[Framework]
         val runner = framework.runner(args.toArray, remoteArgs.toArray, cl)
         runner.tasks(testGroup.taskDefs.map(toSbtTaskDef).toArray)
-      })
+      }
     }
     (mutation: Option[(Int, Seq[String])]) => {
       val tasksToRun = mutation match {

--- a/sbt/src/main/scala/stryker4s/sbt/runner/LegacySbtTestRunner.scala
+++ b/sbt/src/main/scala/stryker4s/sbt/runner/LegacySbtTestRunner.scala
@@ -8,7 +8,6 @@ import stryker4s.extension.exception.InitialTestRunFailedException
 import stryker4s.log.Logger
 import stryker4s.model._
 import stryker4s.run.TestRunner
-import stryker4s.api.testprocess.Fingerprint
 
 class LegacySbtTestRunner(initialState: State, settings: Seq[Def.Setting[_]], extracted: Extracted)(implicit
     log: Logger
@@ -22,7 +21,7 @@ class LegacySbtTestRunner(initialState: State, settings: Seq[Def.Setting[_]], ex
     onFailed = NoCoverageInitialTestRun(false)
   )
 
-  def runMutant(mutant: Mutant, fingerprints: Seq[Fingerprint]): IO[MutantRunResult] = {
+  def runMutant(mutant: Mutant, testNames: Seq[String]): IO[MutantRunResult] = {
     val mutationState =
       extracted.appendWithSession(settings :+ mutationSetting(mutant.id.globalId), initialState)
     runTests(

--- a/sbt/src/main/scala/stryker4s/sbt/runner/ProcessTestRunner.scala
+++ b/sbt/src/main/scala/stryker4s/sbt/runner/ProcessTestRunner.scala
@@ -19,8 +19,8 @@ import scala.util.control.NonFatal
 
 class ProcessTestRunner(testProcess: TestRunnerConnection) extends TestRunner {
 
-  override def runMutant(mutant: Mutant, fingerprints: Seq[Fingerprint]): IO[MutantRunResult] = {
-    val message = StartTestRun(mutant.id.globalId, fingerprints)
+  override def runMutant(mutant: Mutant, testNames: Seq[String]): IO[MutantRunResult] = {
+    val message = StartTestRun(mutant.id.globalId, testNames)
     testProcess.sendMessage(message).map {
       case _: TestsSuccessful      => Survived(mutant)
       case _: TestsUnsuccessful    => Killed(mutant)
@@ -48,8 +48,8 @@ class ProcessTestRunner(testProcess: TestRunnerConnection) extends TestRunner {
           val averageDuration = (firstDuration + secondDuration) / 2
           InitialTestRunCoverageReport(
             firstRun.isSuccessful && secondRun.isSuccessful,
-            CoverageReport(firstRun.coverageTestRunMap.get),
-            CoverageReport(secondRun.coverageTestRunMap.get),
+            CoverageReport(firstRun.CoverageTestNameMap.get),
+            CoverageReport(secondRun.CoverageTestNameMap.get),
             averageDuration
           )
         case x => throw new MatchError(x)

--- a/sbt/src/main/scala/stryker4s/sbt/runner/ProcessTestRunner.scala
+++ b/sbt/src/main/scala/stryker4s/sbt/runner/ProcessTestRunner.scala
@@ -48,8 +48,8 @@ class ProcessTestRunner(testProcess: TestRunnerConnection) extends TestRunner {
           val averageDuration = (firstDuration + secondDuration) / 2
           InitialTestRunCoverageReport(
             firstRun.isSuccessful && secondRun.isSuccessful,
-            CoverageReport(firstRun.CoverageTestNameMap.get),
-            CoverageReport(secondRun.CoverageTestNameMap.get),
+            CoverageReport(firstRun.coverageTestNameMap.get),
+            CoverageReport(secondRun.coverageTestNameMap.get),
             averageDuration
           )
         case x => throw new MatchError(x)


### PR DESCRIPTION
When implementing #1001, we looked at `Fingerprint`s to filter on tests. The misinterpretation with this was that `Fingerprint`s only have information about the _test framework_ that the test is running under, and not the test information. The message for starting a test would look like:

```scala
StartTestRun(1, Vector(Fingerprint("org.scalatest.Suite"), Fingerprint("org.scalatest.Suite"), Fingerprint("org.scalatest.Suite"))
```

This PR fixes that to always look at the `fullyQualifiedName` from a `TaskDef` instead. The message now properly has desired test coverage in it: 

```scala
StartTestRun(1, Vector("stryker4s.config.ConfigTest", "stryker4s.config.ConfigReaderTest", "stryker4s.files.GlobTest"))
```

for example.

As a result of this fix, the average tests run per mutant has gone from ~210 to ~20, significantly improving performance
