### PR TITLE
feat(logging): add more detailed logging for mutant runner and console reporter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val root = (project withId "stryker4s" in file("."))
     // Publish locally for sbt plugin testing
     addCommandAlias(
       "publishPluginLocal",
-      "set ThisBuild / version := \"0.0.0-TEST-SNAPSHOT\"; sbtPlugin/publishLocal; sbtTestRunner/publishLocal;"
+      "set ThisBuild / version := \"0.0.0-TEST-SNAPSHOT\"; sbtPlugin/publishLocal; sbtTestRunner/publishLocal; sbtTestRunner3/publishLocal"
     ),
     // Publish to .m2 folder for Maven plugin testing
     addCommandAlias(

--- a/modules/core/src/main/scala/stryker4s/mutants/Mutator.scala
+++ b/modules/core/src/main/scala/stryker4s/mutants/Mutator.scala
@@ -45,7 +45,7 @@ class Mutator(
       .flatMap { case (ctx, (ignored, found)) => splitIgnoredAndFound(ctx, ignored, found) }
       // Instrument files
       .parEvalMapUnordered(config.concurrency)(_.traverse { case (context, mutations) =>
-        IO(log.debug(s"Instrumenting mutations in ${mutations.size} places in ${context.path}")) *>
+        IO(log.debug(s"Instrumenting mutations in ${mutations.size} places for ${context.path}")) *>
           IO(instrumenter.instrumentFile(context, mutations))
       })
       // Fold into 2 separate lists of ignored and found mutants (in files)
@@ -119,8 +119,8 @@ class Mutator(
           IO(log.warn(s"All found mutations are excluded. ${dryRunText("mutate", "excluded-mutations")}"))
         else
           IO.whenA(totalMutants == 0) {
-            IO(log.info("Files to be mutated are found, but no mutations were found in those files.")) *>
-              IO(log.info("If this is not intended, please check your configuration and try again."))
+            IO(log.warn("Files to be mutated are found, but no mutations were found in those files.")) *>
+              IO(log.warn("If this is not intended, please check your configuration and try again."))
           }
       }
   }

--- a/modules/core/src/main/scala/stryker4s/report/ConsoleReporter.scala
+++ b/modules/core/src/main/scala/stryker4s/report/ConsoleReporter.scala
@@ -72,16 +72,32 @@ class ConsoleReporter()(implicit config: Config, log: Logger) extends Reporter {
       }
 
       scoreStatus match {
-        case _ if metrics.mutationScore.isNaN() => log.info(scoreString)
-        case SuccessStatus                      => log.info(scoreString)
-        case WarningStatus                      => log.warn(scoreString)
-        case DangerStatus                       =>
-          log.error(s"Mutation score dangerously low!")
+        case _ if metrics.mutationScore.isNaN() =>
+          log.info(scoreString)
+          log.warn(
+            "It looks like no mutations were actually tested. This could indicate that the test runner is not set up correctly, or that all mutants are excluded from coverage."
+          )
+          log.warn(
+            "You can enable 'log-test-runner-stdout' in your configuration to see test runner output. See https://stryker-mutator.io/docs/stryker4s/configuration/ for more information."
+          )
+        case SuccessStatus => log.info(scoreString)
+        case WarningStatus => log.warn(scoreString)
+        case DangerStatus  =>
+          log.error(s"Mutation score dangerously low! Below the low threshold of ${config.thresholds.low}%")
           log.error(scoreString)
         case ErrorStatus =>
           log.error(
             s"Mutation score below threshold! $scoreString. Threshold: ${config.thresholds.break}%"
           )
+      }
+
+      if (metrics.totalDetected == 0 && metrics.totalUndetected > 0) {
+        log.warn(
+          "None of the mutations were detected. This may indicate that your tests are not running, or that the test assertions are too weak to catch mutations."
+        )
+        log.warn(
+          "You can enable 'log-test-runner-stdout' in your configuration to see test runner output. See https://stryker-mutator.io/docs/stryker4s/configuration/ for more information."
+        )
       }
     }
 

--- a/modules/core/src/main/scala/stryker4s/run/MutantRunner.scala
+++ b/modules/core/src/main/scala/stryker4s/run/MutantRunner.scala
@@ -9,6 +9,7 @@ import fs2.{Pipe, Stream}
 import mutationtesting.{MutantResult, MutantStatus, TestDefinition, TestFile, TestFileDefinitionDictionary}
 import stryker4s.config.Config
 import stryker4s.exception.{InitialTestRunFailedException, UnableToFixCompilerErrorsException}
+import stryker4s.extension.DurationExtensions.*
 import stryker4s.extension.FileExtensions.*
 import stryker4s.files.FileResolver
 import stryker4s.log.Logger
@@ -115,7 +116,7 @@ class MutantRunner(
   }
 
   private def setupFiles(tmpDir: Path, mutatedFiles: Seq[MutatedFile]): IO[Unit] =
-    IO(log.info("Setting up mutated environment...")) *>
+    IO(log.info(s"Setting up environment for ${mutatedFiles.size} mutated file(s)...")) *>
       IO(log.debug("Using temp directory: " + tmpDir)) *> {
         val mutatedPaths = mutatedFiles.map(_.fileOrigin)
         val unmutatedFilesStream =
@@ -170,11 +171,19 @@ class MutantRunner(
             .Magenta("NoCoverage")}"
       )
       log.debug(s"NoCoverage mutant ids are: ${noCoverageMutants.map(_._2.id).mkString(", ")}")
