### PR TITLE
fix(CLI): correctly parse multiple CLI arguments

### DIFF
--- a/modules/core/src/main/scala/stryker4s/config/source/CliConfigSource.scala
+++ b/modules/core/src/main/scala/stryker4s/config/source/CliConfigSource.scala
@@ -2,8 +2,8 @@ package stryker4s.config.source
 
 import cats.syntax.all.*
 import ciris.*
-import com.monovore.decline.{Command, Opts}
 import fs2.io.file.Path
+import scopt.{DefaultOParserSetup, OEffect, OParser, OParserBuilder}
 import stryker4s.config.codec.CirisConfigDecoders
 import stryker4s.config.{ConfigOrder, DashboardReportType, ExcludedMutation, ReporterType}
 import sttp.model.Uri
@@ -14,18 +14,29 @@ import scala.meta.Dialect
 
 class CliConfigSource[F[_]](args: Seq[String]) extends ConfigSource[F] with CirisConfigDecoders {
 
-  private def parseOpt[T](opt: Opts[T])(implicit name: sourcecode.Name): ConfigValue[F, T] =
-    opts.strykerCommand(opt).parse(args) match {
-      case Right(value) => ConfigValue.loaded(ConfigKey(name.value), value)
-      case Left(help) if help.errors.nonEmpty =>
-        val missing = "Missing "
-        // ConfigValue.missing also adds a "Missing " prefix, so we need to remove it
-        help.errors
-          .map(e => ConfigValue.missing[T](e.replaceFirst(missing, "")))
-          .reduce(_ or _)
-      case Left(help) =>
-        ConfigValue.failed(ConfigError(help.usage.mkString("\n")))
+  private def parseOpt[A, T](
+      parser: OParser[A, Option[T]]
+  )(implicit name: sourcecode.Name): ConfigValue[F, T] = {
+    val parserSetup = new DefaultOParserSetup {
+      override def errorOnUnknownArgument: Boolean = false
     }
+    val parsed = OParser.runParser(parser, args, none, parserSetup)
+
+    parsed match {
+      case (Some(Some(value)), _) => ConfigValue.loaded(ConfigKey(name.value), value)
+      case (_, errs) if errs.nonEmpty =>
+        errs
+          .map {
+            case OEffect.DisplayToErr(msg)    => ConfigValue.missing[T](msg)
+            case OEffect.DisplayToOut(msg)    => ConfigValue.missing[T](msg)
+            case OEffect.ReportError(msg)     => ConfigValue.missing[T](msg)
+            case OEffect.ReportWarning(msg)   => ConfigValue.missing[T](msg)
+            case OEffect.Terminate(exitState) => ConfigValue.failed[T](ConfigError(s"Terminate: $exitState"))
+          }
+          .reduce(_ or _)
+      case (_, _) => ConfigValue.missing(name.value + " option")
+    }
+  }
 
   override def name: String = "CLI arguments"
 
@@ -35,7 +46,7 @@ class CliConfigSource[F[_]](args: Seq[String]) extends ConfigSource[F] with Ciri
 
   override def testFilter: ConfigValue[F, Seq[String]] = parseOpt(opts.testFilter)
 
-  override def baseDir: ConfigValue[F, Path] = parseOpt(opts.baseDir)
+  override def baseDir: ConfigValue[F, Path] = parseOpt(opts.baseDir).map(Path.fromNioPath)
 
   override def reporters: ConfigValue[F, Seq[ReporterType]] = parseOpt(opts.reporters).as[Seq[ReporterType]]
 
@@ -48,167 +59,148 @@ class CliConfigSource[F[_]](args: Seq[String]) extends ConfigSource[F] with Ciri
   override def thresholdsLow: ConfigValue[F, Int] = parseOpt(opts.thresholdsLow)
   override def thresholdsBreak: ConfigValue[F, Int] = parseOpt(opts.thresholdsBreak)
 
-  override def dashboardBaseUrl: ConfigValue[F, Uri] = parseOpt(opts.dashboardBaseUrl).as[Uri]
+  override def dashboardBaseUrl: ConfigValue[F, Uri] = parseOpt(opts.dashboardBaseUrl).map(Uri(_))
   override def dashboardReportType: ConfigValue[F, DashboardReportType] =
     parseOpt(opts.dashboardReportType).as[DashboardReportType]
-  override def dashboardProject: ConfigValue[F, Option[String]] = parseOpt(opts.dashboardProject)
-  override def dashboardVersion: ConfigValue[F, Option[String]] = parseOpt(opts.dashboardVersion)
-  override def dashboardModule: ConfigValue[F, Option[String]] = parseOpt(opts.dashboardModule)
+  override def dashboardProject: ConfigValue[F, Option[String]] = parseOpt(opts.dashboardProject).map(_.some)
+  override def dashboardVersion: ConfigValue[F, Option[String]] = parseOpt(opts.dashboardVersion).map(_.some)
+  override def dashboardModule: ConfigValue[F, Option[String]] = parseOpt(opts.dashboardModule).map(_.some)
 
   override def timeout: ConfigValue[F, FiniteDuration] = parseOpt(opts.timeout)
   override def timeoutFactor: ConfigValue[F, Double] = parseOpt(opts.timeoutFactor)
 
-  override def maxTestRunnerReuse: ConfigValue[F, Option[Int]] = parseOpt(opts.maxTestRunnerReuse)
+  override def maxTestRunnerReuse: ConfigValue[F, Option[Int]] = parseOpt(opts.maxTestRunnerReuse).map(_.some)
 
-  override def legacyTestRunner: ConfigValue[F, Boolean] = parseOpt(opts.legacyTestRunner)
+  override def legacyTestRunner: ConfigValue[F, Boolean] = parseOpt(opts.legacyTestRunner).map(_ => true)
 
   override def scalaDialect: ConfigValue[F, Dialect] = parseOpt(opts.scalaDialect).as[Dialect]
 
   override def concurrency: ConfigValue[F, Int] = parseOpt(opts.concurrency)
 
-  override def debugLogTestRunnerStdout: ConfigValue[F, Boolean] = parseOpt(opts.debugLogTestRunnerStdout)
-  override def debugDebugTestRunner: ConfigValue[F, Boolean] = parseOpt(opts.debugDebugTestRunner)
+  override def debugLogTestRunnerStdout: ConfigValue[F, Boolean] =
+    parseOpt(opts.debugLogTestRunnerStdout).map(_ => true)
+  override def debugDebugTestRunner: ConfigValue[F, Boolean] = parseOpt(opts.debugDebugTestRunner).map(_ => true)
 
-  override def staticTmpDir: ConfigValue[F, Boolean] = parseOpt(opts.staticTmpDir)
+  override def staticTmpDir: ConfigValue[F, Boolean] = parseOpt(opts.staticTmpDir).map(_ => true)
 
-  override def cleanTmpDir: ConfigValue[F, Boolean] = parseOpt(opts.cleanTmpDir)
+  override def cleanTmpDir: ConfigValue[F, Boolean] = parseOpt(opts.cleanTmpDir).map(_ => true)
 
   override def testRunnerCommand: ConfigValue[F, String] = parseOpt(opts.testRunnerCommand)
   override def testRunnerArgs: ConfigValue[F, String] = parseOpt(opts.testRunnerArgs)
 
-  override def openReport: ConfigValue[F, Boolean] = parseOpt(opts.openReport)
+  override def openReport: ConfigValue[F, Boolean] = parseOpt(opts.openReport).map(_ => true)
 
-  override def showHelpMessage: ConfigValue[F, Option[String]] = parseOpt(opts.help)
+  override def showHelpMessage: ConfigValue[F, Option[String]] =
+    parseOpt(opts.help).map(_ => opts.helpText.some)
 
   /* All decline Opts for the CLI.
    * Separately defined so we can build a CLI help message with all options.
    */
   private object opts {
+    private def makeOpt[T](f: OParserBuilder[Option[T]] => OParser[T, Option[T]]) =
+      f(OParser.builder[Option[T]])
+        .action((x, _) => x.some)
 
-    val mutate: Opts[Seq[String]] =
-      Opts.options[String]("mutate", short = "m", help = "A glob expression of files to mutate.").map(_.toList)
+    private def makeRepeatOpt[T](f: OParserBuilder[Option[Seq[T]]] => OParser[T, Option[Seq[T]]]) =
+      f(OParser.builder[Option[Seq[T]]])
+        .unbounded()
+        .action((x, acc) => acc.map(_ :+ x).orElse(Seq(x).some))
 
-    val testFilter: Opts[Seq[String]] =
-      Opts.options[String]("test-filter", short = "t", help = "A glob expression of tests to run.").map(_.toList)
+    val mutate = makeRepeatOpt[String](_.opt[String]('m', "mutate").text("A glob expression of files to mutate."))
 
-    val baseDir: Opts[Path] =
-      Opts.option[JPath]("base-dir", short = "b", help = "The root of the project.").map(Path.fromNioPath)
+    val testFilter = makeRepeatOpt[String](_.opt[String]('t', "test-filter").text("A glob expression of tests to run."))
 
-    val reporters: Opts[Seq[String]] =
-      Opts
-        .options[String]("reporters", short = "r", help = "The reporters to use.")
-        .map(_.toList)
+    val baseDir = makeOpt[JPath](_.opt[JPath]('b', "base-dir").text("The root of the project."))
 
-    val files: Opts[Seq[String]] =
-      Opts
-        .options[String]("files", short = "f", help = "The files to mutate.")
-        .map(_.toList)
+    val reporters = makeRepeatOpt[String](_.opt[String]('r', "reporters").text("The reporters to use."))
 
-    val excludedMutations: Opts[Seq[String]] = Opts
-      .options[String]("excluded-mutations", short = "e", help = "The mutations to exclude.")
-      .map(_.toList)
+    val files = makeRepeatOpt[String](_.opt[String]('f', "files").text("The files to mutate."))
 
-    val thresholdsHigh: Opts[Int] = Opts.option[Int]("thresholds.high", help = "The high threshold.")
-    val thresholdsLow: Opts[Int] = Opts.option[Int]("thresholds.low", help = "The low threshold.")
-    val thresholdsBreak: Opts[Int] = Opts.option[Int]("thresholds.break", help = "The break threshold.")
+    val excludedMutations =
+      makeRepeatOpt[String](_.opt[String]('e', "excluded-mutations").text("The mutations to exclude."))
 
-    val dashboardBaseUrl: Opts[Uri] =
-      Opts.option[java.net.URI]("dashboard.base-url", help = "The base url of the dashboard.").map(Uri(_))
-    val dashboardReportType: Opts[String] =
-      Opts.option[String]("dashboard.report-type", help = "The report type of the dashboard.")
-    val dashboardProject: Opts[Option[String]] =
-      Opts.option[String]("dashboard.project", help = "The project name of the dashboard.").map(_.some)
-    val dashboardVersion: Opts[Option[String]] =
-      Opts.option[String]("dashboard.version", help = "The version of the dashboard.").map(_.some)
-    val dashboardModule: Opts[Option[String]] =
-      Opts.option[String]("dashboard.module", help = "The module of the dashboard.").map(_.some)
+    val thresholdsHigh = makeOpt[Int](_.opt[Int]("thresholds.high").text("The high threshold."))
+    val thresholdsLow = makeOpt[Int](_.opt[Int]("thresholds.low").text("The low threshold."))
+    val thresholdsBreak = makeOpt[Int](_.opt[Int]("thresholds.break").text("The break threshold."))
 
-    val timeout: Opts[FiniteDuration] =
-      Opts.option[FiniteDuration]("timeout", short = "T", help = "The timeout for a test run.")
-    val timeoutFactor: Opts[Double] =
-      Opts.option[Double]("timeout-factor", short = "F", help = "The factor to multiply the timeout with.")
+    val dashboardBaseUrl =
+      makeOpt[java.net.URI](_.opt[java.net.URI]("dashboard.base-url").text("The base url of the dashboard."))
+    val dashboardReportType =
+      makeOpt[String](_.opt[String]("dashboard.report-type").text("The report type of the dashboard."))
+    val dashboardProject =
+      makeOpt[String](_.opt[String]("dashboard.project").text("The project name of the dashboard."))
+    val dashboardVersion = makeOpt[String](_.opt[String]("dashboard.version").text("The version of the dashboard."))
+    val dashboardModule = makeOpt[String](_.opt[String]("dashboard.module").text("The module of the dashboard."))
 
-    val maxTestRunnerReuse: Opts[Option[Int]] = Opts
-      .option[Int](
-        "max-test-runner-reuse",
-        help = "The maximum amount of times a test runner can be reused."
-      )
-      .map(_.some)
+    val timeout = makeOpt[FiniteDuration](_.opt[FiniteDuration]('T', "timeout").text("The timeout for a test run."))
+    val timeoutFactor =
+      makeOpt[Double](_.opt[Double]('F', "timeout-factor").text("The factor to multiply the timeout with."))
 
-    val legacyTestRunner: Opts[Boolean] =
-      Opts.flag("legacy-test-runner", help = "Use the legacy test runner.").as(true)
+    val maxTestRunnerReuse =
+      makeOpt[Int](_.opt[Int]("max-test-runner-reuse").text("The maximum amount of times a test runner can be reused."))
 
-    val scalaDialect: Opts[String] =
-      Opts.option[String]("scala-dialect", help = "The scala dialect to use.")
+    val legacyTestRunner = makeOpt[Unit](_.opt[Unit]("legacy-test-runner").text("Use the legacy test runner."))
 
-    val concurrency: Opts[Int] =
-      Opts.option[Int]("concurrency", short = "c", help = "The amount of concurrent test runners.")
+    val scalaDialect = makeOpt[String](_.opt[String]("scala-dialect").text("The scala dialect to use."))
 
-    val debugLogTestRunnerStdout: Opts[Boolean] = Opts
-      .flag("log-test-runner-stdout", help = "Log the test runner stdout.")
-      .as(true)
+    val concurrency = makeOpt[Int](_.opt[Int]('c', "concurrency").text("The amount of concurrent test runners."))
 
-    val debugDebugTestRunner: Opts[Boolean] = Opts
-      .flag("debug-test-runner", help = "Debug the test runner.")
-      .as(true)
+    val debugLogTestRunnerStdout =
+      makeOpt[Unit](_.opt[Unit]("log-test-runner-stdout").text("Log the test runner stdout."))
 
-    val staticTmpDir: Opts[Boolean] = Opts
-      .flag("static-tmp-dir", help = "Use a static tmp directory.")
-      .as(true)
+    val debugDebugTestRunner = makeOpt[Unit](_.opt[Unit]("debug-test-runner").text("Debug the test runner."))
 
-    val cleanTmpDir: Opts[Boolean] = Opts
-      .flag("clean-tmp-dir", help = "Clean the tmp directory.")
-      .as(true)
+    val staticTmpDir = makeOpt[Unit](_.opt[Unit]("static-tmp-dir").text("Use a static tmp directory."))
 
-    val testRunnerCommand: Opts[String] = Opts
-      .option[String]("test-runner-command", help = "The test runner command.")
-    val testRunnerArgs: Opts[String] = Opts
-      .option[String]("test-runner-args", help = "The test runner arguments.")
+    val cleanTmpDir = makeOpt[Unit](_.opt[Unit]("clean-tmp-dir").text("Clean the tmp directory."))
 
-    val openReport: Opts[Boolean] =
-      Opts.flag("open-report", short = "o", help = "Opens the report in the default browser.").as(true)
+    val testRunnerCommand = makeOpt[String](_.opt[String]("test-runner-command").text("The test runner command."))
+    val testRunnerArgs = makeOpt[String](_.opt[String]("test-runner-args").text("The test runner arguments."))
 
-    // Same as Opts.help, but without `.asHelp`
-    val help: Opts[Option[String]] =
-      Opts.flag("help", help = "Display this help text.").map(_ => strykerCommand(opts.all).showHelp.some)
+    val openReport =
+      makeOpt[Unit](_.opt[Unit]('o', "open-report").text("Opens the report in the default browser."))
 
-    // Used for the help message
-    def all = List(
-      testFilter,
-      mutate,
-      baseDir,
-      reporters,
-      files,
-      excludedMutations,
-      thresholdsHigh,
-      thresholdsLow,
-      thresholdsBreak,
-      dashboardBaseUrl,
-      dashboardReportType,
-      dashboardProject,
-      dashboardVersion,
-      dashboardModule,
-      timeout,
-      timeoutFactor,
-      maxTestRunnerReuse,
-      legacyTestRunner,
-      scalaDialect,
-      concurrency,
-      debugLogTestRunnerStdout,
-      debugDebugTestRunner,
-      staticTmpDir,
-      cleanTmpDir,
-      testRunnerCommand,
-      testRunnerArgs,
-      openReport,
-      help
-    ).sequenceVoid
+    val help = makeOpt[Unit](_.opt[Unit]("help")).text("Display this help text.")
 
-    def strykerCommand[T]: Opts[T] => Command[T] = Command[T](
-      name = "stryker4s",
-      header = "Stryker4s - A mutation testing tool for Scala",
-      helpFlag = false
-    )
+    def helpText = {
+      def asAnyP[A, C](p: OParser[A, Option[C]]): OParser[Any, Option[Any]] = p.asInstanceOf[OParser[Any, Option[Any]]]
+      OParser
+        .usage(
+          OParser.sequence(
+            asAnyP(OParser.builder[Option[Unit]].programName("stryker4s")),
+            asAnyP(OParser.builder[Option[Unit]].note("Stryker4s - A mutation testing tool for Scala")),
+            asAnyP(testFilter),
+            asAnyP(mutate),
+            asAnyP(baseDir),
+            asAnyP(reporters),
+            asAnyP(files),
+            asAnyP(excludedMutations),
+            asAnyP(thresholdsHigh),
+            asAnyP(thresholdsLow),
+            asAnyP(thresholdsBreak),
+            asAnyP(dashboardBaseUrl),
+            asAnyP(dashboardReportType),
+            asAnyP(dashboardProject),
+            asAnyP(dashboardVersion),
+            asAnyP(dashboardModule),
+            asAnyP(timeout),
+            asAnyP(timeoutFactor),
+            asAnyP(maxTestRunnerReuse),
+            asAnyP(legacyTestRunner),
+            asAnyP(scalaDialect),
+            asAnyP(concurrency),
+            asAnyP(debugLogTestRunnerStdout),
+            asAnyP(debugDebugTestRunner),
+            asAnyP(staticTmpDir),
+            asAnyP(cleanTmpDir),
+            asAnyP(testRunnerCommand),
+            asAnyP(testRunnerArgs),
+            asAnyP(openReport),
+            asAnyP(help)
+          )
+        )
+    }
 
   }
+
 }

--- a/modules/core/src/test/scala/stryker4s/config/source/CliConfigSourceTest.scala
+++ b/modules/core/src/test/scala/stryker4s/config/source/CliConfigSourceTest.scala
@@ -54,7 +54,7 @@ class CliConfigSourceTest extends Stryker4sIOSuite {
       parseArg(_.testRunnerArgs, "--test-runner-args", "test").assertEquals("test") *>
       parseArg(_.openReport, "--open-report").assertEquals(true) *>
       parseArg(_.showHelpMessage, "--help").map(_.value).asserting { helpMsg =>
-        assert(helpMsg.startsWith("Usage: stryker4s --"), helpMsg)
+        assert(helpMsg.startsWith("Usage: stryker4s [options]"), helpMsg)
         assert(helpMsg.contains("Stryker4s - A mutation testing tool for Scala"), helpMsg)
 
       }
@@ -87,14 +87,14 @@ class CliConfigSourceTest extends Stryker4sIOSuite {
   test("fails on unknown arguments") {
     parseArgAttempt(_.baseDir, "--unknown-argument=foo")
       .map(_.leftValue.messages.loneElement)
-      .assertEquals("Missing unexpected option: --unknown-argument") *>
+      .assertEquals("Missing unknown option --unknown-argument=foo") *>
       parseArgAttempt(_.baseDir)
         .map(_.leftValue.messages.loneElement)
-        .assertEquals("Missing expected flag --base-dir!")
+        .assertEquals("Missing baseDir option")
   }
 
-  test("should show help message when no arguments are given") {
-    parseArg(_.showHelpMessage, "--help").map(_.value).asserting(helpMsg => assert(helpMsg.startsWith("Usage:")))
+  test("should handle multiple arguments") {
+    parseArg(_.mutate, "--mutate", "foo", "--files", "bar").assertEquals(Seq("foo"))
   }
 
   private def parseArg[T](fn: CliConfigSource[IO] => ConfigValue[IO, T], args: String*)(implicit loc: Location) =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,6 +40,8 @@ object Dependencies {
 
     val scalameta = "4.13.4"
 
+    val scopt = "4.1.0"
+
     val slf4j = "2.0.17"
 
     val sttp = "3.10.3"
@@ -48,7 +50,6 @@ object Dependencies {
 
     val weaponRegeX = "1.3.2"
 
-    val decline = "2.5.0"
   }
 
   object test {
@@ -60,7 +61,6 @@ object Dependencies {
   val catsEffect = "org.typelevel" %% "cats-effect" % versions.catsEffect
   val circeCore = "io.circe" %% "circe-core" % versions.circe
   val ciris = "is.cir" %% "ciris" % versions.ciris
-  val decline = "com.monovore" %% "decline" % versions.decline
   val fansi = "com.lihaoyi" %% "fansi" % versions.fansi
   val fs2Core = "co.fs2" %% "fs2-core" % versions.fs2
   val fs2IO = "co.fs2" %% "fs2-io" % versions.fs2
@@ -75,6 +75,7 @@ object Dependencies {
     .exclude("com.thesamet.scalapb", "scalapb-runtime_2.13")
   val scalapbRuntime =
     "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion % "protobuf"
+  val scopt = "com.github.scopt" %% "scopt" % versions.scopt
   val slf4j = "org.slf4j" % "slf4j-simple" % versions.slf4j
   val sttpCirce = "com.softwaremill.sttp.client3" %% "circe" % versions.sttp
   val sttpFs2Backend = "com.softwaremill.sttp.client3" %% "fs2" % versions.sttp

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -37,7 +37,6 @@ object Settings {
       Dependencies.catsEffect,
       Dependencies.circeCore,
       Dependencies.ciris,
-      Dependencies.decline,
       Dependencies.fansi,
       Dependencies.fs2Core,
       Dependencies.fs2IO,
@@ -45,6 +44,7 @@ object Settings {
       Dependencies.mutationTestingElements,
       Dependencies.mutationTestingMetrics,
       Dependencies.scalameta,
+      Dependencies.scopt,
       Dependencies.sttpCirce,
       Dependencies.sttpFs2Backend,
       Dependencies.weaponRegeX


### PR DESCRIPTION
Fixes #1737

Replaces Decline with Opt. Unfortunately Decline does not allow unhandled arguments, which we need for the way we parse configuration. Scopt does allow this. The API for the CLI remains the same.
