### PR TITLE
fix(sbt): strip -Werror alongside -Xfatal-warnings

### DIFF
--- a/modules/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
+++ b/modules/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
@@ -172,7 +172,8 @@ class Stryker4sSbtRunner(
         // -Ywarn for Scala 2.12, -W for Scala 2.13
       ).flatMap(opt => Seq(s"-Ywarn-$opt", s"-W$opt")) ++ Seq(
         // Disable fatal warnings, as they will cause a lot of mutation switching statements to not compile
-        "-Xfatal-warnings"
+        "-Xfatal-warnings",
+        "-Werror"
       )
 
       val filteredSystemProperties: Seq[String] = {


### PR DESCRIPTION
Scala 3 / tpolecat 0.5.3+ counterpart of `-Xfatal-warnings` (#321) — same failure mode, same fix.