+      if (testableMutants.isEmpty && staticMutants.isEmpty) {
+        log.warn(
+          "All mutants have no code coverage and will not be tested. This typically means that the test runner did not collect any coverage information."
+        )
+        log.warn(
+          "You can enable 'log-test-runner-stdout' in your configuration to see test runner output and diagnose the issue. See https://stryker-mutator.io/docs/stryker4s/configuration/ for more information."
+        )
+      }
     }
 
     if (staticMutants.nonEmpty) {
       log.info(
-        s"${staticMutants.size} mutants detected as static. They will be skipped and marked as Ignored"
+        s"${staticMutants.size} mutant(s) detected as static. They will be skipped and marked as ${Color.Magenta("Ignored")}"
       )
       log.debug(s"Static mutant ids are: ${staticMutants.map(_._2.id).mkString(", ")}")
     }
@@ -194,7 +203,9 @@ class MutantRunner(
       .through(testRunnerPool.run { case (testRunner, (path, mutant)) =>
         val coverageForMutant = coverageExclusions.coveredMutants.getOrElse(mutant.id, Seq.empty)
         IO(log.debug(s"Running mutant $mutant")) *>
-          testRunner.runMutant(mutant, coverageForMutant).tupleLeft(path)
+          testRunner.runMutant(mutant, coverageForMutant).timed.flatMap { case (duration, result) =>
+            IO(log.debug(s"Mutant ${mutant.id} tested in ${duration.toHumanReadable}")).as(path -> result)
+          }
       })
       .observe(in => in.as(MutantTestedEvent(totalTestableMutants)).through(reporter.mutantTested))
 

--- a/modules/core/src/main/scala/stryker4s/run/TestRunner.scala
+++ b/modules/core/src/main/scala/stryker4s/run/TestRunner.scala
@@ -38,7 +38,7 @@ object TestRunner {
                 .runMutant(mutant, testNames)
                 .timeoutTo(
                   time,
-                  IO(log.debug(s"Mutant ${mutant.id} timed out over ${time.toHumanReadable}")) *>
+                  IO(log.debug(s"Mutant ${mutant.id} timed out after ${time.toHumanReadable}")) *>
                     releaseAndSwap
                       .as(
                         mutant.toMutantResult(
@@ -117,7 +117,7 @@ object TestRunner {
             _ <-
               // If the limit has been reached, create a new testrunner
               IO.whenA(uses == maxReuses) {
-                IO(log.info(s"Testrunner has run for $uses times. Restarting it...")) *>
+                IO(log.info(s"Testrunner has run for $uses/$maxReuses times. Restarting it...")) *>
                   releaseAndSwap *>
                   usesRef.set(1)
               }

--- a/modules/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
+++ b/modules/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
@@ -83,7 +83,9 @@ class MutatorTest extends Stryker4sIOSuite with LogMatchers {
       )
       val files = Stream(FileUtil.getResource("scalaFiles/simpleFile.scala"))
 
-      sut.go(files).asserting { _ =>
+      sut.go(files).asserting { files =>
+        val fileOrigin = files._2.loneElement.fileOrigin
+        assertLoggedDebug(s"Instrumenting mutations in 2 places for $fileOrigin")
         assertLoggedInfo(s"Found ${Cyan("1")} file(s) to be mutated.")
         assertNotLoggedInfo(s"Found ${Cyan("1")} file(s) to be mutated. Of which")
         assertLoggedInfo(s"${Cyan("4")} mutant(s) generated")
@@ -102,8 +104,8 @@ class MutatorTest extends Stryker4sIOSuite with LogMatchers {
       sut.go(files).asserting { _ =>
         assertLoggedInfo(s"Found ${Cyan("1")} file(s) to be mutated.")
         assertLoggedInfo(s"${Cyan("4")} mutant(s) generated. Of which ${LightRed("3")} mutant(s) are excluded.")
-        assertNotLoggedInfo("Files to be mutated are found, but no mutations were found in those files.")
-        assertNotLoggedInfo("If this is not intended, please check your configuration and try again.")
+        assertNotLoggedWarn("Files to be mutated are found, but no mutations were found in those files.")
+        assertNotLoggedWarn("If this is not intended, please check your configuration and try again.")
       }
     }
 
@@ -119,8 +121,8 @@ class MutatorTest extends Stryker4sIOSuite with LogMatchers {
       sut.go(files).asserting { _ =>
         assertLoggedInfo(s"Found ${Cyan("1")} file(s) to be mutated.")
         assertLoggedInfo(s"${Cyan("0")} mutant(s) generated.")
-        assertLoggedInfo("Files to be mutated are found, but no mutations were found in those files.")
-        assertLoggedInfo("If this is not intended, please check your configuration and try again.")
+        assertLoggedWarn("Files to be mutated are found, but no mutations were found in those files.")
+        assertLoggedWarn("If this is not intended, please check your configuration and try again.")
       }
     }
 
@@ -142,8 +144,8 @@ class MutatorTest extends Stryker4sIOSuite with LogMatchers {
           s"""All found mutations are excluded. Stryker4s will perform a dry-run without actually mutating anything.
              |You can configure the `mutate` or `excluded-mutations` property in your configuration""".stripMargin
         )
-        assertNotLoggedInfo("Files to be mutated are found, but no mutations were found in those files.")
-        assertNotLoggedInfo("If this is not intended, please check your configuration and try again.")
+        assertNotLoggedWarn("Files to be mutated are found, but no mutations were found in those files.")
+        assertNotLoggedWarn("If this is not intended, please check your configuration and try again.")
       }
     }
   }

--- a/modules/core/src/test/scala/stryker4s/report/ConsoleReporterTest.scala
+++ b/modules/core/src/test/scala/stryker4s/report/ConsoleReporterTest.scala
@@ -333,7 +333,7 @@ class ConsoleReporterTest extends Stryker4sIOSuite with LogMatchers {
       sut
         .onRunFinished(FinishedRunEvent(report, metrics, 15.seconds, config.baseDir))
         .asserting { _ =>
-          assertLoggedError("Mutation score dangerously low!")
+          assertLoggedError("Mutation score dangerously low! Below the low threshold of 51%")
           assertLoggedError(s"Mutation score: ${Red("50.0")}%")
         }
     }
@@ -359,6 +359,65 @@ class ConsoleReporterTest extends Stryker4sIOSuite with LogMatchers {
         .onRunFinished(FinishedRunEvent(reportWithNoCoverage, metricsWithNoCoverage, 15.seconds, config.baseDir))
         .asserting { _ =>
           assertLoggedWarn(s"Mutation score: ${Yellow("33.33")}% (of total), ${Green("50.0")}% (of covered code)")
+        }
+    }
+
+    test("should warn when mutation score is n/a") {
+      implicit val config: Config = Config.default
+      val sut = new ConsoleReporter()
+      val allIgnoredReport = MutationTestResult(
+        thresholds = Thresholds(80, 60),
+        files = Map(
+          "stryker4s.scala" -> FileResult(
+            source = "foo",
+            mutants = Seq(
+              MutantResult("0", "", ">", Location(Position(1, 1), Position(1, 2)), MutantStatus.Ignored)
+            )
+          )
+        )
+      )
+
+      sut
+        .onRunFinished(
+          FinishedRunEvent(allIgnoredReport, Metrics.calculateMetrics(allIgnoredReport), 15.seconds, config.baseDir)
+        )
+        .asserting { _ =>
+          assertLoggedWarn(
+            "It looks like no mutations were actually tested. This could indicate that the test runner is not set up correctly, or that all mutants are excluded from coverage."
+          )
+          assertLoggedWarn(
+            "You can enable 'log-test-runner-stdout' in your configuration to see test runner output. See https://stryker-mutator.io/docs/stryker4s/configuration/ for more information."
+          )
+        }
+    }
+
+    test("should warn when all mutants survived") {
+      implicit val config: Config = Config.default
+      val sut = new ConsoleReporter()
+      val allSurvivedReport = MutationTestResult(
+        thresholds = Thresholds(80, 60),
+        files = Map(
+          "stryker4s.scala" -> FileResult(
+            source = "foo",
+            mutants = Seq(
+              MutantResult("0", "", ">", Location(Position(1, 1), Position(1, 2)), MutantStatus.Survived),
+              MutantResult("1", "", "==", Location(Position(1, 2), Position(1, 4)), MutantStatus.Survived)
+            )
+          )
+        )
+      )
+
+      sut
+        .onRunFinished(
+          FinishedRunEvent(allSurvivedReport, Metrics.calculateMetrics(allSurvivedReport), 15.seconds, config.baseDir)
+        )
+        .asserting { _ =>
+          assertLoggedWarn(
+            "None of the mutations were detected. This may indicate that your tests are not running, or that the test assertions are too weak to catch mutations."
+          )
+          assertLoggedWarn(
+            "You can enable 'log-test-runner-stdout' in your configuration to see test runner output. See https://stryker-mutator.io/docs/stryker4s/configuration/ for more information."
+          )
         }
     }
   }

--- a/modules/core/src/test/scala/stryker4s/run/MutantRunnerTest.scala
+++ b/modules/core/src/test/scala/stryker4s/run/MutantRunnerTest.scala
@@ -3,17 +3,21 @@ package stryker4s.run
 import cats.data.{NonEmptyList, NonEmptyVector}
 import cats.effect.{IO, Resource}
 import cats.syntax.either.*
+import fansi.Color
 import fs2.io.file.{Files, Path}
-import mutationtesting.MutantStatus
+import mutationtesting.{MutantResult, MutantStatus}
 import stryker4s.config.Config
 import stryker4s.exception.InitialTestRunFailedException
 import stryker4s.model.*
 import stryker4s.testkit.{FileUtil, LogMatchers, Stryker4sIOSuite}
+import stryker4s.testrunner.api.{CoverageReport, TestFile}
 import stryker4s.testutil.TestData
 import stryker4s.testutil.stubs.{ReporterStub, RollbackHandlerStub, TestFileResolver, TestRunnerStub}
 
-class MutantRunnerTest extends Stryker4sIOSuite with LogMatchers with TestData {
+import scala.concurrent.duration.*
 
+class MutantRunnerTest extends Stryker4sIOSuite with LogMatchers with TestData {
+  override def printLogs = true
   val baseDir = FileUtil.getResource("scalaFiles")
   val staticTmpDir = baseDir.resolve("target/stryker4s-tmpDir")
 
@@ -22,155 +26,261 @@ class MutantRunnerTest extends Stryker4sIOSuite with LogMatchers with TestData {
     Resource.onFinalize(Files[IO].exists(staticTmpDir).ifM(Files[IO].deleteRecursively(staticTmpDir), IO.unit))
   )
 
-  describe("apply") {
+  implicit val config: Config = Config.default.copy(baseDir = baseDir)
 
-    implicit val config: Config = Config.default.copy(baseDir = baseDir)
+  val staticTmpDirConfig = config.copy(staticTmpDir = true)
+  val noCleanTmpDirConfig = staticTmpDirConfig.copy(cleanTmpDir = false)
 
-    val staticTmpDirConfig = config.copy(staticTmpDir = true)
-    val noCleanTmpDirConfig = staticTmpDirConfig.copy(cleanTmpDir = false)
+  test("should return a mutationScore of 66.67 when 2 of 3 mutants are killed") {
+    val fileCollectorStub = new TestFileResolver(Seq.empty)
+    val reporterStub = ReporterStub()
+    val rollbackHandler = RollbackHandlerStub.alwaysSuccessful()
+    val mutant = createMutant.copy(id = MutantId(3))
+    val secondMutant = createMutant.copy(id = MutantId(1))
+    val thirdMutant = createMutant.copy(id = MutantId(2))
 
-    test("should return a mutationScore of 66.67 when 2 of 3 mutants are killed") {
-      val fileCollectorStub = new TestFileResolver(Seq.empty)
-      val reporterStub = ReporterStub()
-      val rollbackHandler = RollbackHandlerStub.alwaysSuccessful()
-      val mutant = createMutant.copy(id = MutantId(3))
-      val secondMutant = createMutant.copy(id = MutantId(1))
-      val thirdMutant = createMutant.copy(id = MutantId(2))
-
-      val testRunner = { (path: Path) =>
-        // Static temp dir is not used with default settings.
-        assert(!path.endsWith("stryker4s-tmpDir"))
-        TestRunnerStub.withResults(
-          mutant.toMutantResult(MutantStatus.Killed),
-          secondMutant.toMutantResult(MutantStatus.Killed),
-          thirdMutant.toMutantResult(MutantStatus.Survived)
-        )(path)
-      }
-
-      val sut = new MutantRunner(testRunner, fileCollectorStub, rollbackHandler, reporterStub)
-      val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
-      val mutants = NonEmptyVector.of(mutant, secondMutant, thirdMutant)
-      val mutatedFile = MutatedFile(file, "def foo = 4".parseDef, mutants)
-      sut(Vector(mutatedFile)).asserting { case RunResult(results, _, _) =>
-        assertLoggedInfo("Setting up mutated environment...")
-        assertLoggedInfo("Starting initial test run...")
-        assertLoggedInfo("Initial test run succeeded! Testing mutants...")
-        val (path, resultForFile) = results.loneElement
-        assertEquals(path, file)
-        assertEquals(
-          resultForFile.map(_.status),
-          Vector(MutantStatus.Killed, MutantStatus.Survived, MutantStatus.Killed)
-        )
-      }
+    val testRunner = { (path: Path) =>
+      // Static temp dir is not used with default settings.
+      assert(!path.endsWith("stryker4s-tmpDir"))
+      TestRunnerStub.withResults(
+        mutant.toMutantResult(MutantStatus.Killed),
+        secondMutant.toMutantResult(MutantStatus.Killed),
+        thirdMutant.toMutantResult(MutantStatus.Survived)
+      )(path)
     }
 
-    test("should return a mutationScore of 66.67 when 2 of 3 mutants are killed and 1 doesn't compile.") {
-      val mutant = createMutant.copy(id = MutantId(3))
-      val secondMutant = createMutant.copy(id = MutantId(1))
-      val thirdMutant = createMutant.copy(id = MutantId(2))
-      val compileErrorResult = thirdMutant.toMutantResult(MutantStatus.CompileError)
-      val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
-      val mutants = NonEmptyVector.of(mutant, secondMutant, thirdMutant)
-      val mutatedFile = MutatedFile(file, "def foo = 4".parseDef, mutants)
+    val sut = new MutantRunner(testRunner, fileCollectorStub, rollbackHandler, reporterStub)
+    val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
+    val mutants = NonEmptyVector.of(mutant, secondMutant, thirdMutant)
+    val mutatedFile = MutatedFile(file, "def foo = 4".parseDef, mutants)
+    sut(Vector(mutatedFile)).asserting { case RunResult(results, _, _) =>
+      assertLoggedInfo("Setting up environment for 1 mutated file(s)...")
+      assertLoggedDebug(s"Using temp directory: ")
+      assertLoggedDebug(s"Writing ${results.loneElement._1} file to ")
+      assertLoggedInfo("Starting initial test run...")
+      assertLoggedInfo("Initial test run succeeded! Testing mutants...")
+      val (path, resultForFile) = results.loneElement
+      assertEquals(path, file)
+      assertEquals(
+        resultForFile.map(_.status),
+        Vector(MutantStatus.Killed, MutantStatus.Survived, MutantStatus.Killed)
+      )
+    }
+  }
 
-      val fileCollectorStub = new TestFileResolver(Seq.empty)
-      val reporterStub = ReporterStub()
+  test("should return a mutationScore of 66.67 when 2 of 3 mutants are killed and 1 doesn't compile.") {
+    val mutant = createMutant.copy(id = MutantId(3))
+    val secondMutant = createMutant.copy(id = MutantId(1))
+    val thirdMutant = createMutant.copy(id = MutantId(2))
+    val compileErrorResult = thirdMutant.toMutantResult(MutantStatus.CompileError)
+    val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
+    val mutants = NonEmptyVector.of(mutant, secondMutant, thirdMutant)
+    val mutatedFile = MutatedFile(file, "def foo = 4".parseDef, mutants)
 
-      val rollbackHandler = RollbackHandlerStub.withResult(
-        RollbackResult(
-          Vector(mutatedFile.copy(mutants = NonEmptyVector.of(mutant, secondMutant))),
-          Map(file -> Vector(compileErrorResult))
-        ).asRight
+    val fileCollectorStub = new TestFileResolver(Seq.empty)
+    val reporterStub = ReporterStub()
+
+    val rollbackHandler = RollbackHandlerStub.withResult(
+      RollbackResult(
+        Vector(mutatedFile.copy(mutants = NonEmptyVector.of(mutant, secondMutant))),
+        Map(file -> Vector(compileErrorResult))
+      ).asRight
+    )
+
+    val testRunner =
+      TestRunnerStub.withInitialCompilerError(
+        NonEmptyList.one(CompilerErrMsg("blah", "scalaFiles/simpleFile.scala", 123)),
+        mutant.toMutantResult(MutantStatus.Killed),
+        secondMutant.toMutantResult(MutantStatus.Killed)
       )
 
-      val testRunner =
-        TestRunnerStub.withInitialCompilerError(
-          NonEmptyList.one(CompilerErrMsg("blah", "scalaFiles/simpleFile.scala", 123)),
-          mutant.toMutantResult(MutantStatus.Killed),
-          secondMutant.toMutantResult(MutantStatus.Killed)
-        )
+    val sut = new MutantRunner(testRunner, fileCollectorStub, rollbackHandler, reporterStub)
 
-      val sut = new MutantRunner(testRunner, fileCollectorStub, rollbackHandler, reporterStub)
+    sut(Vector(mutatedFile)).asserting { case RunResult(results, _, _) =>
+      val (path, resultForFile) = results.loneElement
+      assertEquals(path, file)
+      assertLoggedInfo("Attempting to remove 1 mutant(s) that gave a compile error...")
+      assertEquals(
+        resultForFile.map(_.status),
+        Vector(MutantStatus.Killed, MutantStatus.Killed, MutantStatus.CompileError)
+      )
+    }
+  }
 
-      sut(Vector(mutatedFile)).asserting { case RunResult(results, _, _) =>
-        val (path, resultForFile) = results.loneElement
-        assertEquals(path, file)
-        assertLoggedInfo("Attempting to remove 1 mutant(s) that gave a compile error...")
-        assertEquals(
-          resultForFile.map(_.status),
-          Vector(MutantStatus.Killed, MutantStatus.Killed, MutantStatus.CompileError)
+  test("should use static temp dir if it was requested") {
+    val fileCollectorStub = new TestFileResolver(Seq.empty)
+    val reporterStub = ReporterStub()
+    val rollbackHandler = RollbackHandlerStub.alwaysSuccessful()
+    val mutant = createMutant.copy(id = MutantId(3))
+
+    val testRunner = { (path: Path) =>
+      // Static temp dir is used.
+      assert(path.endsWith("stryker4s-tmpDir"))
+      TestRunnerStub.withResults(mutant.toMutantResult(MutantStatus.Killed))(path)
+    }
+
+    val sut =
+      new MutantRunner(testRunner, fileCollectorStub, rollbackHandler, reporterStub)(using
+        staticTmpDirConfig,
+        testLogger
+      )
+    val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
+    val mutants = NonEmptyVector.one(mutant)
+    val mutatedFile = MutatedFile(file, "def foo = 4".parseDef, mutants)
+
+    sut(Vector(mutatedFile)) *>
+      // Cleaned up after run
+      Files[IO].exists(staticTmpDir).assertEquals(false)
+  }
+
+  test("should not clean up tmp dir on errors") {
+    val fileCollectorStub = new TestFileResolver(Seq.empty)
+    val reporterStub = ReporterStub()
+    val rollbackHandler = RollbackHandlerStub.alwaysSuccessful()
+
+    val testRunner = TestRunnerStub.withResults(NoCoverageInitialTestRun(false))()
+    val mutant = createMutant.copy(id = MutantId(3))
+
+    val sut =
+      new MutantRunner(testRunner, fileCollectorStub, rollbackHandler, reporterStub)(using
+        staticTmpDirConfig,
+        testLogger
+      )
+    val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
+    val mutants = NonEmptyVector.one(mutant)
+    val mutatedFile = MutatedFile(file, "def foo = 4".parseDef, mutants)
+
+    sut(Vector(mutatedFile))
+      .interceptMessage[InitialTestRunFailedException](
+        "Initial test run failed. Please make sure your tests pass before running Stryker4s."
+      )
+  }
+
+  test("should not clean up tmp dir if clean-tmp-dir is disabled") {
+    val fileCollectorStub = new TestFileResolver(Seq.empty)
+    val reporterStub = ReporterStub()
+    val rollbackHandler = RollbackHandlerStub.alwaysSuccessful()
+    val mutant = createMutant.copy(id = MutantId(1))
+
+    val testRunner = TestRunnerStub.withResults(mutant.toMutantResult(MutantStatus.Killed))
+
+    val sut =
+      new MutantRunner(testRunner, fileCollectorStub, rollbackHandler, reporterStub)(using
+        noCleanTmpDirConfig,
+        testLogger
+      )
+    val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
+    val mutants = NonEmptyVector.one(mutant)
+    val mutatedFile = MutatedFile(file, "def foo = 4".parseDef, mutants)
+
+    sut(Vector(mutatedFile)) *>
+      Files[IO].exists(staticTmpDir).assertEquals(true).asserting { _ =>
+        assertLoggedInfo(
+          s"Not deleting $staticTmpDir (turn off cleanTmpDir to disable this). Please clean it up manually."
         )
       }
+  }
+
+  test("should debug log timing when a mutant is tested") {
+    val fileCollectorStub = new TestFileResolver(Seq.empty)
+    val reporterStub = ReporterStub()
+    val rollbackHandler = RollbackHandlerStub.alwaysSuccessful()
+    val mutant = createMutant.copy(id = MutantId(1))
+
+    val testRunner = TestRunnerStub.withResults(mutant.toMutantResult(MutantStatus.Killed))
+    val sut = new MutantRunner(testRunner, fileCollectorStub, rollbackHandler, reporterStub)
+    val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
+    val mutants = NonEmptyVector.one(mutant)
+    val mutatedFile = MutatedFile(file, "def foo = 4".parseDef, mutants)
+
+    sut(Vector(mutatedFile)).asserting { _ =>
+      assertLoggedDebug(s"Running mutant $mutant")
+      assertLoggedDebug("Mutant 1 tested in")
     }
+  }
 
-    test("should use static temp dir if it was requested") {
-      val fileCollectorStub = new TestFileResolver(Seq.empty)
-      val reporterStub = ReporterStub()
-      val rollbackHandler = RollbackHandlerStub.alwaysSuccessful()
-      val mutant = createMutant.copy(id = MutantId(3))
+  test("should warn when all mutants have no code coverage") {
+    val fileCollectorStub = new TestFileResolver(Seq.empty)
+    val reporterStub = ReporterStub()
+    val rollbackHandler = RollbackHandlerStub.alwaysSuccessful()
+    val mutant = createMutant.copy(id = MutantId(1))
 
-      val testRunner = { (path: Path) =>
-        // Static temp dir is used.
-        assert(path.endsWith("stryker4s-tmpDir"))
-        TestRunnerStub.withResults(mutant.toMutantResult(MutantStatus.Killed))(path)
-      }
+    val allNoCoverageTestRunner: Path => Either[NonEmptyList[CompilerErrMsg], Resource[IO, TestRunnerPool]] =
+      (_: Path) =>
+        ResourcePool(
+          NonEmptyList.one(
+            Resource.pure[IO, TestRunner](new TestRunner {
+              override def initialTestRun(): IO[InitialTestRunResult] =
+                IO.pure(
+                  InitialTestRunCoverageReport(
+                    isSuccessful = true,
+                    firstRun = CoverageReport.empty,
+                    secondRun = CoverageReport.empty,
+                    duration = 100.milliseconds,
+                    testNames = Seq.empty
+                  )
+                )
+              override def runMutant(mutant: MutantWithId, testNames: Seq[TestFile]): IO[MutantResult] =
+                IO.raiseError(new Exception("runMutant should not be called when all mutants are NoCoverage"))
+            })
+          )
+        ).asRight
 
-      val sut =
-        new MutantRunner(testRunner, fileCollectorStub, rollbackHandler, reporterStub)(using
-          staticTmpDirConfig,
-          testLogger
-        )
-      val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
-      val mutants = NonEmptyVector.one(mutant)
-      val mutatedFile = MutatedFile(file, "def foo = 4".parseDef, mutants)
+    val sut = new MutantRunner(allNoCoverageTestRunner, fileCollectorStub, rollbackHandler, reporterStub)
+    val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
+    val mutants = NonEmptyVector.one(mutant)
+    val mutatedFile = MutatedFile(file, "def foo = 4".parseDef, mutants)
 
-      sut(Vector(mutatedFile)) *>
-        // Cleaned up after run
-        Files[IO].exists(staticTmpDir).assertEquals(false)
+    sut(Vector(mutatedFile)).asserting { results =>
+      val mutantResult = results.results.loneElement._2.loneElement
+      assertEquals(mutantResult.status, MutantStatus.NoCoverage)
+      assertEquals(mutantResult.statusReason.value, "This mutant was not covered by any code.")
+      assertLoggedInfo(s"1 mutant(s) detected as having no code coverage. They will be skipped and marked as ${Color
+          .Magenta("NoCoverage")}")
+      assertLoggedDebug("NoCoverage mutant ids are: 1")
+      assertLoggedWarn(
+        "All mutants have no code coverage and will not be tested. This typically means that the test runner did not collect any coverage information."
+      )
+      assertLoggedWarn(
+        "You can enable 'log-test-runner-stdout' in your configuration to see test runner output and diagnose the issue. See https://stryker-mutator.io/docs/stryker4s/configuration/ for more information."
+      )
+      assertNotLoggedDebug("Static mutant ids are:")
     }
+  }
 
-    test("should not clean up tmp dir on errors") {
-      val fileCollectorStub = new TestFileResolver(Seq.empty)
-      val reporterStub = ReporterStub()
-      val rollbackHandler = RollbackHandlerStub.alwaysSuccessful()
+  test("should log and report static mutants") {
+    val fileCollectorStub = new TestFileResolver(Seq.empty)
+    val reporterStub = ReporterStub()
+    val rollbackHandler = RollbackHandlerStub.alwaysSuccessful()
+    val mutant = createMutant.copy(id = MutantId(1))
 
-      val testRunner = TestRunnerStub.withResults(initialTestRunResultIsSuccessful = false)()
-      val mutant = createMutant.copy(id = MutantId(3))
+    val testRunner = TestRunnerStub.withResults(
+      InitialTestRunCoverageReport(
+        isSuccessful = true,
+        firstRun = CoverageReport(Map(mutant.id -> Seq.empty)),
+        secondRun = CoverageReport.empty,
+        duration = 100.milliseconds,
+        testNames = Seq.empty
+      )
+    )(mutant.toMutantResult(MutantStatus.NoCoverage))
+    val sut = new MutantRunner(testRunner, fileCollectorStub, rollbackHandler, reporterStub)
+    val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
+    val mutants = NonEmptyVector.one(mutant)
+    val mutatedFile = MutatedFile(file, "def foo = 4".parseDef, mutants)
 
-      val sut =
-        new MutantRunner(testRunner, fileCollectorStub, rollbackHandler, reporterStub)(using
-          staticTmpDirConfig,
-          testLogger
-        )
-      val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
-      val mutants = NonEmptyVector.one(mutant)
-      val mutatedFile = MutatedFile(file, "def foo = 4".parseDef, mutants)
-
-      sut(Vector(mutatedFile))
-        .interceptMessage[InitialTestRunFailedException](
-          "Initial test run failed. Please make sure your tests pass before running Stryker4s."
-        )
-    }
-
-    test("should not clean up tmp dir if clean-tmp-dir is disabled") {
-      val fileCollectorStub = new TestFileResolver(Seq.empty)
-      val reporterStub = ReporterStub()
-      val rollbackHandler = RollbackHandlerStub.alwaysSuccessful()
-      val mutant = createMutant.copy(id = MutantId(1))
-
-      val testRunner = TestRunnerStub.withResults(mutant.toMutantResult(MutantStatus.Killed))
-
-      val sut =
-        new MutantRunner(testRunner, fileCollectorStub, rollbackHandler, reporterStub)(using
-          noCleanTmpDirConfig,
-          testLogger
-        )
-      val file = FileUtil.getResource("scalaFiles/simpleFile.scala")
-      val mutants = NonEmptyVector.one(mutant)
-      val mutatedFile = MutatedFile(file, "def foo = 4".parseDef, mutants)
-
-      sut(Vector(mutatedFile)) *>
-        Files[IO].exists(staticTmpDir).assertEquals(true)
+    sut(Vector(mutatedFile)).asserting { case RunResult(results, _, _) =>
+      val mutantResult = results.loneElement._2.loneElement
+      assertEquals(mutantResult.status, MutantStatus.Ignored)
+      assertEquals(
+        mutantResult.statusReason.value,
+        "This is a 'static' mutant and can not be tested. If you still want to have this mutant tested, change your code to make this value initialize each time it is called."
+      )
+      assert(mutantResult.static.value)
+      assertLoggedInfo(
+        s"1 mutant(s) detected as static. They will be skipped and marked as ${Color.Magenta("Ignored")}"
+      )
+      assertLoggedDebug("Static mutant ids are: 1")
+      assertNotLoggedDebug("NoCoverage mutant ids are:")
     }
   }
 }

--- a/modules/core/src/test/scala/stryker4s/run/TestRunnerTest.scala
+++ b/modules/core/src/test/scala/stryker4s/run/TestRunnerTest.scala
@@ -85,7 +85,7 @@ class TestRunnerTest extends Stryker4sIOSuite with LogMatchers with TestData {
             result,
             mutant.toMutantResult(MutantStatus.Timeout, statusReason = "Timeout of 1 millisecond exceeded.".some)
           )
-          assertLoggedDebug(s"Mutant ${mutant.id} timed out over 1 millisecond")
+          assertLoggedDebug(s"Mutant ${mutant.id} timed out after 1 millisecond")
         }
       }
 
@@ -116,7 +116,7 @@ class TestRunnerTest extends Stryker4sIOSuite with LogMatchers with TestData {
 
         op.asserting { result =>
           assertEquals(result, mutant.toMutantResult(MutantStatus.Killed))
-          assertNotLoggedDebug(s"Mutant ${mutant.id} timed out over")
+          assertNotLoggedDebug(s"Mutant ${mutant.id} timed out after")
         }
       }
     }
@@ -224,7 +224,7 @@ class TestRunnerTest extends Stryker4sIOSuite with LogMatchers with TestData {
       op.asserting { case (result, log) =>
         assertEquals(log, List("open", "close"))
         assertEquals(result, expectedResults)
-        assertNotLoggedInfo(s"Testrunner has run for $reuse times. Restarting it...")
+        assertNotLoggedInfo(s"Testrunner has run for $reuse/$reuse times. Restarting it...")
       }
     }
 
@@ -245,7 +245,7 @@ class TestRunnerTest extends Stryker4sIOSuite with LogMatchers with TestData {
       op.asserting { case (result, log) =>
         assertEquals(log, List("open", "close", "open", "close"))
         assertEquals(result, expectedResults)
-        assertLoggedInfo(s"Testrunner has run for $reuse times. Restarting it...")
+        assertLoggedInfo(s"Testrunner has run for $reuse/$reuse times. Restarting it...")
       }
     }
   }

--- a/modules/core/src/test/scala/stryker4s/testutil/stubs/TestRunnerStub.scala
+++ b/modules/core/src/test/scala/stryker4s/testutil/stubs/TestRunnerStub.scala
@@ -10,12 +10,14 @@ import stryker4s.run.{ResourcePool, TestRunner, TestRunnerPool}
 import stryker4s.testrunner.api.TestFile
 import stryker4s.testutil.TestData
 
-class TestRunnerStub(results: Seq[() => MutantResult], initialTestRunResultIsSuccessful: Boolean = true)
-    extends TestRunner {
+class TestRunnerStub(
+    results: Seq[() => MutantResult],
+    initialTestRunResult: InitialTestRunResult = NoCoverageInitialTestRun(true)
+) extends TestRunner {
   private val stream = Iterator.from(0)
 
   override def initialTestRun(): IO[InitialTestRunResult] =
-    IO.pure(NoCoverageInitialTestRun(initialTestRunResultIsSuccessful))
+    IO.pure(initialTestRunResult)
 
   override def runMutant(mutant: MutantWithId, testNames: Seq[TestFile]): IO[MutantResult] = {
     // Ensure runMutant can always continue
@@ -30,8 +32,8 @@ object TestRunnerStub extends TestData {
 
   def withResults(mutants: MutantResult*) = (_: Path) => makeResults(mutants)
 
-  def withResults(initialTestRunResultIsSuccessful: Boolean)(mutants: MutantResult*) = (_: Path) =>
-    makeResults(mutants, initialTestRunResultIsSuccessful)
+  def withResults(initialTestRun: InitialTestRunResult)(mutants: MutantResult*) = (_: Path) =>
+    makeResults(mutants, initialTestRun)
 
   def withInitialCompilerError(
       errs: NonEmptyList[CompilerErrMsg],
@@ -49,11 +51,11 @@ object TestRunnerStub extends TestData {
 
   private def makeResults(
       mutants: Seq[MutantResult],
-      initialTestRunResultIsSuccessful: Boolean = true
+      initialTestRunResult: InitialTestRunResult = NoCoverageInitialTestRun(isSuccessful = true)
   ): Either[NonEmptyList[CompilerErrMsg], Resource[IO, TestRunnerPool]] =
     ResourcePool(
       NonEmptyList.one(
-        Resource.pure[IO, TestRunner](new TestRunnerStub(mutants.map(() => _), initialTestRunResultIsSuccessful))
+        Resource.pure[IO, TestRunner](new TestRunnerStub(mutants.map(() => _), initialTestRunResult))
       )
     ).asRight
 }

--- a/modules/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
+++ b/modules/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
@@ -48,7 +48,9 @@ class Stryker4sSbtRunner(
         settings: Seq[Def.Setting[?]],
         extracted: Extracted
     ): NonEmptyList[Resource[IO, TestRunner]] = {
-      log.info("Using the legacy sbt testrunner")
+      log.warn(
+        "Using the legacy sbt testrunner. Note: this mode is much slower, and does not support compiler error detection. Consider disabling 'legacy-test-runner' for a better experience."
+      )
 
       val emptyLogManager =
         LogManager.defaultManager(ConsoleOut.printStreamOut(new PrintStream((_: Int) => {})))
@@ -83,7 +85,7 @@ class Stryker4sSbtRunner(
         PluginCompat.runTask(task, newState) match {
           case Some(Right(result)) => result
           case other               =>
-            log.debug(s"Expected ${task.key.label} but got $other")
+            log.debug(s"Expected task '${task.key.label}' to succeed, but got: $other")
             throw TestSetupException(task.key.label)
         }
       }
@@ -187,7 +189,7 @@ class Stryker4sSbtRunner(
           param = s"-D$key=$value"
         } yield param
       }
-      log.debug(s"System properties added to the forked JVM: ${filteredSystemProperties.mkString(",")}")
+      log.debug(s"System properties added to the forked JVM: ${filteredSystemProperties.mkString(", ")}")
 
       Seq(
         targetProject / scalacOptions --= blocklistedScalacOptions,

--- a/modules/sbt/src/main/scala/stryker4s/sbt/runner/ProcessTestRunner.scala
+++ b/modules/sbt/src/main/scala/stryker4s/sbt/runner/ProcessTestRunner.scala
@@ -144,7 +144,7 @@ object ProcessTestRunner extends TestInterfaceMapper {
 
     val logger = config.debug.logTestRunnerStdout
       .guard[Option]
-      .as((m: String) => IO(log.debug(s"testrunner $id: $m")))
+      .as((m: String) => IO(log.debug(s"[test-runner $id] $m")))
 
     for {
       args <-
@@ -169,7 +169,7 @@ object ProcessTestRunner extends TestInterfaceMapper {
         ProcessBuilder(javaBin, args).withWorkingDirectory(config.baseDir),
         logger
       )
-      _ <- IO(log.debug("Started process")).toResource
+      _ <- IO(log.debug(s"Started test-runner process for id $id")).toResource
     } yield process
   }
 
@@ -203,9 +203,9 @@ object ProcessTestRunner extends TestInterfaceMapper {
       .retryWithBackoff(
         6,
         0.2.seconds,
-        delay => IO(log.debug(s"Could not connect to testprocess. Retrying after ${delay.toHumanReadable}..."))
+        delay => IO(log.debug(s"Could not connect to test process. Retrying after ${delay.toHumanReadable}..."))
       )
-      .evalTap(_ => IO(log.debug(s"Connected to testprocess at $name")))
+      .evalTap(_ => IO(log.debug(s"Connected to test process at $name")))
       .onFinalize(IO(log.debug(s"Closing test-runner at $name")))
   }
 

--- a/modules/sbt/src/main/scala/stryker4s/sbt/runner/TestRunnerConnection.scala
+++ b/modules/sbt/src/main/scala/stryker4s/sbt/runner/TestRunnerConnection.scala
@@ -8,7 +8,6 @@ import fs2.io.file.{Files, Path}
 import fs2.io.net.{Network, Socket}
 import fs2.io.readOutputStream
 import scalapb.LiteParser
-import stryker4s.log.Logger
 import stryker4s.testrunner.api.{Request, RequestMessage, Response, ResponseMessage}
 
 import java.net.SocketException
@@ -17,13 +16,12 @@ sealed trait TestRunnerConnection {
   def sendMessage(request: Request): IO[Response]
 }
 
-final class SocketTestRunnerConnection private (socket: Socket[IO])(implicit log: Logger) extends TestRunnerConnection {
+final class SocketTestRunnerConnection private (socket: Socket[IO]) extends TestRunnerConnection {
 
   override def sendMessage(request: Request): IO[Response] =
-    (write(request.asMessage) *> read)
-      .flatTap(response => IO(log.debug(s"Received message $response")))
+    write(request.asMessage) *> read
 
-  def write(msg: RequestMessage) =
+  def write(msg: RequestMessage): IO[Unit] =
     readOutputStream(bufferSizeForMsg(msg))(os => IO.blocking(msg.writeDelimitedTo(os)))
       .through(socket.writes)
       .compile
@@ -70,7 +68,7 @@ final class SocketTestRunnerConnection private (socket: Socket[IO])(implicit log
 
 object SocketTestRunnerConnection {
 
-  def create(socketAddress: GenSocketAddress)(implicit log: Logger): Resource[IO, TestRunnerConnection] = for {
+  def create(socketAddress: GenSocketAddress): Resource[IO, TestRunnerConnection] = for {
     _ <- socketAddress match {
       case UnixSocketAddress(path) =>
         Files[IO]

--- a/modules/testRunnerApi/src/main/scala/stryker4s/testrunner/api/CoverageReport.scala
+++ b/modules/testRunnerApi/src/main/scala/stryker4s/testrunner/api/CoverageReport.scala
@@ -11,4 +11,6 @@ object CoverageReport {
     }
     CoverageReport(map)
   }
+
+  lazy val empty: CoverageReport = CoverageReport(Map.empty[MutantId, Seq[TestFile]])
 }


### PR DESCRIPTION
Closes #1156 and #1417

- ConsoleReporter provides clearer warnings when no mutations are tested or when mutation scores are dangerously low.
- MutantRunner logs detailed information about the setup of mutated environments and the status of mutants during testing.
- TestRunner and ProcessTestRunner provide more informative debug messages
- Warnings in SBT runner for using legacy test runners, encouraging users to switch for better performance.
