### PR TITLE
Use fs2 socket implementations instead of old java.net

### DIFF
--- a/core/src/main/scala/stryker4s/mutants/findmutants/MutantFinder.scala
+++ b/core/src/main/scala/stryker4s/mutants/findmutants/MutantFinder.scala
@@ -1,7 +1,8 @@
 package stryker4s.mutants.findmutants
 
 import cats.effect.IO
-import cats.implicits.*
+import cats.syntax.either.*
+import cats.syntax.foldable.*
 import fs2.io.file.Path
 import stryker4s.config.Config
 import stryker4s.extension.FileExtensions.*
@@ -37,7 +38,7 @@ class MutantFinder(matcher: MutantMatcher)(implicit config: Config, log: Logger)
       case e: Parsed.Error =>
         log.error(s"Error while parsing file '${file.relativePath}', ${e.message}")
         IO.raiseError(e.details)
-      case s => IO.pure(s.get)
+      case s => IO.fromEither(s.toEither.leftMap(_.details))
     }
 
   }

--- a/sbt/src/main/scala/stryker4s/sbt/Stryker4sMain.scala
+++ b/sbt/src/main/scala/stryker4s/sbt/Stryker4sMain.scala
@@ -38,6 +38,9 @@ object Stryker4sMain extends AutoPlugin {
         s"Sbt version ${sbtVersion.value} is not supported by Stryker4s. Please upgrade to a later version. The lowest supported version is ${strykerMinimumSbtVersion.value}. If you know what you are doing you can override this with the 'strykerIsSupported' sbt setting."
       )
     }
+    // Call logLevel so it shows up as a used setting when set
+    val _ = (stryker / logLevel).value
+
     implicit val runtime: IORuntime = IORuntime.global
     implicit val logger: Logger = new SbtLogger(streams.value.log)
 

--- a/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
+++ b/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
@@ -2,9 +2,10 @@ package stryker4s.sbt
 
 import cats.data.NonEmptyList
 import cats.effect.{Deferred, IO, Resource}
+import com.comcast.ip4s.Port
 import fs2.io.file.Path
-import sbt.Keys.*
 import sbt.*
+import sbt.Keys.*
 import sbt.internal.LogManager
 import stryker4s.config.{Config, TestFilter}
 import stryker4s.extension.FileExtensions.*
@@ -145,7 +146,9 @@ class Stryker4sSbtRunner(
           }
 
           val portStart = 13336
