### PR TITLE
fix: compatibility with sbt-crossproject

### DIFF
--- a/modules/sbt/src/main/scala/stryker4s/sbt/Stryker4sPlugin.scala
+++ b/modules/sbt/src/main/scala/stryker4s/sbt/Stryker4sPlugin.scala
@@ -96,8 +96,7 @@ object Stryker4sPlugin extends AutoPlugin {
   private val projectMatrixBaseDirectory = SettingKey[File]("projectMatrixBaseDirectory")
 
   private def getSourceDirectories(postfix: String) = Def.setting {
-    (Compile / sourceDirectories).value
-      .filterNot(_.toString().startsWith(target.value.toString()))
+    (Compile / unmanagedSourceDirectories).value
       .flatMap(_.relativeTo(strykerBaseDir.value))
       .map(file => (file / postfix).toString)
   }
@@ -105,7 +104,7 @@ object Stryker4sPlugin extends AutoPlugin {
   private def getStryker4sBaseDir = Def.setting[File] {
     crossProjectBaseDirectory.?.value
       .orElse(projectMatrixBaseDirectory.?.value)
-      .orElse(sourceDirectory.?.value.flatMap(f => if (f.getName() == "src") f.getParentFile.some else none))
+      .orElse(sourceDirectory.?.value.flatMap(f => if (f.getName() == "src") Option(f.getParentFile) else none))
       .getOrElse(baseDirectory.value)
   }
 

--- a/modules/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
+++ b/modules/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
@@ -184,10 +184,7 @@ class Stryker4sSbtRunner(
       val settings: Seq[Def.Setting[?]] = Seq(
         scalacOptions --= blocklistedScalacOptions,
         Test / fork := true,
-        Compile / scalaSource := tmpDirFor(Compile / scalaSource, tmpDir).value,
-        // Java code is not mutated, but can point to the same directory as the Scala code
-        // so we need to also change the directory for javaSource to the tmpDir to prevent this
-        Compile / javaSource := tmpDirFor(Compile / javaSource, tmpDir).value,
+        Compile / unmanagedSourceDirectories ~= (_.map(tmpDirFor(_, tmpDir))),
         Test / javaOptions ++= filteredSystemProperties
       ) ++ {
         if (config.testFilter.nonEmpty) {
@@ -200,8 +197,8 @@ class Stryker4sSbtRunner(
       (settings, Project.extract(state))
     }
 
-    def tmpDirFor(langSource: SettingKey[File], tmpDir: Path): Def.Initialize[JFile] =
-      langSource(source => (Path.fromNioPath(source.toPath()) inSubDir tmpDir).toNioPath.toFile())
+    def tmpDirFor(source: File, tmpDir: Path): JFile =
+      (Path.fromNioPath(source.toPath()) inSubDir tmpDir).toNioPath.toFile()
 
     val (settings, extracted) = extractSbtProject(tmpDir)
 


### PR DESCRIPTION
Fixes #646

Also fixes some issue where _most_ source code was mutated, rather than _all_, if the project had multiple source directories.
