### PR TITLE
feat(report): add tests, per-test coverage and statusReason to report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          # Sbt version that is tested (1.4.0) doesn't work on Java 21
-          java-version: 11
+          # Sbt version that is tested (1.7.0) doesn't work on Java 21
+          java-version: 17
           cache: 'sbt'
       - name: Run tests
         run: sbt 'sbtTestRunner2_12/publishLocal; scripted'

--- a/maven/src/main/scala/stryker4s/maven/runner/MavenTestRunner.scala
+++ b/maven/src/main/scala/stryker4s/maven/runner/MavenTestRunner.scala
@@ -8,6 +8,7 @@ import org.apache.maven.shared.invoker.{DefaultInvocationRequest, InvocationRequ
 import stryker4s.log.Logger
 import stryker4s.model.*
 import stryker4s.run.TestRunner
+import stryker4s.testrunner.api.TestFile
 
 import java.util.Properties
 import scala.jdk.CollectionConverters.*
@@ -28,7 +29,7 @@ class MavenTestRunner(
     IO.blocking(invoker.execute(request)).map(_.getExitCode() == 0).map(NoCoverageInitialTestRun(_))
   }
 
-  def runMutant(mutant: MutantWithId, testNames: Seq[String]): IO[MutantResult] = {
+  def runMutant(mutant: MutantWithId, testNames: Seq[TestFile]): IO[MutantResult] = {
     val request = createRequestWithMutation(mutant.id)
 
     IO.blocking(invoker.execute(request)).map { result =>

--- a/maven/src/test/scala/stryker4s/maven/runner/MavenTestRunnerTest.scala
+++ b/maven/src/test/scala/stryker4s/maven/runner/MavenTestRunnerTest.scala
@@ -10,6 +10,7 @@ import stryker4s.maven.stubs.{InvocationResultStub, InvokerStub}
 import stryker4s.model.{MutantId, MutantMetadata, MutantWithId, MutatedCode, NoCoverageInitialTestRun}
 import stryker4s.mutation.LesserThan
 import stryker4s.testkit.{LogMatchers, Stryker4sIOSuite}
+import stryker4s.testrunner.api.TestFile
 
 import java.util as ju
 import scala.jdk.CollectionConverters.*
@@ -19,7 +20,7 @@ class MavenTestRunnerTest extends Stryker4sIOSuite with LogMatchers {
   implicit val config: Config = Config.default
 
   val tmpDir = Path("/home/user/tmpDir")
-  val coverageTestNames = Seq.empty[String]
+  val coverageTestNames = Seq.empty[TestFile]
   def properties = new ju.Properties()
   def goals = Seq("test")
 

--- a/modules/commandRunner/src/main/scala/stryker4s/command/runner/ProcessTestRunner.scala
+++ b/modules/commandRunner/src/main/scala/stryker4s/command/runner/ProcessTestRunner.scala
@@ -7,6 +7,7 @@ import stryker4s.config.Config
 import stryker4s.model.*
 import stryker4s.run.TestRunner
 import stryker4s.run.process.{Command, ProcessRunner}
+import stryker4s.testrunner.api.TestFile
 
 import scala.concurrent.TimeoutException
 import scala.util.{Failure, Success}
@@ -20,7 +21,7 @@ class ProcessTestRunner(command: Command, processRunner: ProcessRunner, tmpDir: 
     }
   }
 
-  def runMutant(mutant: MutantWithId, testNames: Seq[String]): IO[MutantResult] = {
+  def runMutant(mutant: MutantWithId, testNames: Seq[TestFile]): IO[MutantResult] = {
     val id = mutant.id.value
     processRunner(command, tmpDir, ("ACTIVE_MUTATION", id.toString)).map {
       case Success(0)                   => mutant.toMutantResult(MutantStatus.Survived)

--- a/modules/core/src/main/scala/stryker4s/Stryker4s.scala
+++ b/modules/core/src/main/scala/stryker4s/Stryker4s.scala
@@ -33,7 +33,7 @@ class Stryker4s(fileSource: MutatesFileResolver, mutator: Mutator, runner: Mutan
     val mapper = new MutantRunResultMapper() {}
     for {
       time <- IO.realTime
-      report = mapper.toReport(merged)
+      report = mapper.toReport(merged, results.testFiles)
       metrics = Metrics.calculateMetrics(report)
       reportsLocation = config.baseDir / "target/stryker4s-report" / time.toMillis.toString()
       _ <- reporter.onRunFinished(FinishedRunEvent(report, metrics, results.duration, reportsLocation))

--- a/modules/core/src/main/scala/stryker4s/model/InitialTestRunCoverageReport.scala
+++ b/modules/core/src/main/scala/stryker4s/model/InitialTestRunCoverageReport.scala
@@ -1,7 +1,7 @@
 package stryker4s.model
 
 import cats.syntax.option.*
-import stryker4s.testrunner.api.testprocess.CoverageReport
+import stryker4s.testrunner.api.{CoverageReport, TestFile}
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -11,15 +11,42 @@ sealed trait InitialTestRunResult {
   /** Initial testruns can report their own taken duration, or a timed one will be taken as a backup if this is `
     */
   def reportedDuration: Option[FiniteDuration] = none
+
+  def coveredMutants: Map[MutantId, Seq[TestFile]]
+
+  def staticMutants: Seq[MutantId]
+
+  def hasCoverage: Boolean
+
+  def testNames: Seq[TestFile]
 }
 
 final case class InitialTestRunCoverageReport(
     isSuccessful: Boolean,
     firstRun: CoverageReport,
     secondRun: CoverageReport,
-    duration: FiniteDuration
+    duration: FiniteDuration,
+    testNames: Seq[TestFile]
 ) extends InitialTestRunResult {
+
+  override val staticMutants: Seq[MutantId] = (firstRun.report -- (secondRun.report.keys)).keys.toSeq
+
+  override val coveredMutants: Map[MutantId, Seq[TestFile]] = firstRun.report.filterNot { case (id, _) =>
+    staticMutants.contains(id)
+  }
+
   override def reportedDuration: Option[FiniteDuration] = duration.some
+
+  override def hasCoverage: Boolean = true
 }
 
-final case class NoCoverageInitialTestRun(isSuccessful: Boolean) extends InitialTestRunResult
+final case class NoCoverageInitialTestRun(isSuccessful: Boolean) extends InitialTestRunResult {
+
+  override def staticMutants: Seq[MutantId] = Seq.empty
+
+  override def coveredMutants: Map[MutantId, Seq[TestFile]] = Map.empty
+
+  override def hasCoverage: Boolean = false
+
+  override def testNames: Seq[TestFile] = Seq.empty
+}

--- a/modules/core/src/main/scala/stryker4s/model/Mutant.scala
+++ b/modules/core/src/main/scala/stryker4s/model/Mutant.scala
@@ -4,18 +4,17 @@ import cats.Show
 import cats.syntax.all.*
 import mutationtesting.{Location, MutantResult, MutantStatus}
 import stryker4s.extension.TreeExtensions.PositionExtension
+import stryker4s.testrunner.api.TestDefinitionId
 
 import scala.meta.{Position, Term}
-
-final case class MutantId(value: Int) extends AnyVal {
-  override def toString(): String = value.toString
-}
 
 final case class MutantWithId(id: MutantId, mutatedCode: MutatedCode) {
   def toMutantResult(
       status: MutantStatus,
       testsCompleted: Option[Int] = none,
-      statusReason: Option[String] = none
+      statusReason: Option[String] = none,
+      killedBy: Option[Seq[TestDefinitionId]] = none,
+      coveredBy: Option[Seq[TestDefinitionId]] = none
   ): MutantResult =
     MutantResult(
       id = id.toString(),
@@ -25,7 +24,9 @@ final case class MutantWithId(id: MutantId, mutatedCode: MutatedCode) {
       status = status,
       description = mutatedCode.metadata.description,
       statusReason = statusReason,
-      testsCompleted = testsCompleted
+      testsCompleted = testsCompleted,
+      coveredBy = coveredBy.map(_.map(_.toString)),
+      killedBy = killedBy.map(_.map(_.toString))
     )
 }
 

--- a/modules/core/src/main/scala/stryker4s/model/RunResult.scala
+++ b/modules/core/src/main/scala/stryker4s/model/RunResult.scala
@@ -1,5 +1,11 @@
 package stryker4s.model
 
+import mutationtesting.TestFileDefinitionDictionary
+
 import scala.concurrent.duration.FiniteDuration
 
-final case class RunResult(results: MutantResultsPerFile, duration: FiniteDuration)
+final case class RunResult(
+    results: MutantResultsPerFile,
+    testFiles: Option[TestFileDefinitionDictionary],
+    duration: FiniteDuration
+)

--- a/modules/core/src/main/scala/stryker4s/report/mapper/MutantRunResultMapper.scala
+++ b/modules/core/src/main/scala/stryker4s/report/mapper/MutantRunResultMapper.scala
@@ -12,7 +12,8 @@ import scala.util.{Properties, Try}
 
 trait MutantRunResultMapper {
   protected[stryker4s] def toReport(
-      results: MutantResultsPerFile
+      results: MutantResultsPerFile,
+      testFiles: Option[TestFileDefinitionDictionary]
   )(implicit config: Config): MutationTestResult[Config] =
     MutationTestResult(
       thresholds = toThresholds(config.thresholds),
@@ -20,7 +21,8 @@ trait MutantRunResultMapper {
       projectRoot = config.baseDir.absolute.toString.some,
       config = config.some,
       system = systemInformation.some,
-      framework = frameworkInformation.some
+      framework = frameworkInformation.some,
+      testFiles = testFiles
     )
 
   private def toThresholds(thresholds: ConfigThresholds): Thresholds =

--- a/modules/core/src/test/scala/stryker4s/report/mapper/MutantRunResultMapperTest.scala
+++ b/modules/core/src/test/scala/stryker4s/report/mapper/MutantRunResultMapperTest.scala
@@ -18,7 +18,7 @@ class MutantRunResultMapperTest extends Stryker4sSuite {
       val sut = new MutantRunResultMapper {}
       implicit val config: Config = Config(thresholds = ConfigThresholds(high = 60, low = 40))
 
-      val result = sut.toReport(mutationRunResults)
+      val result = sut.toReport(mutationRunResults, testFiles.some)
 
       assertEquals(result.thresholds, Thresholds(high = 60, low = 40))
       assertEquals(result.files.size, 2)
@@ -82,6 +82,8 @@ class MutantRunResultMapperTest extends Stryker4sSuite {
 
     Map(path -> Vector(mutantRunResult, mutantRunResult2), path3 -> Vector(mutantRunResult3))
   }
+
+  def testFiles: TestFileDefinitionDictionary = Map.empty
 
   /** Helper method to create a [[stryker4s.model.MutantWithId]], with the `original` param having the correct
     * `Location` property

--- a/modules/core/src/test/scala/stryker4s/run/MutantRunnerTest.scala
+++ b/modules/core/src/test/scala/stryker4s/run/MutantRunnerTest.scala
@@ -54,7 +54,7 @@ class MutantRunnerTest extends Stryker4sIOSuite with LogMatchers with TestData {
       val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
       val mutants = NonEmptyVector.of(mutant, secondMutant, thirdMutant)
       val mutatedFile = MutatedFile(file, q"def foo = 4", mutants)
-      sut(Vector(mutatedFile)).asserting { case RunResult(results, _) =>
+      sut(Vector(mutatedFile)).asserting { case RunResult(results, _, _) =>
         assertLoggedInfo("Setting up mutated environment...")
         assertLoggedInfo("Starting initial test run...")
         assertLoggedInfo("Initial test run succeeded! Testing mutants...")
@@ -92,7 +92,7 @@ class MutantRunnerTest extends Stryker4sIOSuite with LogMatchers with TestData {
 
       val sut = new MutantRunner(testRunner, fileCollectorStub, rollbackHandler, reporterStub)
 
-      sut(Vector(mutatedFile)).asserting { case RunResult(results, _) =>
+      sut(Vector(mutatedFile)).asserting { case RunResult(results, _, _) =>
         val (path, resultForFile) = results.loneElement
         assertEquals(path, file)
         assertLoggedInfo("Attempting to remove 1 mutant(s) that gave a compile error...")

--- a/modules/core/src/test/scala/stryker4s/testutil/stubs/TestRunnerStub.scala
+++ b/modules/core/src/test/scala/stryker4s/testutil/stubs/TestRunnerStub.scala
@@ -7,15 +7,17 @@ import fs2.io.file.Path
 import mutationtesting.{MutantResult, MutantStatus}
 import stryker4s.model.*
 import stryker4s.run.{ResourcePool, TestRunner, TestRunnerPool}
+import stryker4s.testrunner.api.TestFile
 import stryker4s.testutil.TestData
 
 class TestRunnerStub(results: Seq[() => MutantResult], initialTestRunResultIsSuccessful: Boolean = true)
     extends TestRunner {
   private val stream = Iterator.from(0)
 
-  def initialTestRun(): IO[InitialTestRunResult] = IO.pure(NoCoverageInitialTestRun(initialTestRunResultIsSuccessful))
+  override def initialTestRun(): IO[InitialTestRunResult] =
+    IO.pure(NoCoverageInitialTestRun(initialTestRunResultIsSuccessful))
 
-  def runMutant(mutant: MutantWithId, testNames: Seq[String]): IO[MutantResult] = {
+  override def runMutant(mutant: MutantWithId, testNames: Seq[TestFile]): IO[MutantResult] = {
     // Ensure runMutant can always continue
     IO(results.applyOrElse(stream.next(), (_: Int) => results.head)())
       .recover { case _: ArrayIndexOutOfBoundsException => results.head() }

--- a/modules/sbt/src/main/scala/stryker4s/model/TestInterfaceMapper.scala
+++ b/modules/sbt/src/main/scala/stryker4s/model/TestInterfaceMapper.scala
@@ -3,7 +3,7 @@ package stryker4s.model
 import cats.syntax.option.*
 import sbt.testing.Framework as SbtFramework
 import sbt.{TestDefinition as SbtTestDefinition, TestFramework as SbtTestFramework, Tests}
-import stryker4s.testrunner.api.testprocess.*
+import stryker4s.testrunner.api.*
 
 trait TestInterfaceMapper {
   def toApiTestGroups(frameworks: Seq[SbtFramework], sbtTestGroups: Seq[Tests.Group]): Array[TestGroup] = {

--- a/modules/sbt/src/main/scala/stryker4s/sbt/runner/LegacySbtTestRunner.scala
+++ b/modules/sbt/src/main/scala/stryker4s/sbt/runner/LegacySbtTestRunner.scala
@@ -9,6 +9,7 @@ import stryker4s.exception.InitialTestRunFailedException
 import stryker4s.log.Logger
 import stryker4s.model.*
 import stryker4s.run.TestRunner
+import stryker4s.testrunner.api.TestFile
 
 class LegacySbtTestRunner(initialState: State, settings: Seq[Def.Setting[?]], extracted: Extracted)(implicit
     log: Logger
@@ -22,7 +23,7 @@ class LegacySbtTestRunner(initialState: State, settings: Seq[Def.Setting[?]], ex
     onFailed = NoCoverageInitialTestRun(false)
   )
 
-  def runMutant(mutant: MutantWithId, testNames: Seq[String]): IO[MutantResult] = {
+  def runMutant(mutant: MutantWithId, testNames: Seq[TestFile]): IO[MutantResult] = {
     val mutationState =
       extracted.appendWithSession(settings :+ mutationSetting(mutant.id.value), initialState)
     runTests(

--- a/modules/sbt/src/main/scala/stryker4s/sbt/runner/TestRunnerConnection.scala
+++ b/modules/sbt/src/main/scala/stryker4s/sbt/runner/TestRunnerConnection.scala
@@ -7,7 +7,7 @@ import fs2.Chunk
 import fs2.io.net.Socket
 import scodec.bits.BitVector
 import stryker4s.log.Logger
-import stryker4s.testrunner.api.testprocess.{Request, RequestMessage, Response, ResponseMessage}
+import stryker4s.testrunner.api.{Request, RequestMessage, Response, ResponseMessage}
 
 sealed trait TestRunnerConnection {
   def sendMessage(request: Request): IO[Response]

--- a/modules/sbtTestRunner/src/main/scala/stryker4s/sbt/testrunner/Context.scala
+++ b/modules/sbtTestRunner/src/main/scala/stryker4s/sbt/testrunner/Context.scala
@@ -1,6 +1,6 @@
 package stryker4s.sbt.testrunner
 
-import stryker4s.testrunner.api.testprocess.TestProcessProperties
+import stryker4s.testrunner.api.TestProcessProperties
 
 object Context {
   def resolveSocketConfig(): Int = {

--- a/modules/sbtTestRunner/src/main/scala/stryker4s/sbt/testrunner/MessageHandler.scala
+++ b/modules/sbtTestRunner/src/main/scala/stryker4s/sbt/testrunner/MessageHandler.scala
@@ -2,7 +2,7 @@ package stryker4s.sbt.testrunner
 
 import sbt.testing.Status
 import stryker4s.coverage.{collectCoverage, timed}
-import stryker4s.testrunner.api.testprocess.*
+import stryker4s.testrunner.api.*
 
 import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal
@@ -21,7 +21,7 @@ final class TestRunnerMessageHandler() extends MessageHandler {
           val result = testRunner.runMutation(mutation, testNames)
           toTestResult(result)
         } catch {
-          case NonFatal(e) => ErrorDuringTestRun(e.toString())
+          case NonFatal(e) => ErrorDuringTestRun.of(e.toString())
         }
 
       case StartInitialTestRun() =>
@@ -39,10 +39,10 @@ final class TestRunnerMessageHandler() extends MessageHandler {
     }
 
   def toTestResult(result: TestRunResult): Response =
-    if (result.status == Status.Success) TestsSuccessful(result.testsCompleted)
-    else TestsUnsuccessful(result.testsCompleted)
+    if (result.status == Status.Success) TestsSuccessful.of(result.testsCompleted)
+    else TestsUnsuccessful.of(result.testsCompleted, failedTests = result.failedTests)
 
   def toInitialTestResult(status: Status, coverage: CoverageTestNameMap, duration: FiniteDuration): Response =
-    CoverageTestRunResult(status == Status.Success, Some(coverage), durationNanos = duration.toNanos)
+    CoverageTestRunResult.of(status == Status.Success, Some(coverage), durationNanos = duration.toNanos)
 
 }

--- a/modules/sbtTestRunner/src/main/scala/stryker4s/sbt/testrunner/SbtTestRunnerMain.scala
+++ b/modules/sbtTestRunner/src/main/scala/stryker4s/sbt/testrunner/SbtTestRunnerMain.scala
@@ -1,7 +1,7 @@
 package stryker4s.sbt.testrunner
 
 import com.google.protobuf.CodedInputStream
-import stryker4s.testrunner.api.testprocess.RequestMessage
+import stryker4s.testrunner.api.RequestMessage
 
 import java.net.{InetAddress, ServerSocket, Socket}
 

--- a/modules/sbtTestRunner/src/main/scala/stryker4s/sbt/testrunner/TestRunner.scala
+++ b/modules/sbtTestRunner/src/main/scala/stryker4s/sbt/testrunner/TestRunner.scala
@@ -1,23 +1,23 @@
 package stryker4s.sbt.testrunner
 
 import sbt.testing.{Event, EventHandler, Framework, Status, Task}
-import stryker4s.testrunner.api.testprocess.*
+import stryker4s.model.MutantId
+import stryker4s.testrunner.api.*
 
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
-import java.util.function.UnaryOperator
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
 sealed trait TestRunner {
-  def runMutation(mutation: Int, fingerprints: Seq[String]): TestRunResult
+  def runMutation(mutation: MutantId, fingerprints: Seq[String]): TestRunResult
   def initialTestRun(): TestRunResult
 }
 
-private[stryker4s] case class TestRunResult(status: Status, testsCompleted: Int)
+private[stryker4s] case class TestRunResult(status: Status, testsCompleted: Int, failedTests: Seq[FailedTestDefinition])
 
 class SbtTestInterfaceRunner(context: TestProcessContext) extends TestRunner with TestInterfaceMapper {
 
-  val testFunctions: Option[(Int, Seq[String])] => TestRunResult = {
+  val testFunctions: Option[(MutantId, Seq[String])] => TestRunResult = {
     val tasks = {
       val cl = getClass().getClassLoader()
       context.testGroups.flatMap { testGroup =>
@@ -27,7 +27,7 @@ class SbtTestInterfaceRunner(context: TestProcessContext) extends TestRunner wit
         runner.tasks(testGroup.taskDefs.map(toSbtTaskDef).toArray)
       }
     }
-    (mutation: Option[(Int, Seq[String])]) => {
+    (mutation: Option[(MutantId, Seq[String])]) => {
       val tasksToRun = mutation match {
         case Some((_, testNames)) =>
           tasks.filter(t => testNames.contains(t.taskDef().fullyQualifiedName()))
@@ -35,15 +35,21 @@ class SbtTestInterfaceRunner(context: TestProcessContext) extends TestRunner wit
       }
       val testsCompleted = new AtomicInteger(0)
       val statusRef = new AtomicReference[Status](Status.Success)
-      val eventHandler = new StatusEventHandler(statusRef, testsCompleted)
-      mutation.foreach { case (mutantId, _) => stryker4s.activeMutation = mutantId }
+      val failedTestsRef = new AtomicReference[Seq[FailedTestDefinition]](Vector.empty)
+
+      val eventHandler = mutation match {
+        case Some(_) => new MutantRunEventHandler(statusRef, testsCompleted, failedTestsRef)
+        case None    => new InitialTestRunEventHandler(statusRef)
+      }
+
+      mutation.foreach { case (mutantId, _) => stryker4s.activeMutation = mutantId.value }
       val status = runTests(tasksToRun, statusRef, eventHandler)
 
-      TestRunResult(status, testsCompleted.get())
+      TestRunResult(status, testsCompleted.get(), failedTestsRef.get())
     }
   }
 
-  override def runMutation(mutation: Int, testNames: Seq[String]): TestRunResult = {
+  override def runMutation(mutation: MutantId, testNames: Seq[String]): TestRunResult = {
     testFunctions(Some((mutation, testNames)))
   }
 
@@ -51,48 +57,72 @@ class SbtTestInterfaceRunner(context: TestProcessContext) extends TestRunner wit
     testFunctions(None)
   }
 
-  @tailrec
   private def runTests(
       testTasks: Seq[Task],
       status: AtomicReference[Status],
       eventHandler: EventHandler
   ): sbt.testing.Status = {
 
-    val newTasks = testTasks.flatMap(task =>
-      status.get() match {
-        // Fail early
-        case Status.Failure => Array.empty[Task]
-        case Status.Error   => Array.empty[Task]
-        case _ =>
-          stryker4s.coverage.setActiveTest(task.taskDef().fullyQualifiedName())
-          task.execute(eventHandler, Array.empty)
-      }
-    )
-    if (newTasks.nonEmpty) runTests(newTasks, status, eventHandler)
-    else status.get()
+    @tailrec
+    def runTasks(testTasks: Seq[Task]): sbt.testing.Status = {
+      val newTasks = testTasks.flatMap(task =>
+        status.get() match {
+          // Fail early
+          case Status.Failure => Array.empty[Task]
+          case Status.Error   => Array.empty[Task]
+          case _ =>
+            stryker4s.coverage.setActiveTest(task.taskDef().fullyQualifiedName())
+            task.execute(eventHandler, Array.empty)
+        }
+      )
+      if (newTasks.nonEmpty) runTasks(newTasks)
+      else status.get()
+    }
+
+    runTasks(testTasks)
   }
 
-  class StatusEventHandler(status: AtomicReference[Status], testsCompleted: AtomicInteger) extends EventHandler {
+  class InitialTestRunEventHandler(status: AtomicReference[Status]) extends EventHandler {
+    private val testDefinitionIds = new AtomicInteger(0)
     override def handle(event: Event) = {
+      val td = TestDefinition.of(TestDefinitionId(testDefinitionIds.getAndIncrement()), testNameFromEvent(event))
+      stryker4s.coverage.appendDefinitionToActiveTest(td)
+      status.updateAndGet(old => combineStatus(old, event.status()))
+      ()
+    }
+
+  }
+
+  class MutantRunEventHandler(
+      status: AtomicReference[Status],
+      testsCompleted: AtomicInteger,
+      failedTestIdsRef: AtomicReference[Seq[FailedTestDefinition]]
+  ) extends EventHandler {
+    override def handle(event: Event) = {
+      val testName = testNameFromEvent(event)
       testsCompleted.incrementAndGet()
       if (event.status() != Status.Success) {
-        println(s"Test unsuccessful: ${event.fullyQualifiedName()} status ${event.status()} with ${event.throwable()}")
+        println(s"Test unsuccessful: $testName status ${event.status()} with ${event.throwable()}")
 
         // Re-throw Fatal exceptions to restart the testrunner
-        val maybethrowable =
-          if (event.throwable().isDefined())
-            Some(event.throwable().get()).filterNot(NonFatal(_))
-          else None
-        maybethrowable.foreach { t =>
-          println(s"Fatal exception reported by testrunner. Re-throwing $t")
-          throw t
+        if (event.throwable().isDefined()) {
+          val t = event.throwable().get()
+          if (!NonFatal(t)) {
+            println(s"Fatal exception reported by testrunner. Re-throwing $t")
+            throw t
+          }
         }
+        failedTestIdsRef.updateAndGet(
+          _ :+ FailedTestDefinition.of(
+            fullyQualifiedName = event.fullyQualifiedName,
+            name = testName,
+            message = toOption(event.throwable()).map(_.getMessage())
+          )
+        )
+        ()
       }
-      status.updateAndGet(new UnaryOperator[Status]() {
-        override def apply(old: Status) = {
-          combineStatus(old, event.status())
-        }
-      })
+
+      status.updateAndGet(old => combineStatus(old, event.status()))
       ()
     }
   }

--- a/modules/testRunnerApi/src/main/protobuf/stryker4s/testrunner/api.proto
+++ b/modules/testRunnerApi/src/main/protobuf/stryker4s/testrunner/api.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package stryker4s.testrunner.api;
+package stryker4s.testrunner;
 
 import "scalapb/scalapb.proto";
 option (scalapb.options) = {
@@ -18,7 +18,7 @@ message Request {
 }
 
 message StartTestRun {
-  int32 mutation = 1;
+  int32 mutation = 1 [(scalapb.field).type = "stryker4s.model.MutantId"];
   repeated string test_names = 3;
 }
 message StartInitialTestRun {}
@@ -85,6 +85,7 @@ message TestsSuccessful {
 }
 message TestsUnsuccessful {
   int32 tests_completed = 1;
+  repeated FailedTestDefinition failed_tests = 2;
 }
 message ErrorDuringTestRun {
   string msg = 1;
@@ -99,12 +100,30 @@ message CoverageTestRunResult {
   * Without it, the size grows exponentially with the number of tests and mutants
   */
 message CoverageTestNameMap {
-  map<int32, string> test_name_ids = 1;
-  map<int32, TestNames> test_names = 2;
+  map<int32, TestFile> test_name_ids = 1 [
+      (scalapb.field).key_type = "stryker4s.testrunner.api.TestFileId"];
+  map<int32, TestNames> test_names = 2 [
+      (scalapb.field).key_type = "stryker4s.model.MutantId"];
 }
 
 message TestNames {
-  repeated int32 test_name = 1;
+  repeated int32 test_name = 1 [(scalapb.field).type = "stryker4s.testrunner.api.TestFileId"];
+}
+
+message TestFile {
+  string fully_qualified_name = 1;
+  repeated TestDefinition definitions = 2;
+}
+
+message TestDefinition {
+  int32 id = 1 [(scalapb.field).type = "stryker4s.testrunner.api.TestDefinitionId"];
+  string name = 2;
+}
+
+message FailedTestDefinition {
+  string fully_qualified_name = 1;
+  string name = 2;
+  optional string message = 3;
 }
 
 message Fingerprint {

--- a/modules/testRunnerApi/src/main/scala/stryker4s/model/MutantId.scala
+++ b/modules/testRunnerApi/src/main/scala/stryker4s/model/MutantId.scala
@@ -1,0 +1,11 @@
+package stryker4s.model
+
+import scalapb.TypeMapper
+
+final case class MutantId(value: Int) extends AnyVal {
+  override def toString(): String = value.toString
+}
+
+object MutantId {
+  implicit val tm: TypeMapper[Int, MutantId] = TypeMapper[Int, MutantId](MutantId(_))(_.value)
+}

--- a/modules/testRunnerApi/src/main/scala/stryker4s/testrunner/api/CoverageReport.scala
+++ b/modules/testRunnerApi/src/main/scala/stryker4s/testrunner/api/CoverageReport.scala
@@ -1,6 +1,8 @@
-package stryker4s.testrunner.api.testprocess
+package stryker4s.testrunner.api
 
-case class CoverageReport(report: Map[Int, Seq[String]]) extends AnyVal
+import stryker4s.model.MutantId
+
+case class CoverageReport(report: Map[MutantId, Seq[TestFile]]) extends AnyVal
 
 object CoverageReport {
   def apply(testRunMap: CoverageTestNameMap): CoverageReport = {

--- a/modules/testRunnerApi/src/main/scala/stryker4s/testrunner/api/TestDefinitionId.scala
+++ b/modules/testRunnerApi/src/main/scala/stryker4s/testrunner/api/TestDefinitionId.scala
@@ -1,0 +1,11 @@
+package stryker4s.testrunner.api
+
+import scalapb.TypeMapper
+
+final case class TestDefinitionId(value: Int) extends AnyVal {
+  override def toString(): String = value.toString
+}
+
+object TestDefinitionId {
+  implicit val tm: TypeMapper[Int, TestDefinitionId] = TypeMapper[Int, TestDefinitionId](TestDefinitionId(_))(_.value)
+}

--- a/modules/testRunnerApi/src/main/scala/stryker4s/testrunner/api/TestProcessProperties.scala
+++ b/modules/testRunnerApi/src/main/scala/stryker4s/testrunner/api/TestProcessProperties.scala
@@ -1,4 +1,4 @@
-package stryker4s.testrunner.api.testprocess
+package stryker4s.testrunner.api
 
 /** Keys for system properties passed to the testprocess
   */

--- a/modules/testRunnerApi/src/main/scala/stryker4s/testrunner/api/TestSelectorId.scala
+++ b/modules/testRunnerApi/src/main/scala/stryker4s/testrunner/api/TestSelectorId.scala
@@ -1,0 +1,11 @@
+package stryker4s.testrunner.api
+
+import scalapb.TypeMapper
+
+final case class TestFileId(value: Int) extends AnyVal {
+  override def toString(): String = value.toString
+}
+
+object TestFileId {
+  implicit val tm: TypeMapper[Int, TestFileId] = TypeMapper[Int, TestFileId](TestFileId(_))(_.value)
+}


### PR DESCRIPTION
<!---
Thanks for your pull request 😄! Please fill in the information below so we can quickly review and merge your PR.

If you feel the template doesn't apply to your PR, feel free to ignore it
-->

<!-- Please enter the issue number that's fixed with this PR, or delete this line if there's no related issue -->

### Fixes #910

#### What it does

Adds `testFiles` to the report. Which is a list of all suites in the project. Each test file has a list of test-definitions, which are individual tests inside the suite (if reported by the framework).

Mutants will now also have the `coveredBy` and `killedBy` fields filled to show which tests killed it. `statusReason` is also filled with the test framework exception if the mutant is killed. Coverage is per-suite, as we don't have the info when collecting coverage. But `killedBy` reports individual tests.

#### How it works

Test files and definitions are collected during the initial test run using the `EventHandler` interface. When mutants run, which tests kill a mutant is collected and sent back to the main process.

Test sources are not filled. This can be part of a separate PR. Locations inside a test file are also unknown as it is not part of the sbt.testing api.

<img width="1262" alt="afbeelding" src="https://github.com/stryker-mutator/stryker4s/assets/10114577/b3f0787c-f5c1-4f21-8b10-ca29c0487b3b">

<img width="1329" alt="afbeelding" src="https://github.com/stryker-mutator/stryker4s/assets/10114577/912182e7-99f9-46da-83d8-46d40fd6c442">