-          val portRanges = NonEmptyList.fromListUnsafe((1 to concurrency).map(_ + portStart).toList)
+          val portRanges = NonEmptyList.fromListUnsafe(
+            (1 to concurrency).map(p => Port.fromInt(p + portStart).get).toList
+          )
 
           Right(
             portRanges.map { port =>

--- a/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
+++ b/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
@@ -131,7 +131,7 @@ class Stryker4sSbtRunner(
             else {
               val testFilter = new TestFilter()
               val filteredTests = group.tests.filter(t => testFilter.filter(t.name))
-              group.copy(tests = filteredTests)
+              new Tests.Group(name = group.name, tests = filteredTests, runPolicy = group.runPolicy)
             }
           }
 

--- a/sbt/src/main/scala/stryker4s/sbt/runner/SbtTestRunner.scala
+++ b/sbt/src/main/scala/stryker4s/sbt/runner/SbtTestRunner.scala
@@ -1,13 +1,14 @@
 package stryker4s.sbt.runner
 
-import scala.concurrent.duration.FiniteDuration
-
 import cats.effect.{Deferred, IO, Resource}
+import com.comcast.ip4s.Port
 import sbt.Tests
 import sbt.testing.Framework
 import stryker4s.config.Config
 import stryker4s.log.Logger
 import stryker4s.run.TestRunner
+
+import scala.concurrent.duration.FiniteDuration
 
 object SbtTestRunner {
   def create(
@@ -15,7 +16,7 @@ object SbtTestRunner {
       javaOpts: Seq[String],
       frameworks: Seq[Framework],
       testGroups: Seq[Tests.Group],
-      port: Int,
+      port: Port,
       timeout: Deferred[IO, FiniteDuration]
   )(implicit
       config: Config,

--- a/sbt/src/main/scala/stryker4s/sbt/runner/TestRunnerConnection.scala
+++ b/sbt/src/main/scala/stryker4s/sbt/runner/TestRunnerConnection.scala
@@ -1,44 +1,53 @@
 package stryker4s.sbt.runner
 
-import cats.effect.{IO, Resource}
-import com.google.protobuf.CodedInputStream
-import stryker4s.api.testprocess.{Request, Response, ResponseMessage}
+import cats.effect.IO
+import com.google.protobuf.UInt32Value
+import fs2.Chunk
+import fs2.io.net.Socket
+import scodec.bits.BitVector
+import stryker4s.api.testprocess.{Request, RequestMessage, Response, ResponseMessage}
 import stryker4s.log.Logger
-
-import java.io.OutputStream
-import java.net.Socket
 
 sealed trait TestRunnerConnection {
   def sendMessage(request: Request): IO[Response]
 }
 
-final class SocketTestRunnerConnection(out: OutputStream, in: CodedInputStream)(implicit log: Logger)
-    extends TestRunnerConnection {
+final class SocketTestRunnerConnection(socket: Socket[IO])(implicit log: Logger) extends TestRunnerConnection {
 
   override def sendMessage(request: Request): IO[Response] =
     IO(log.debug(s"Sending message $request")) *>
-      skipCancel(IO.blocking(request.asMessage.writeDelimitedTo(out))) *>
-      skipCancel(IO.blocking(ResponseMessage.parseDelimitedFrom(in)))
-        .map(_.get)
-        .map(_.toResponse)
+      write(request.asMessage) *>
+      read
         .flatTap(response => IO(log.debug(s"Received message $response")))
 
-  /** Returns a new IO that instantly returns when cancelled, instead of calling it's cancellation logic
-    *
-    * This is needed because the blocking call only starts its cancellation logic when the blocking call returns, which
-    * goes against what we want when e.g. a timeout occurs
-    */
-  private def skipCancel[T](f: IO[T]) = f.start.flatMap(_.joinWithNever)
+  def write(msg: RequestMessage) = {
+    // Delimiter announcing the size of the upcoming message. `tail` because the first byte is the tag of the message, which isn't included in the delimiter (it is always uint32)
+    val serializedSize = msg.serializedSize
+    val delimiter = Chunk.array(UInt32Value.of(serializedSize).toByteArray().tail)
 
-}
+    IO(log.debug(s"Writing message of $serializedSize bytes")) *>
+      socket.write(delimiter ++ Chunk.array(msg.toByteArray))
+  }
 
-object TestRunnerConnection {
-  def create(socket: Socket)(implicit log: Logger): Resource[IO, TestRunnerConnection] =
-    for {
-      out <- Resource.fromAutoCloseable(IO(socket.getOutputStream()))
-      in <- Resource
-        .fromAutoCloseable(IO(socket.getInputStream()))
-        .evalMap(inStr => IO(CodedInputStream.newInstance(inStr)))
-    } yield new SocketTestRunnerConnection(out, in)
+  def read: IO[Response] = {
+    // The delimiter tells us how many bytes to read for the response.
+    // @see https://developers.google.com/protocol-buffers/docs/encoding#varints
+    def readDelimiter: IO[BitVector] =
+      socket
+        .readN(1)
+        .map(_.toBitVector)
+        .map(_.splitAt(1))
+        .flatMap { case (continue, sum) =>
+          // If the first bit is positive (1), continue reading bytes
+          if (continue.head) readDelimiter.map(_ ++ sum) // Construct all bits appending new reads to the _start_
+          else IO.pure(sum)
+        }
+
+    readDelimiter
+      .map(_.toInt(false))
+      .flatTap(size => IO(log.debug(s"Reading message of $size bytes")))
+      .flatMap(socket.readN)
+      .map(bytes => ResponseMessage.parseFrom(bytes.toArray).toResponse)
+  }
 
 }


### PR DESCRIPTION
Usage of the older java.net network stuff is discouraged as it is less performant and uses blocking code. Fs2 thankfully has some nice interfaces for sockets built on NIO2 