### PR TITLE
Use more accurate initial test-run duration (sbt plugin)

### DIFF
--- a/api/src/main/protobuf/stryker4s/api/testprocess.proto
+++ b/api/src/main/protobuf/stryker4s/api/testprocess.proto
@@ -92,6 +92,7 @@ message ErrorDuringTestRun {
 message CoverageTestRunResult {
   bool is_successful = 1;
   CoverageTestNameMap coverage_test_name_map = 3;
+  int64 duration_nanos = 4;
 }
 
 /** Convert to a flat structure to save space of duplicate test name items when serializing.

--- a/sbt-testrunner/src/main/scala/stryker4s/package.scala
+++ b/sbt-testrunner/src/main/scala/stryker4s/package.scala
@@ -1,9 +1,10 @@
 import stryker4s.api.testprocess.CoverageTestNameMap
 import stryker4s.sbt.testrunner.TestInterfaceMapper
 
-import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReference}
+import java.util.concurrent.{ConcurrentLinkedQueue, TimeUnit}
 import scala.collection.concurrent.TrieMap
+import scala.concurrent.duration.FiniteDuration
 
 package object stryker4s {
 
@@ -54,6 +55,15 @@ package object stryker4s {
     } finally {
       collectCoverage.set(false)
       coveredTests.clear()
+    }
+
+    /** Time a given function and return the result and the duration of that function as a tuple
+      */
+    protected[stryker4s] def timed[A](f: => A): (FiniteDuration, A) = {
+      val start = System.nanoTime()
+      val result = f
+      val duration = FiniteDuration(System.nanoTime() - start, TimeUnit.NANOSECONDS)
+      (duration, result)
     }
 
     /** Build the coverage report from the collected data

--- a/sbt/src/main/scala/stryker4s/sbt/runner/ProcessTestRunner.scala
+++ b/sbt/src/main/scala/stryker4s/sbt/runner/ProcessTestRunner.scala
@@ -43,20 +43,19 @@ class ProcessTestRunner(testProcess: TestRunnerConnection) extends TestRunner {
   override def initialTestRun(): IO[InitialTestRunResult] = {
     val initialTestRun = testProcess.sendMessage(StartInitialTestRun())
 
-    initialTestRun
-      .map2(initialTestRun) {
-        case (firstRun: CoverageTestRunResult, secondRun: CoverageTestRunResult) =>
-          val averageDuration =
-            FiniteDuration((firstRun.durationNanos + secondRun.durationNanos) / 2, TimeUnit.NANOSECONDS)
+    initialTestRun.map2(initialTestRun) {
+      case (firstRun: CoverageTestRunResult, secondRun: CoverageTestRunResult) =>
+        val averageDuration =
+          FiniteDuration((firstRun.durationNanos + secondRun.durationNanos) / 2, TimeUnit.NANOSECONDS)
 
-          InitialTestRunCoverageReport(
-            firstRun.isSuccessful && secondRun.isSuccessful,
-            CoverageReport(firstRun.coverageTestNameMap.get),
-            CoverageReport(secondRun.coverageTestNameMap.get),
-            averageDuration
-          )
-        case x => throw new MatchError(x)
-      }
+        InitialTestRunCoverageReport(
+          firstRun.isSuccessful && secondRun.isSuccessful,
+          CoverageReport(firstRun.coverageTestNameMap.get),
+          CoverageReport(secondRun.coverageTestNameMap.get),
+          averageDuration
+        )
+      case x => throw new MatchError(x)
+    }
   }
 }
 


### PR DESCRIPTION
Calculate the duration of the initial test-run without framework overhead.
