### PR TITLE
fix(sbt): scope task queries to the invoking project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/setup
       - name: Run tests
-        run: sbt 'sbtTestRunner2_12/publishLocal; sbtPlugin/scripted'
+        # sbtTestRunner3 is required by test-subproject (Scala 3 LTS); 2_12 by test-1.
+        run: sbt 'sbtTestRunner2_12/publishLocal; sbtTestRunner3/publishLocal; sbtPlugin/scripted'
   sbt-scripted-2:
     name: sbt 2 plugin scripted tests
     runs-on: ubuntu-latest
@@ -42,7 +43,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/setup
       - name: Run tests
-        run: sbt 'sbtTestRunner2_12/publishLocal; sbtPlugin3/scripted'
+        run: sbt 'sbtTestRunner2_12/publishLocal; sbtTestRunner3/publishLocal; sbtPlugin3/scripted'
   maven-plugin:
     name: Test Maven plugin
     runs-on: ubuntu-latest

--- a/modules/sbt/src/main/scala/stryker4s/sbt/Stryker4sPlugin.scala
+++ b/modules/sbt/src/main/scala/stryker4s/sbt/Stryker4sPlugin.scala
@@ -170,10 +170,6 @@ object Stryker4sPlugin extends AutoPlugin {
     }
 
     val sbtConfig = SbtConfigSource[IO]().value
