### PR TITLE
Optimize CoverageTestRunResult size

### DIFF
--- a/sbt-testrunner/src/main/scala/stryker4s/package.scala
+++ b/sbt-testrunner/src/main/scala/stryker4s/package.scala
@@ -29,7 +29,8 @@ package object stryker4s {
         if (currentTest != null) {
           ids.foreach { id =>
             val currentCovered = coveredTests.getOrElseUpdate(id, new ConcurrentLinkedQueue())
-            currentCovered.add(currentTest)
+            if (!currentCovered.contains(currentTest))
+              currentCovered.add(currentTest)
           }
         }
       }


### PR DESCRIPTION
By only adding a covered test once, instead of each time it is hit. Makes the protobuf messages smaller and lowers the memory usage in the initial test-run
