### PR TITLE
staticTmpDir: enable forcing tmpDir to a static path

### DIFF
--- a/core/src/main/scala/stryker4s/config/Config.scala
+++ b/core/src/main/scala/stryker4s/config/Config.scala
@@ -21,7 +21,9 @@ final case class Config(
     legacyTestRunner: Boolean = false,
     scalaDialect: Dialect = dialects.Scala3,
     concurrency: Int = Config.defaultConcurrency,
-    debug: DebugOptions = DebugOptions()
+    debug: DebugOptions = DebugOptions(),
+    staticTmpDir: Boolean = false,
+    staticTmpDirLeaveAfterError: Boolean = false
 )
 
 object Config extends pure.ConfigConfigReader with circe.ConfigEncoder {


### PR DESCRIPTION
Added staticTmpDir option to Config.
This will force tmpDir to be created at a static path. Tmp dir will be autodeleted at exit, maybe that
`staticTmpDirLeaveAfterError` was defined, then we'll show a warning that it needs to be manually cleaned up.

This helps with using stryker4s with Bazel, as Bazel uses the path to the workspace (folder) to determine where to store the local cache (hashes the path to create the sandbox's name).
Enabled not autoremoving the folder to be able to debug issues (as Bazel support is early-stage).