-    // The project the user invoked `stryker` on. Captured here (task-scoped) so that the runner
-    // can scope its task queries (Test / loadedTestFrameworks, Compile / compile, ...) to it.
-    // Without this, `sbt sub/stryker` queries those tasks against the build's current project
-    // (typically the auto-generated root), which has no test frameworks → silent 0% mutation score.
     val targetProject = thisProjectRef.value
 
     Def.task {

--- a/modules/sbt/src/main/scala/stryker4s/sbt/Stryker4sPlugin.scala
+++ b/modules/sbt/src/main/scala/stryker4s/sbt/Stryker4sPlugin.scala
@@ -170,6 +170,11 @@ object Stryker4sPlugin extends AutoPlugin {
     }
 
     val sbtConfig = SbtConfigSource[IO]().value
+    // The project the user invoked `stryker` on. Captured here (task-scoped) so that the runner
+    // can scope its task queries (Test / loadedTestFrameworks, Compile / compile, ...) to it.
+    // Without this, `sbt sub/stryker` queries those tasks against the build's current project
+    // (typically the auto-generated root), which has no test frameworks → silent 0% mutation score.
+    val targetProject = thisProjectRef.value
 
     Def.task {
       implicit val runtime: IORuntime = IORuntime.global
@@ -180,7 +185,7 @@ object Stryker4sPlugin extends AutoPlugin {
       val extraConfigSources = List(sbtConfig, cliConfig)
 
       Deferred[IO, FiniteDuration] // Create shared timeout between testrunners
-        .map(new Stryker4sSbtRunner(state.value, javaHome.value, _, extraConfigSources))
+        .map(new Stryker4sSbtRunner(state.value, javaHome.value, targetProject, _, extraConfigSources))
         .flatMap(_.run())
         .flatMap {
           case ErrorStatus => IO.raiseError(new MessageOnlyException("Mutation score is below configured threshold"))

--- a/modules/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
+++ b/modules/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
@@ -33,6 +33,7 @@ import Stryker4sPlugin.autoImport.stryker
 class Stryker4sSbtRunner(
     state: State,
     javaHome: Option[File],
+    targetProject: ProjectRef,
     sharedTimeout: Deferred[IO, FiniteDuration],
     override val extraConfigSources: List[ConfigSource[IO]]
 )(implicit
@@ -53,14 +54,14 @@ class Stryker4sSbtRunner(
         LogManager.defaultManager(ConsoleOut.printStreamOut(new PrintStream((_: Int) => {})))
 
       val fullSettings = settings ++ Seq(
-        logManager := {
+        targetProject / logManager := {
           if ((stryker / logLevel).value == Level.Debug) logManager.value
           else emptyLogManager
         }
       )
       val newState = extracted.appendWithSession(fullSettings, state)
 
-      NonEmptyList.of(Resource.pure(new LegacySbtTestRunner(newState, fullSettings, extracted)))
+      NonEmptyList.of(Resource.pure(new LegacySbtTestRunner(newState, fullSettings, extracted, targetProject)))
     }
 
     def setupSbtTestRunner(
@@ -71,9 +72,10 @@ class Stryker4sSbtRunner(
       log.debug(s"Resolved stryker4s version $stryker4sVersion")
 
       val fullSettings = settings ++ Seq(
-        libraryDependencies += "io.stryker-mutator" %% "stryker4s-sbt-testrunner" % stryker4sVersion,
-        resolvers ++= (if (stryker4sVersion.endsWith("-SNAPSHOT")) Seq(Resolver.sonatypeCentralSnapshots)
-                       else Seq.empty)
+        targetProject / libraryDependencies +=
+          "io.stryker-mutator" %% "stryker4s-sbt-testrunner" % stryker4sVersion,
+        targetProject / resolvers ++=
+          (if (stryker4sVersion.endsWith("-SNAPSHOT")) Seq(Resolver.sonatypeCentralSnapshots) else Seq.empty)
       )
       val newState = extracted.appendWithSession(fullSettings, state)
 
@@ -97,8 +99,10 @@ class Stryker4sSbtRunner(
         }
       }
 
-      // See if the mutations compile, and if not extract the errors
-      val compilerErrors = PluginCompat.runTask(Compile / compile, newState) match {
+      // See if the mutations compile, and if not extract the errors.
+      // Scoped to targetProject so `sbt sub/stryker` compiles the subproject's sources, not the
+      // (auto-generated) root project's. See also extractTaskValue calls below.
+      val compilerErrors = PluginCompat.runTask(targetProject / Compile / compile, newState) match {
         case Some(Left(cause)) =>
           val rootCauses = getRootCause(cause)
           rootCauses.foreach(t => log.debug(s"Compile failed with ${t.getClass().getName()} root cause: $t"))
@@ -121,18 +125,18 @@ class Stryker4sSbtRunner(
       }
 
       compilerErrors.toLeft {
-        val classpath = PluginCompat.toNioPaths(extractTaskValue(Test / fullClasspath))
+        val classpath = PluginCompat.toNioPaths(extractTaskValue(targetProject / Test / fullClasspath))
 
-        val javaOpts = extractTaskValue(Test / javaOptions)
+        val javaOpts = extractTaskValue(targetProject / Test / javaOptions)
 
-        val frameworks = extractTaskValue(Test / loadedTestFrameworks).values.toSeq
+        val frameworks = extractTaskValue(targetProject / Test / loadedTestFrameworks).values.toSeq
         if (frameworks.isEmpty)
           log.warn(
             "No test frameworks found via loadedTestFrameworks. " +
               "Will likely result in no tests being run and a NoCoverage result for all mutants."
           )
 
-        val testGroups = extractTaskValue(Test / testGrouping).map { group =>
+        val testGroups = extractTaskValue(targetProject / Test / testGrouping).map { group =>
           if (config.testFilter.isEmpty) group
           else {
             val testFilter = new TestFilter()
@@ -171,8 +175,12 @@ class Stryker4sSbtRunner(
         "unused:explicits"
         // -Ywarn for Scala 2.12, -W for Scala 2.13
       ).flatMap(opt => Seq(s"-Ywarn-$opt", s"-W$opt")) ++ Seq(
-        // Disable fatal warnings, as they will cause a lot of mutation switching statements to not compile
-        "-Xfatal-warnings"
+        // Disable fatal warnings, as they will cause a lot of mutation switching statements to not compile.
+        // -Xfatal-warnings is the Scala 2.x flag; -Werror is the Scala 3 / tpolecat 0.5.3+ replacement
+        // and must also be stripped — otherwise warnings the mutation-switching pattern triggers
+        // (e.g. non-exhaustive match on the synthetic Some("n") cases) propagate as errors.
+        "-Xfatal-warnings",
+        "-Werror"
       )
 
       val filteredSystemProperties: Seq[String] = {
@@ -185,15 +193,18 @@ class Stryker4sSbtRunner(
       }
       log.debug(s"System properties added to the forked JVM: ${filteredSystemProperties.mkString(",")}")
 
+      // All settings are scoped to targetProject so that appendWithSession changes only affect the
+      // subproject the user invoked stryker on, not every project in the build (in particular not the
+      // auto-generated root, against which our task queries previously resolved).
       val settings: Seq[Def.Setting[?]] = Seq(
-        scalacOptions --= blocklistedScalacOptions,
-        Test / fork := true,
-        Compile / unmanagedSourceDirectories ~= (_.map(tmpDirFor(_, tmpDir))),
-        Test / javaOptions ++= filteredSystemProperties
+        targetProject / scalacOptions --= blocklistedScalacOptions,
+        targetProject / Test / fork := true,
+        targetProject / Compile / unmanagedSourceDirectories ~= (_.map(tmpDirFor(_, tmpDir))),
+        targetProject / Test / javaOptions ++= filteredSystemProperties
       ) ++ {
         if (config.testFilter.nonEmpty) {
           val testFilter = new TestFilter()
-          Seq(Test / testOptions := Seq(Tests.Filter(testFilter.filter)))
+          Seq(targetProject / Test / testOptions := Seq(Tests.Filter(testFilter.filter)))
         } else
           Nil
       }

--- a/modules/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
+++ b/modules/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
@@ -99,32 +99,30 @@ class Stryker4sSbtRunner(
         }
       }
 
-      // See if the mutations compile, and if not extract the errors.
-      // Scoped to targetProject so `sbt sub/stryker` compiles the subproject's sources, not the
-      // (auto-generated) root project's. See also extractTaskValue calls below.
-      val compilerErrors = PluginCompat.runTask(targetProject / Compile / compile, newState) match {
-        case Some(Left(cause)) =>
-          val rootCauses = getRootCause(cause)
-          rootCauses.foreach(t => log.debug(s"Compile failed with ${t.getClass().getName()} root cause: $t"))
-          val compileErrors = rootCauses
-            .collect { case e: xsbti.CompileFailed => e }
-            .flatMap { exception =>
-              exception.problems.flatMap { e =>
-                for {
-                  path <- e.position().sourceFile().asScala
-                  pathStr = Path.fromNioPath(path.toPath()).relativePath(tmpDir).toString
-                  line <- e.position().line().asScala
-                } yield CompilerErrMsg(e.message(), pathStr, line)
+      def attemptCompileAndCollectErrors(): Option[NonEmptyList[CompilerErrMsg]] =
+        PluginCompat.runTask(targetProject / Compile / compile, newState) match {
+          case Some(Left(cause)) =>
+            val rootCauses = getRootCause(cause)
+            rootCauses.foreach(t => log.debug(s"Compile failed with ${t.getClass().getName()} root cause: $t"))
+            val compileErrors = rootCauses
+              .collect { case e: xsbti.CompileFailed => e }
+              .flatMap { exception =>
+                exception.problems.flatMap { e =>
+                  for {
+                    path <- e.position().sourceFile().asScala
+                    pathStr = Path.fromNioPath(path.toPath()).relativePath(tmpDir).toString
+                    line <- e.position().line().asScala
+                  } yield CompilerErrMsg(e.message(), pathStr, line)
+                }
               }
-            }
-            .toList
+              .toList
 
-          NonEmptyList.fromList(compileErrors)
-        case _ =>
-          None
-      }
+            NonEmptyList.fromList(compileErrors)
+          case _ =>
+            None
+        }
 
-      compilerErrors.toLeft {
+      attemptCompileAndCollectErrors().toLeft {
         val classpath = PluginCompat.toNioPaths(extractTaskValue(targetProject / Test / fullClasspath))
 
         val javaOpts = extractTaskValue(targetProject / Test / javaOptions)
@@ -165,7 +163,7 @@ class Stryker4sSbtRunner(
       }
     }
 
-    def extractSbtProject(tmpDir: Path)(implicit config: Config) = {
+    def targetProjectSessionOverrides(tmpDir: Path)(implicit config: Config): Seq[Def.Setting[?]] = {
       // Remove scalacOptions that are very likely to cause errors with generated code
       // https://github.com/stryker-mutator/stryker4s/issues/321
       val blocklistedScalacOptions = Seq(
@@ -175,12 +173,8 @@ class Stryker4sSbtRunner(
         "unused:explicits"
         // -Ywarn for Scala 2.12, -W for Scala 2.13
       ).flatMap(opt => Seq(s"-Ywarn-$opt", s"-W$opt")) ++ Seq(
-        // Disable fatal warnings, as they will cause a lot of mutation switching statements to not compile.
-        // -Xfatal-warnings is the Scala 2.x flag; -Werror is the Scala 3 / tpolecat 0.5.3+ replacement
-        // and must also be stripped — otherwise warnings the mutation-switching pattern triggers
-        // (e.g. non-exhaustive match on the synthetic Some("n") cases) propagate as errors.
-        "-Xfatal-warnings",
-        "-Werror"
+        // Disable fatal warnings, as they will cause a lot of mutation switching statements to not compile
+        "-Xfatal-warnings"
       )
 
       val filteredSystemProperties: Seq[String] = {
@@ -193,10 +187,7 @@ class Stryker4sSbtRunner(
       }
       log.debug(s"System properties added to the forked JVM: ${filteredSystemProperties.mkString(",")}")
 
-      // All settings are scoped to targetProject so that appendWithSession changes only affect the
-      // subproject the user invoked stryker on, not every project in the build (in particular not the
-      // auto-generated root, against which our task queries previously resolved).
-      val settings: Seq[Def.Setting[?]] = Seq(
+      Seq(
         targetProject / scalacOptions --= blocklistedScalacOptions,
         targetProject / Test / fork := true,
         targetProject / Compile / unmanagedSourceDirectories ~= (_.map(tmpDirFor(_, tmpDir))),
@@ -208,20 +199,19 @@ class Stryker4sSbtRunner(
         } else
           Nil
       }
-
-      (settings, Project.extract(state))
     }
 
     def tmpDirFor(source: File, tmpDir: Path): JFile =
       Path.fromNioPath(source.toPath()).inSubDir(tmpDir).toNioPath.toFile().getAbsoluteFile()
 
-    val (settings, extracted) = extractSbtProject(tmpDir)
+    val sessionOverrides = targetProjectSessionOverrides(tmpDir)
+    val extracted = Project.extract(state)
 
     if (config.legacyTestRunner) {
       // No compiler error handling in the legacy runner
-      setupLegacySbtTestRunner(settings, extracted).asRight
+      setupLegacySbtTestRunner(sessionOverrides, extracted).asRight
     } else
-      setupSbtTestRunner(settings, extracted)
+      setupSbtTestRunner(sessionOverrides, extracted)
   }
 
   override def instrumenterOptions(implicit config: Config): InstrumenterOptions =

--- a/modules/sbt/src/main/scala/stryker4s/sbt/runner/LegacySbtTestRunner.scala
+++ b/modules/sbt/src/main/scala/stryker4s/sbt/runner/LegacySbtTestRunner.scala
@@ -12,7 +12,12 @@ import stryker4s.run.TestRunner
 import stryker4s.sbt.PluginCompat
 import stryker4s.testrunner.api.TestFile
 
-class LegacySbtTestRunner(initialState: State, settings: Seq[Def.Setting[?]], extracted: Extracted)(implicit
+class LegacySbtTestRunner(
+    initialState: State,
+    settings: Seq[Def.Setting[?]],
+    extracted: Extracted,
+    targetProject: ProjectRef
+)(implicit
     log: Logger
 ) extends TestRunner {
   def initialTestRun(): IO[InitialTestRunResult] = runTests(
@@ -39,7 +44,7 @@ class LegacySbtTestRunner(initialState: State, settings: Seq[Def.Setting[?]], ex
   }
 
   private def runTests[T](state: State, onError: => T, onSuccess: => T, onFailed: => T): IO[T] =
-    IO(PluginCompat.runTask(Test / executeTests, state)) map {
+    IO(PluginCompat.runTask(targetProject / Test / executeTests, state)) map {
       case Some(Right(output)) if output.overall == TestResult.Passed => onSuccess
       case Some(Right(output)) if output.overall == TestResult.Failed => onFailed
       case Some(Right(output)) if output.overall == TestResult.Error  => onFailed
@@ -47,5 +52,5 @@ class LegacySbtTestRunner(initialState: State, settings: Seq[Def.Setting[?]], ex
     }
 
   private def mutationSetting(mutation: Int): Def.Setting[?] =
-    Test / javaOptions += s"-DACTIVE_MUTATION=${mutation.toString()}"
+    targetProject / Test / javaOptions += s"-DACTIVE_MUTATION=${mutation.toString()}"
 }

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-subproject/README.md
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-subproject/README.md
@@ -1,0 +1,14 @@
+# SBT plugin test project — subproject layout
+
+Regression test for the case where the project being mutated lives in a
+subdirectory (`file("app")`) rather than at the build root. The bug:
+`sbt-stryker4s` queried `Test / loadedTestFrameworks`, `Test / fullClasspath`,
+`Compile / compile`, etc. without scoping them to the calling project, so
+`sbt app/stryker` resolved them against the auto-generated root project
+(which has no test framework) → empty frameworks → silent 0% mutation
+score.
+
+The fix: pass `thisProjectRef` from the task macro into `Stryker4sSbtRunner`
+and scope every task query / appended setting to it. If the fix regresses,
+the threshold break in `app/stryker4s.conf` trips and this scripted test
+fails.

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-subproject/README.md
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-subproject/README.md
@@ -10,5 +10,5 @@ score.
 
 The fix: pass `thisProjectRef` from the task macro into `Stryker4sSbtRunner`
 and scope every task query / appended setting to it. If the fix regresses,
-the threshold break in `app/stryker4s.conf` trips and this scripted test
-fails.
+the `strykerThresholdsBreak` set in `build.sbt` trips and this scripted
+test fails.

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-subproject/app/src/main/scala/example/Calculator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-subproject/app/src/main/scala/example/Calculator.scala
@@ -1,0 +1,6 @@
+package example
+
+object Calculator {
+  def add(a: Int, b: Int): Int = a + b
+  def isPositive(n: Int): Boolean = n > 0
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-subproject/app/src/test/scala/example/CalculatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-subproject/app/src/test/scala/example/CalculatorTest.scala
@@ -1,0 +1,14 @@
+package example
+
+class CalculatorTest extends munit.FunSuite {
+  test("add sums two numbers") {
+    assertEquals(Calculator.add(2, 3), 5)
+    assertEquals(Calculator.add(-1, 1), 0)
+  }
+
+  test("isPositive distinguishes positive from non-positive") {
+    assert(Calculator.isPositive(1))
+    assert(!Calculator.isPositive(0))
+    assert(!Calculator.isPositive(-1))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-subproject/app/stryker4s.conf
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-subproject/app/stryker4s.conf
@@ -1,3 +1,0 @@
-stryker4s {
-  reporters: ["console"]
-}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-subproject/app/stryker4s.conf
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-subproject/app/stryker4s.conf
@@ -1,0 +1,3 @@
+stryker4s {
+  reporters: ["console"]
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-subproject/build.sbt
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-subproject/build.sbt
@@ -1,11 +1,3 @@
-// The whole point of this scripted test: the project to be mutated is in `file("app")`,
-// not at the build root. With the pre-fix plugin, `sbt app/stryker` resolved task queries
-// against the auto-generated root (no test framework) → 0% mutation score.
-
-// Scala 3 LTS so we can exercise the -Werror stripping path: -Werror is what
-// tpolecat 0.5.3+ emits for Scala 3 (replacing the legacy -Xfatal-warnings).
-// This is also the path the original bug surfaced on (Scala 3.8.3 in a real-world
-// build, binary-compatible with 3.3.x).
 ThisBuild / scalaVersion := "3.3.7"
 
 lazy val app = (project in file("app"))
@@ -13,15 +5,5 @@ lazy val app = (project in file("app"))
     libraryDependencies += "org.scalameta" %% "munit" % "1.3.0" % Test,
     strykerDebugLogTestRunnerStdout := true,
     stryker / logLevel := Level.Debug,
-    // Set thresholds via sbt settings rather than stryker4s.conf so they apply in both
-    // sbt 1.x and sbt 2.x scripted runs (the file-based config didn't get picked up under
-    // sbt 2 in this layout). The break threshold is the actual regression guard: if the
-    // subproject-scoping bug returns, the score collapses to 0% and `app/stryker` fails.
-    strykerThresholdsBreak := 50,
-    // Exercises the fatal-warning stripping path: without it, warnings the synthetic
-    // `case Some("1") => ...` mutation-switching pattern emits (e.g. non-exhaustive match)
-    // would be promoted to errors → compilation fails → all mutants get rolled back → 0%.
-    // Both flags appear in real-world builds (tpolecat 0.5.3+ emits -Werror for Scala 3;
-    // -Xfatal-warnings is the legacy 2.x flag) so the test pins both.
-    scalacOptions ++= Seq("-Werror", "-Xfatal-warnings")
+    strykerThresholdsBreak := 50
   )

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-subproject/build.sbt
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-subproject/build.sbt
@@ -1,0 +1,27 @@
+// The whole point of this scripted test: the project to be mutated is in `file("app")`,
+// not at the build root. With the pre-fix plugin, `sbt app/stryker` resolved task queries
+// against the auto-generated root (no test framework) → 0% mutation score.
+
+// Scala 3 LTS so we can exercise the -Werror stripping path: -Werror is what
+// tpolecat 0.5.3+ emits for Scala 3 (replacing the legacy -Xfatal-warnings).
+// This is also the path the original bug surfaced on (Scala 3.8.3 in a real-world
+// build, binary-compatible with 3.3.x).
+ThisBuild / scalaVersion := "3.3.7"
+
+lazy val app = (project in file("app"))
+  .settings(
+    libraryDependencies += "org.scalameta" %% "munit" % "1.3.0" % Test,
+    strykerDebugLogTestRunnerStdout := true,
+    stryker / logLevel := Level.Debug,
+    // Set thresholds via sbt settings rather than stryker4s.conf so they apply in both
+    // sbt 1.x and sbt 2.x scripted runs (the file-based config didn't get picked up under
+    // sbt 2 in this layout). The break threshold is the actual regression guard: if the
+    // subproject-scoping bug returns, the score collapses to 0% and `app/stryker` fails.
+    strykerThresholdsBreak := 50,
+    // Exercises the fatal-warning stripping path: without it, warnings the synthetic
+    // `case Some("1") => ...` mutation-switching pattern emits (e.g. non-exhaustive match)
+    // would be promoted to errors → compilation fails → all mutants get rolled back → 0%.
+    // Both flags appear in real-world builds (tpolecat 0.5.3+ emits -Werror for Scala 3;
+    // -Xfatal-warnings is the legacy 2.x flag) so the test pins both.
+    scalacOptions ++= Seq("-Werror", "-Xfatal-warnings")
+  )

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-subproject/project/plugins.sbt
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-subproject/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("io.stryker-mutator" % "sbt-stryker4s" % x)
+  case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                               |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-subproject/test
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-subproject/test
@@ -1,0 +1,1 @@
+> app/stryker


### PR DESCRIPTION
### Related: #646, #1417, #1424

Same silent-0% failure mode previously reported in #646 (sbt-crossproject) and #1417 (UX of the bad result). #1424 added the *warning* that fires when this happens; this PR addresses the underlying cause.

#### What it does

Makes `sbt sub/stryker` actually work when the project being mutated lives in a subdirectory (`lazy val app = (project in file("app"))`) rather than at the build root. With the current 0.20.x plugin, that layout silently produces a 0% mutation score: the mutator runs, mutants are generated, "Initial test run succeeded" prints — but every mutant survives because no tests actually execute. Reproduces on a 12-line bare repro on Scala 3 and Scala 2.13; only difference vs. the working case is `(project in file("subdir"))` vs. an implicit root.

Also fixes a second, smaller issue uncovered while validating the first: `blocklistedScalacOptions` only strips `-Xfatal-warnings`, not the newer `-Werror`. Any project that opts into strict warnings (default for tpolecat 0.5.3+ on Scala 3) hits a compile failure during mutation switching whose root cause is a normal warning (e.g. non-exhaustive `match` over the synthetic `Some(\"1\") | Some(\"2\") | _` cases) being promoted to an error.

#### How it works

**Issue 1 — task scope.** `Stryker4sSbtRunner.setupSbtTestRunner` queried `Test / loadedTestFrameworks`, `Test / fullClasspath`, `Compile / compile`, `Test / testGrouping` (and `Test / executeTests` in the legacy runner) without a project scope. `PluginCompat.runTask` then resolved them against the State's current ref — which, for \`sub/stryker\`, is the auto-generated root, not the subproject. The root has no test frameworks and an empty test classpath, so the empty-framework warning added in #1424 fired and the run silently produced 0%.

The settings appended via \`extracted.appendWithSession\` (scalacOptions, Test/fork, Compile/unmanagedSourceDirectories, Test/javaOptions, Test/testOptions, libraryDependencies, resolvers, logManager, and the ACTIVE_MUTATION javaOption) had the same problem at a quieter scope — they applied build-globally rather than to the subproject.

Fix: capture \`thisProjectRef\` at the task macro site in \`Stryker4sPlugin.strykerTask\` (where it correctly resolves to the calling subproject) and thread it through \`Stryker4sSbtRunner\` and \`LegacySbtTestRunner\`. Every task query and every appended setting is now \`targetProject / ...\`-scoped.

**Issue 2 — \`-Werror\`.** One-line addition to the existing strip list.

#### Test plan

- New scripted test \`test-subproject\` defines a project in \`file(\"app\")\`, Scala 3 LTS (3.3.7, binary-compatible with the 3.8.x where the issue first surfaced), \`scalacOptions ++= Seq(\"-Werror\", \"-Xfatal-warnings\")\`, and a 50% break threshold. Invokes \`> app/stryker\`. If either fix regresses (scope or \`-Werror\` strip), the score collapses to 0% and the scripted test fails.
- CI now publishes \`sbtTestRunner3\` alongside \`sbtTestRunner2_12\` so the Scala 3 test classpath resolves.
- Verified locally on both \`sbtPlugin/scripted\` (sbt 1 / Scala 2.12 plugin) and \`sbtPlugin3/scripted\` (sbt 2 / Scala 3 plugin): test-subproject 100% (3/3 killed); existing test-1 unchanged at 88.89%.

No new dependencies, no API changes beyond an internal constructor parameter on two non-public runner classes, no behaviour change for builds already using a single root project.