### PR TITLE
fix(sbt): use argfile to start new java processes

### DIFF
--- a/modules/sbt/src/main/scala/stryker4s/sbt/Stryker4sPlugin.scala
+++ b/modules/sbt/src/main/scala/stryker4s/sbt/Stryker4sPlugin.scala
@@ -166,7 +166,7 @@ object Stryker4sPlugin extends AutoPlugin {
       val extraConfigSources = List(sbtConfig, cliConfig)
 
       Deferred[IO, FiniteDuration] // Create shared timeout between testrunners
-        .map(new Stryker4sSbtRunner(state.value, _, extraConfigSources))
+        .map(new Stryker4sSbtRunner(state.value, javaHome.value, _, extraConfigSources))
         .flatMap(_.run())
         .flatMap {
           case ErrorStatus => IO.raiseError(new MessageOnlyException("Mutation score is below configured threshold"))

--- a/modules/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
+++ b/modules/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
@@ -32,6 +32,7 @@ import Stryker4sPlugin.autoImport.stryker
   */
 class Stryker4sSbtRunner(
     state: State,
+    javaHome: Option[File],
     sharedTimeout: Deferred[IO, FiniteDuration],
     override val extraConfigSources: List[ConfigSource[IO]]
 )(implicit
@@ -156,7 +157,7 @@ class Stryker4sSbtRunner(
         )
 
         portRanges.map { port =>
-          SbtTestRunner.create(classpath, javaOpts, frameworks, testGroups, port, sharedTimeout)
+          SbtTestRunner.create(javaHome, classpath, javaOpts, frameworks, testGroups, port, sharedTimeout)
         }
       }
     }

--- a/modules/sbt/src/main/scala/stryker4s/sbt/runner/SbtTestRunner.scala
+++ b/modules/sbt/src/main/scala/stryker4s/sbt/runner/SbtTestRunner.scala
@@ -8,11 +8,13 @@ import stryker4s.config.Config
 import stryker4s.log.Logger
 import stryker4s.run.TestRunner
 
+import java.io.File
 import java.nio.file.Path
 import scala.concurrent.duration.FiniteDuration
 
 object SbtTestRunner {
   def create(
+      javaHome: Option[File],
       classpath: Seq[Path],
       javaOpts: Seq[String],
       frameworks: Seq[Framework],
@@ -24,7 +26,7 @@ object SbtTestRunner {
       log: Logger
   ): Resource[IO, TestRunner] = {
     // Timeout will be set by timeoutRunner after initialTestRun
-    val innerTestRunner = ProcessTestRunner.newProcess(classpath, javaOpts, frameworks, testGroups, port)
+    val innerTestRunner = ProcessTestRunner.newProcess(javaHome, classpath, javaOpts, frameworks, testGroups, port)
 
     val withTimeout = TestRunner.timeoutRunner(timeout, innerTestRunner)
 


### PR DESCRIPTION
Fixes #1740

Create a temporary arg file for java arguments. The file is removed after the process is closed.

Also start the process with javaHome from sbt, if set
