### PR TITLE
[sbt] Add warning in case of empty framework sequence

### DIFF
--- a/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
+++ b/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
@@ -123,6 +123,11 @@ class Stryker4sSbtRunner(
         val javaOpts = extractTaskValue(Test / javaOptions, "javaOptions")
 
         val frameworks = extractTaskValue(Test / loadedTestFrameworks, "test frameworks").values.toSeq
+        if (frameworks.isEmpty)
+          log.warn(
+            "No test frameworks found via loadedTestFrameworks. " +
+              "Will likely result in no tests being run and a NoCoverage result for all mutants."
+          )
 
         val testGroups = extractTaskValue(Test / testGrouping, "testGrouping").map { group =>
           if (config.testFilter.isEmpty) group


### PR DESCRIPTION
For helping debug an issue on Scala 3.3.1 / sbt 1.9.6

```
[info] set current project to fakeRoot (in build file:/home/fabian/Development/LibreCybernetics/basecodecs.scala/)
[warn] No test frameworks found via sbt / loadedTestFrameworks
[info] Creating 7 test-runners
```
