### PR TITLE
fix(sbt): read test-runner responses on demand to avoid teardown race (#1861)

### DIFF
--- a/modules/sbt/src/main/scala/stryker4s/sbt/runner/TestRunnerConnection.scala
+++ b/modules/sbt/src/main/scala/stryker4s/sbt/runner/TestRunnerConnection.scala
@@ -2,23 +2,22 @@ package stryker4s.sbt.runner
 
 import cats.effect.{IO, Resource}
 import com.comcast.ip4s.{GenSocketAddress, UnixSocketAddress}
-import com.google.protobuf.CodedOutputStream
+import com.google.protobuf.{CodedInputStream, CodedOutputStream}
+import fs2.Chunk
 import fs2.io.file.{Files, Path}
 import fs2.io.net.{Network, Socket}
-import fs2.io.{readOutputStream, toInputStreamResource}
+import fs2.io.readOutputStream
 import scalapb.LiteParser
 import stryker4s.log.Logger
 import stryker4s.testrunner.api.{Request, RequestMessage, Response, ResponseMessage}
 
-import java.io.InputStream
 import java.net.SocketException
 
 sealed trait TestRunnerConnection {
   def sendMessage(request: Request): IO[Response]
 }
 
-final class SocketTestRunnerConnection private (socket: Socket[IO], input: InputStream)(implicit log: Logger)
-    extends TestRunnerConnection {
+final class SocketTestRunnerConnection private (socket: Socket[IO])(implicit log: Logger) extends TestRunnerConnection {
 
   override def sendMessage(request: Request): IO[Response] =
     (write(request.asMessage) *> read)
@@ -30,10 +29,28 @@ final class SocketTestRunnerConnection private (socket: Socket[IO], input: Input
       .compile
       .drain
 
-  def read: IO[Response] = IO.interruptible(ResponseMessage.parseDelimitedFrom(input)).flatMap {
-    case Some(responseMsg) => IO.pure(responseMsg.toResponse)
-    case None              => IO.raiseError(new RuntimeException("Failed to parse ResponseMessage from input stream"))
+  def read: IO[Response] =
+    readVarint32
+      .flatMap(readExactly)
+      .map(bytes => ResponseMessage.parseFrom(bytes.toArray).toResponse)
+
+  private def readVarint32: IO[Int] = {
+    def readWhileContinuationBitSet(readSoFar: Chunk[Byte]): IO[Chunk[Byte]] =
+      readByte.flatMap { byte =>
+        val read = readSoFar ++ Chunk(byte)
+        if ((byte & 0x80) != 0) readWhileContinuationBitSet(read) else IO.pure(read)
+      }
+
+    readWhileContinuationBitSet(Chunk.empty).map(bytes => CodedInputStream.newInstance(bytes.toArray).readRawVarint32())
   }
+
+  private def readByte: IO[Byte] = readExactly(1).map(_(0))
+
+  private def readExactly(numBytes: Int): IO[Chunk[Byte]] =
+    socket.readN(numBytes).flatMap { chunk =>
+      if (chunk.size == numBytes) IO.pure(chunk)
+      else IO.raiseError(new SocketException("Test-runner closed the connection while reading a message"))
+    }
 
   /** Copied from RequestMessage#writeDelimitedTo
     */
@@ -58,7 +75,6 @@ object SocketTestRunnerConnection {
       case _ => Resource.unit[IO]
     }
     socket <- Network[IO].connect(socketAddress)
-    input <- toInputStreamResource(socket.reads)
-  } yield new SocketTestRunnerConnection(socket, input)
+  } yield new SocketTestRunnerConnection(socket)
 
 }


### PR DESCRIPTION
Fixes #1861.

## Problem
At the end of a run, `java.nio.channels.AsynchronousCloseException` is printed to
stderr (#1861). The run itself succeeds — it is pure teardown noise. So far it has
only been observed on Java 21+ and with ≥2 truly-parallel cores; it does not
reproduce under `-XX:ActiveProcessorCount=1`. (The call for reproductions was
already raised in the issue.)

## Root cause
The sbt connection wraps the socket in `toInputStreamResource(socket.reads)`, whose
background fiber stays parked in a blocking `ch.read`. fs2's unix-socket `readChunk`
is `F.blocking(ch.read(buff)).cancelable(close)`. On teardown the `toInputStream`
finalizer cancels that parked read, and `.cancelable(close)` closes the channel from
another thread while `ch.read` is still parked → `AsynchronousCloseException`. The
fiber is already cancelled, so the exception is reported as a lost failure on stderr.

## Fix
The protocol is strictly request→response, so a persistently-blocked reader is not
needed. Read each response on demand: the varint length delimiter byte by byte, then
the body — mirroring the test-runner server side. With no read in flight at teardown,
closing the channel races nothing. Net code removed (`toInputStreamResource` /
`InputStream` / `IO.interruptible` / `Dispatcher`).

One file: `modules/sbt/src/main/scala/stryker4s/sbt/runner/TestRunnerConnection.scala`.

## Validation
The bug is **non-deterministic**. Running `sbt 'set strykerConcurrency := 12' stryker`
K=10 times on Java 21 / multi-core and counting `AsynchronousCloseException`:

| | runs reproduced | total occurrences |
|---|---|---|
| baseline `0.20.4` | 10/10 | 39 |
| this fix | 0/10 | 0 |

Fix runs completed full mutation testing (18 mutants, 9 detected — identical to
baseline). Box: 16-core / 25 GB / JDK 21.0.8 / Linux.

## On testing
This is a non-deterministic, environment-gated teardown side-effect, and the run
exits 0 — so the existing sbt scripted tests (success checks) cannot reliably catch
it, and a deterministic regression test for the race isn't feasible. I propose
documenting it as such rather than adding a flaky CI assertion. Happy to add a
deterministic unit test covering the new on-demand `read` decoding (protocol
correctness, not the race) if you'd like.

---
Driven by Claude Opus 4.8 (1M context) in a pair-programming setup; I navigated the
root-cause analysis, design, and validation.
