### PR TITLE
Use cats-effect Env for reading CI environment variables

### DIFF
--- a/core/src/main/scala/stryker4s/env/package.scala
+++ b/core/src/main/scala/stryker4s/env/package.scala
@@ -1,5 +1,0 @@
-package stryker4s
-
-package object env {
-  type Environment = Map[String, String]
-}

--- a/core/src/main/scala/stryker4s/report/DashboardReporter.scala
+++ b/core/src/main/scala/stryker4s/report/DashboardReporter.scala
@@ -15,13 +15,13 @@ import sttp.client3.*
 import sttp.client3.circe.{asJson, circeBodySerializer}
 import sttp.model.{MediaType, StatusCode}
 
-class DashboardReporter(dashboardConfigProvider: DashboardConfigProvider)(implicit
+class DashboardReporter(dashboardConfigProvider: DashboardConfigProvider[IO])(implicit
     log: Logger,
     httpBackend: Resource[IO, SttpBackend[IO, Any]]
 ) extends Reporter {
 
   override def onRunFinished(runReport: FinishedRunEvent): IO[Unit] =
-    dashboardConfigProvider.resolveConfig() match {
+    dashboardConfigProvider.resolveConfig().flatMap {
       case Invalid(configKeys) =>
         val configKeysStr = Str.join(configKeys.map(c => Str("'", Bold.On(c), "'")).toList, ", ")
         IO(log.warn(s"Could not resolve dashboard configuration key(s) $configKeysStr. Not sending report."))

--- a/core/src/main/scala/stryker4s/report/dashboard/DashboardConfigProvider.scala
+++ b/core/src/main/scala/stryker4s/report/dashboard/DashboardConfigProvider.scala
@@ -1,41 +1,51 @@
 package stryker4s.report.dashboard
 
-import cats.data.ValidatedNec
+import cats.Monad
+import cats.data.{OptionT, ValidatedNec}
+import cats.effect.std.Env
 import cats.syntax.apply.*
+import cats.syntax.functor.*
 import cats.syntax.option.*
 import stryker4s.config.Config
-import stryker4s.env.Environment
 import stryker4s.report.dashboard.Providers.*
 import stryker4s.report.model.DashboardConfig
 
-class DashboardConfigProvider(env: Environment)(implicit config: Config) {
-  def resolveConfig(): ValidatedNec[String, DashboardConfig] =
-    (resolveapiKey(), resolveproject(), resolveversion()).mapN {
-      DashboardConfig(
-        _,
-        config.dashboard.baseUrl,
-        config.dashboard.reportType,
-        _,
-        _,
-        config.dashboard.module
-      )
+class DashboardConfigProvider[F[_]: Monad: Env]()(implicit config: Config) {
+
+  def resolveConfig(): F[ValidatedNec[String, DashboardConfig]] =
+    (resolveapiKey(), resolveproject(), resolveversion()).mapN { case t =>
+      t.mapN {
+        DashboardConfig(
+          _,
+          config.dashboard.baseUrl,
+          config.dashboard.reportType,
+          _,
+          _,
+          config.dashboard.module
+        )
+      }
     }
 
   private val apiKeyName = "STRYKER_DASHBOARD_API_KEY"
   private def resolveapiKey() =
-    env
+    Env[F]
       .get(apiKeyName)
-      .toValidNec(apiKeyName)
+      .map(_.toValidNec(apiKeyName))
 
   private def resolveproject() =
-    config.dashboard.project
+    OptionT
+      .fromOption(config.dashboard.project)
       .orElse(byCiProvider(_.determineProject()))
-      .toValidNec("dashboard.project")
+      .value
+      .map(_.toValidNec("dashboard.project"))
 
   private def resolveversion() =
-    config.dashboard.version
+    OptionT
+      .fromOption(config.dashboard.version)
       .orElse(byCiProvider(_.determineVersion()))
-      .toValidNec("dashboard.version")
+      .value
+      .map(_.toValidNec("dashboard.version"))
 
-  private def byCiProvider[T](f: CiProvider => Option[T]) = Providers.determineCiProvider(env).flatMap(f)
+  private def byCiProvider[T](f: CiProvider[F] => F[Option[T]]) =
+    Providers.determineCiProvider[F]().flatMapF(f)
 }

--- a/core/src/main/scala/stryker4s/run/Stryker4sRunner.scala
+++ b/core/src/main/scala/stryker4s/run/Stryker4sRunner.scala
@@ -71,7 +71,7 @@ abstract class Stryker4sRunner(implicit log: Logger) {
                 )
               )
           }
-        new DashboardReporter(new DashboardConfigProvider(sys.env))
+        new DashboardReporter(new DashboardConfigProvider[IO]())
     }
 
   def resolveTestRunners(tmpDir: Path)(implicit

--- a/core/src/test/scala/stryker4s/report/DashboardReporterTest.scala
+++ b/core/src/test/scala/stryker4s/report/DashboardReporterTest.scala
@@ -22,7 +22,7 @@ class DashboardReporterTest extends Stryker4sIOSuite with MockitoIOSuite with Lo
   describe("buildRequest") {
     it("should compose the request") {
       implicit val backend = backendStub
-      val mockDashConfig = mock[DashboardConfigProvider]
+      val mockDashConfig = mock[DashboardConfigProvider[IO]]
       val sut = new DashboardReporter(mockDashConfig)
       val dashConfig = baseDashConfig
       val FinishedRunEvent(report, metrics, _, _) = baseResults
@@ -44,7 +44,7 @@ class DashboardReporterTest extends Stryker4sIOSuite with MockitoIOSuite with Lo
 
     it("should make a score-only request when score-only is configured") {
       implicit val backend = backendStub
-      val mockDashConfig = mock[DashboardConfigProvider]
+      val mockDashConfig = mock[DashboardConfigProvider[IO]]
       val sut = new DashboardReporter(mockDashConfig)
       val dashConfig = baseDashConfig.copy(reportType = MutationScoreOnly)
       val FinishedRunEvent(report, metrics, _, _) = baseResults
@@ -57,7 +57,7 @@ class DashboardReporterTest extends Stryker4sIOSuite with MockitoIOSuite with Lo
 
     it("should add the module if it is present") {
       implicit val backend = backendStub
-      val mockDashConfig = mock[DashboardConfigProvider]
+      val mockDashConfig = mock[DashboardConfigProvider[IO]]
       val sut = new DashboardReporter(mockDashConfig)
       val dashConfig = baseDashConfig.copy(module = Some("myModule"))
       val FinishedRunEvent(report, metrics, _, _) = baseResults
@@ -74,8 +74,8 @@ class DashboardReporterTest extends Stryker4sIOSuite with MockitoIOSuite with Lo
         _.whenAnyRequest
           .thenRespond(Right(DashboardPutResult("https://hrefHere.com")))
       )
-      val mockDashConfig = mock[DashboardConfigProvider]
-      when(mockDashConfig.resolveConfig()).thenReturn(baseDashConfig.validNec)
+      val mockDashConfig = mock[DashboardConfigProvider[IO]]
+      whenF(mockDashConfig.resolveConfig()).thenReturn(baseDashConfig.validNec)
       val sut = new DashboardReporter(mockDashConfig)
       val runReport = baseResults
 
@@ -88,8 +88,8 @@ class DashboardReporterTest extends Stryker4sIOSuite with MockitoIOSuite with Lo
 
     it("log when not being able to resolve dashboard config") {
       implicit val backend = backendStub
-      val mockDashConfig = mock[DashboardConfigProvider]
-      when(mockDashConfig.resolveConfig()).thenReturn(NonEmptyChain("fooConfigKey", "barConfigKey").invalid)
+      val mockDashConfig = mock[DashboardConfigProvider[IO]]
+      whenF(mockDashConfig.resolveConfig()).thenReturn(NonEmptyChain("fooConfigKey", "barConfigKey").invalid)
       val sut = new DashboardReporter(mockDashConfig)
       val runReport = baseResults
 
@@ -102,8 +102,8 @@ class DashboardReporterTest extends Stryker4sIOSuite with MockitoIOSuite with Lo
 
     it("should log when a response can't be parsed to a href") {
       implicit val backend = backendStub.map(_.whenAnyRequest.thenRespond("some other response"))
-      val mockDashConfig = mock[DashboardConfigProvider]
-      when(mockDashConfig.resolveConfig()).thenReturn(baseDashConfig.validNec)
+      val mockDashConfig = mock[DashboardConfigProvider[IO]]
+      whenF(mockDashConfig.resolveConfig()).thenReturn(baseDashConfig.validNec)
       val sut = new DashboardReporter(mockDashConfig)
       val runReport = baseResults
 
@@ -119,8 +119,8 @@ class DashboardReporterTest extends Stryker4sIOSuite with MockitoIOSuite with Lo
         _.whenAnyRequest
           .thenRespond(Response(Left(HttpError("auth required", StatusCode.Unauthorized)), StatusCode.Unauthorized))
       )
-      val mockDashConfig = mock[DashboardConfigProvider]
-      when(mockDashConfig.resolveConfig()).thenReturn(baseDashConfig.validNec)
+      val mockDashConfig = mock[DashboardConfigProvider[IO]]
+      whenF(mockDashConfig.resolveConfig()).thenReturn(baseDashConfig.validNec)
       val sut = new DashboardReporter(mockDashConfig)
       val runReport = baseResults
 
@@ -139,8 +139,8 @@ class DashboardReporterTest extends Stryker4sIOSuite with MockitoIOSuite with Lo
             Response(Left(HttpError("internal error", StatusCode.InternalServerError)), StatusCode.InternalServerError)
           )
         )
-      val mockDashConfig = mock[DashboardConfigProvider]
-      when(mockDashConfig.resolveConfig()).thenReturn(baseDashConfig.validNec)
+      val mockDashConfig = mock[DashboardConfigProvider[IO]]
+      whenF(mockDashConfig.resolveConfig()).thenReturn(baseDashConfig.validNec)
       val sut = new DashboardReporter(mockDashConfig)
       val runReport = baseResults
 

--- a/core/src/test/scala/stryker4s/report/dashboard/DashboardConfigProviderTest.scala
+++ b/core/src/test/scala/stryker4s/report/dashboard/DashboardConfigProviderTest.scala
@@ -1,6 +1,8 @@
 package stryker4s.report.dashboard
 
+import cats.Id
 import cats.data.NonEmptyChain
+import cats.effect.std.Env
 import cats.syntax.validated.*
 import org.scalatest.EitherValues
 import stryker4s.config.{Config, DashboardOptions, Full, MutationScoreOnly}
@@ -9,16 +11,26 @@ import stryker4s.testutil.Stryker4sSuite
 import sttp.client3.UriContext
 
 class DashboardConfigProviderTest extends Stryker4sSuite with EitherValues {
+
+  /** Create a cats-effect Env using 'Id' (not suspended in anything) as the effect type
+    */
+  def makeEnv(entr: (String, String)*): Env[Id] = new Env[Id] {
+    val env = entr.toMap
+
+    override def entries = env
+    override def get(name: String): Option[String] = env.get(name)
+  }
+
   describe("resolveConfig") {
     it("should resolve a Travis environment") {
       implicit val config = Config.default
-      val env = Map(
+      implicit val env: Env[Id] = makeEnv(
         "STRYKER_DASHBOARD_API_KEY" -> "apiKeyHere",
         "TRAVIS" -> "true",
         "TRAVIS_REPO_SLUG" -> "travisRepo/slug",
         "TRAVIS_BRANCH" -> "travisBranch"
       )
-      val sut = new DashboardConfigProvider(env)
+      val sut = new DashboardConfigProvider[Id]()
 
       val result = sut.resolveConfig()
 
@@ -35,14 +47,14 @@ class DashboardConfigProviderTest extends Stryker4sSuite with EitherValues {
 
     it("should resolve a CircleCI environment") {
       implicit val config = Config.default
-      val env = Map(
+      implicit val env = makeEnv(
         "STRYKER_DASHBOARD_API_KEY" -> "apiKeyHere",
         "CIRCLECI" -> "true",
         "CIRCLE_PROJECT_USERNAME" -> "circleUsername",
         "CIRCLE_PROJECT_REPONAME" -> "circleRepoName",
         "CIRCLE_BRANCH" -> "circleBranch"
       )
-      val sut = new DashboardConfigProvider(env)
+      val sut = new DashboardConfigProvider[Id]()
 
       val result = sut.resolveConfig()
 
@@ -59,13 +71,13 @@ class DashboardConfigProviderTest extends Stryker4sSuite with EitherValues {
 
     it("should resolve a GitHub actions environment") {
       implicit val config = Config.default
-      val env = Map(
+      implicit val env = makeEnv(
         "STRYKER_DASHBOARD_API_KEY" -> "apiKeyHere",
         "GITHUB_ACTION" -> "true",
         "GITHUB_REPOSITORY" -> "github/repo",
         "GITHUB_REF" -> "refs/heads/feat/branch-1"
       )
-      val sut = new DashboardConfigProvider(env)
+      val sut = new DashboardConfigProvider[Id]()
 
       val result = sut.resolveConfig()
 
@@ -81,13 +93,13 @@ class DashboardConfigProviderTest extends Stryker4sSuite with EitherValues {
 
     it("should resolve a GitHub actions PR environment") {
       implicit val config = Config.default
-      val env = Map(
+      implicit val env = makeEnv(
         "STRYKER_DASHBOARD_API_KEY" -> "apiKeyHere",
         "GITHUB_ACTION" -> "true",
         "GITHUB_REPOSITORY" -> "github/repo",
         "GITHUB_REF" -> "refs/pull/10/merge"
       )
-      val sut = new DashboardConfigProvider(env)
+      val sut = new DashboardConfigProvider[Id]()
 
       val result = sut.resolveConfig()
 
@@ -111,10 +123,10 @@ class DashboardConfigProviderTest extends Stryker4sSuite with EitherValues {
           module = Some("moduleHere")
         )
       )
-      val env = Map(
+      implicit val env = makeEnv(
         "STRYKER_DASHBOARD_API_KEY" -> "apiKeyHere"
       )
-      val sut = new DashboardConfigProvider(env)
+      val sut = new DashboardConfigProvider[Id]()
 
       val result = sut.resolveConfig()
 
@@ -136,8 +148,8 @@ class DashboardConfigProviderTest extends Stryker4sSuite with EitherValues {
           module = None
         )
       )
-      val env = Map("STRYKER_DASHBOARD_API_KEY" -> "apiKeyHere")
-      val sut = new DashboardConfigProvider(env)
+      implicit val env = makeEnv("STRYKER_DASHBOARD_API_KEY" -> "apiKeyHere")
+      val sut = new DashboardConfigProvider[Id]()
 
       val result = sut.resolveConfig()
 
@@ -153,13 +165,13 @@ class DashboardConfigProviderTest extends Stryker4sSuite with EitherValues {
 
     it("should not resolve a GitHub actions with malformed ref") {
       implicit val config = Config.default
-      val env = Map(
+      implicit val env = makeEnv(
         "STRYKER_DASHBOARD_API_KEY" -> "apiKeyHere",
         "GITHUB_ACTION" -> "true",
         "GITHUB_REPOSITORY" -> "github/repo",
         "GITHUB_REF" -> "refs/whatever"
       )
-      val sut = new DashboardConfigProvider(env)
+      val sut = new DashboardConfigProvider[Id]()
 
       val result = sut.resolveConfig()
 
@@ -168,14 +180,14 @@ class DashboardConfigProviderTest extends Stryker4sSuite with EitherValues {
 
     it("should not resolve empty env variables") {
       implicit val config = Config.default
-      val env = Map(
+      implicit val env = makeEnv(
         "STRYKER_DASHBOARD_API_KEY" -> "apiKeyHere",
         "CIRCLECI" -> "true",
         "CIRCLE_PROJECT_USERNAME" -> "circleUsername",
         "CIRCLE_PROJECT_REPONAME" -> "circleRepoName",
         "CIRCLE_BRANCH" -> ""
       )
-      val sut = new DashboardConfigProvider(env)
+      val sut = new DashboardConfigProvider[Id]()
 
       val result = sut.resolveConfig()
 
@@ -190,8 +202,8 @@ class DashboardConfigProviderTest extends Stryker4sSuite with EitherValues {
           module = Some("moduleHere")
         )
       )
-      val env = Map.empty[String, String]
-      val sut = new DashboardConfigProvider(env)
+      implicit val env = makeEnv()
+      val sut = new DashboardConfigProvider[Id]()
 
       val result = sut.resolveConfig()
 
@@ -206,8 +218,8 @@ class DashboardConfigProviderTest extends Stryker4sSuite with EitherValues {
           module = Some("moduleHere")
         )
       )
-      val env = Map("STRYKER_DASHBOARD_API_KEY" -> "apiKeyHere")
-      val sut = new DashboardConfigProvider(env)
+      implicit val env = makeEnv("STRYKER_DASHBOARD_API_KEY" -> "apiKeyHere")
+      val sut = new DashboardConfigProvider[Id]()
 
       val result = sut.resolveConfig()
 
@@ -222,8 +234,8 @@ class DashboardConfigProviderTest extends Stryker4sSuite with EitherValues {
           module = Some("moduleHere")
         )
       )
-      val env = Map("STRYKER_DASHBOARD_API_KEY" -> "apiKeyHere")
-      val sut = new DashboardConfigProvider(env)
+      implicit val env = makeEnv("STRYKER_DASHBOARD_API_KEY" -> "apiKeyHere")
+      val sut = new DashboardConfigProvider[Id]()
 
       val result = sut.resolveConfig()
 
@@ -238,8 +250,8 @@ class DashboardConfigProviderTest extends Stryker4sSuite with EitherValues {
           module = Some("moduleHere")
         )
       )
-      val env = Map.empty[String, String]
-      val sut = new DashboardConfigProvider(env)
+      implicit val env = makeEnv()
+      val sut = new DashboardConfigProvider[Id]()
 
       val result = sut.resolveConfig()
 


### PR DESCRIPTION
#### What it does

Refactors env loading for the dashboard to use cats-effect Env typeclass instead of `sys.env` with a `Map[String, String]`. This simplifies some of the code, and makes testing a bit easier. 

#### How it works

The `Env` typeclass provides a different way to reading environment variables than `sys.env`, mainly the `.get` returns an effect because the environment is not 'pure'. The `DashboardConfigProvider` and `CIProvider` now use the `Env` typeclass, and a `F[_]` type parameter to allow for different effect types. Runtime code uses `IO`, and tests use `Id` (which is an alias for no suspension).

https://typelevel.org/cats-effect/docs/std/env
