### PR TITLE
Add language mutator-api submodule

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,8 @@ lazy val root = (project withId "stryker4s" in file("."))
       sbtTestRunner.projectRefs ++
       testRunnerApi.projectRefs ++
       api.projectRefs ++
-      testkit.projectRefs) *
+      testkit.projectRefs :+
+      mutatorApi.project) *
   )
 
 lazy val core = (projectMatrix in file("modules") / "core")
@@ -63,6 +64,12 @@ lazy val testRunnerApi = (projectMatrix in file("modules") / "testRunnerApi")
 lazy val api = (projectMatrix in file("modules") / "api")
   .settings(commonSettings, apiSettings)
   .jvmPlatform(scalaVersions = versions.fullCrossScalaVersions)
+
+/** Java-only project that contains interfaces for a language-agnostic mutator API
+  */
+lazy val mutatorApi = (project in file("modules") / "mutatorApi")
+  .settings(mutatorApiSettings)
+// .dependsOn(testkit.jvm(versions.scala3) % Test)
 
 lazy val testkit = (projectMatrix in file("modules") / "testkit")
   .settings(commonSettings, testkitSettings, publishLocalDependsOn(api))

--- a/modules/mutatorApi/src/main/java/stryker/mutator/api/AST.java
+++ b/modules/mutatorApi/src/main/java/stryker/mutator/api/AST.java
@@ -1,0 +1,4 @@
+package stryker.mutator.api;
+
+public interface AST {
+}

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -105,6 +105,16 @@ object Settings {
     )
   )
 
+  lazy val mutatorApiSettings: Seq[Setting[?]] = Seq(
+    moduleName := "stryker-mutator-api",
+    // Target Java 11 as the minimum version
+    javacOptions ++= Seq("--release", "11"),
+    // Disable Scala library dependency
+    crossPaths := false,
+    autoScalaLibrary := false
+    // scalaVersion  := Dependencies.versions.scala3,
+  )
+
   lazy val testkitSettings: Seq[Setting[?]] = Seq(
     moduleName := "stryker4s-testkit",
     libraryDependencies ++= Seq(


### PR DESCRIPTION
This adds a new submodule called `mutator-api` which contains interfaces that language-specific mutators can implement.

Interfaces are to be added and discussed before merging this PR.

@jessemaas  @YVbakker 