### PR TITLE
build: narrow down Scala cross-compile targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           java-version: ${{ matrix.java-version }}
       - name: Run tests
-        run: sbt 'compile; ++2.13 test'
+        run: sbt 'compile; ++ 3 test'
   sbt-integration:
     strategy:
       matrix:

--- a/build.sbt
+++ b/build.sbt
@@ -47,9 +47,10 @@ lazy val core = (projectMatrix in file("modules") / "core")
   .jvmPlatform(scalaVersions = versions.crossScalaVersions)
 
 lazy val commandRunner = (projectMatrix in file("modules") / "commandRunner")
+  .defaultAxes(VirtualAxis.scalaABIVersion(versions.scala3), VirtualAxis.jvm)
   .settings(commonSettings, commandRunnerSettings, publishLocalDependsOn(core))
   .dependsOn(core, testkit % Test)
-  .jvmPlatform(scalaVersions = versions.crossScalaVersions)
+  .jvmPlatform(scalaVersions = Seq(versions.scala3))
 
 // sbt plugins have to use Scala 2.12
 lazy val sbtPlugin = (projectMatrix in file("modules") / "sbt")
@@ -57,11 +58,11 @@ lazy val sbtPlugin = (projectMatrix in file("modules") / "sbt")
   .defaultAxes(VirtualAxis.scalaPartialVersion("2.12"), VirtualAxis.jvm)
   .settings(commonSettings, sbtPluginSettings, publishLocalDependsOn(core, testRunner))
   .dependsOn(core)
-  .jvmPlatform(scalaVersions = Seq(versions.scala212, versions.scala3Lts))
+  .jvmPlatform(scalaVersions = Seq(versions.scala3, versions.scala212))
 
 // Mill plugins are compiled with the Scala version of the minimum supported Mill version
 lazy val millPlugin = (projectMatrix in file("modules") / "mill")
-  .defaultAxes(VirtualAxis.scalaABIVersion(versions.scala3Lts), VirtualAxis.jvm)
+  .defaultAxes(VirtualAxis.scalaABIVersion(versions.scalaMill), VirtualAxis.jvm)
   .settings(
     commonSettings,
     millPluginSettings,
@@ -71,20 +72,20 @@ lazy val millPlugin = (projectMatrix in file("modules") / "mill")
       .value
   )
   .dependsOn(core, testkit % Test)
-  .jvmPlatform(scalaVersions = Seq(versions.scala3Lts))
+  .jvmPlatform(scalaVersions = Seq(versions.scalaMill))
 
 lazy val testRunner = (projectMatrix in file("modules") / "testRunner")
   .settings(commonSettings, testRunnerSettings, publishLocalDependsOn(testRunnerApi))
   .dependsOn(testRunnerApi)
-  .jvmPlatform(scalaVersions = versions.crossScalaVersions)
+  .jvmPlatform(scalaVersions = versions.fullCrossScalaVersions)
 
 lazy val testRunnerApi = (projectMatrix in file("modules") / "testRunnerApi")
   .settings(commonSettings, testRunnerApiSettings)
-  .jvmPlatform(scalaVersions = versions.crossScalaVersions)
+  .jvmPlatform(scalaVersions = versions.fullCrossScalaVersions)
 
 lazy val api = (projectMatrix in file("modules") / "api")
   .settings(commonSettings, apiSettings)
-  .jvmPlatform(scalaVersions = versions.crossScalaVersions)
+  .jvmPlatform(scalaVersions = versions.fullCrossScalaVersions)
 
 lazy val testkit = (projectMatrix in file("modules") / "testkit")
   .settings(commonSettings, testkitSettings, publishLocalDependsOn(api))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,11 @@ object Dependencies {
     // Mill plugins must be compiled with the same Scala version as the minimum supported Mill version
     val scalaMill = "3.8.2"
 
-    val crossScalaVersions = Seq(scala3Lts, scala213, scala212)
+    // All supported Scala versions
+    val fullCrossScalaVersions = Seq(scala3Lts, scala213, scala212)
+
+    // Scala 3 versions and 2.12 (for sbtPlugin)
+    val crossScalaVersions = Seq(scala3Lts, scala3, scalaMill, scala212).distinct
 
     // Test dependencies
     val munit = "1.3.3"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -72,12 +72,6 @@ object Settings {
         case _      => "2.0.0"
       }
     },
-    scalaVersion ~= {
-      // Hard code Scala 3 version to non-LTS for SBT plugins, as required by SBT 2
-      // Hardcoding to prevent core2_13 being used
-      case Dependencies.versions.scala3Lts => Dependencies.versions.scala3
-      case other                           => other
-    },
     scriptedBufferLog := false,
     // Disable unused import warnings (for 2.12), for better compatibility with SBT 2/Scala 3
     tpolecatExcludeOptions ++= Set(ScalacOptions.privateWarnUnusedImports)
@@ -85,7 +79,6 @@ object Settings {
 
   lazy val millPluginSettings: Seq[Setting[?]] = Seq(
     moduleName := "mill-stryker4s_mill1",
-    scalaVersion := Dependencies.versions.scalaMill,
     libraryDependencies ++= Seq(
       Dependencies.millLibsScalalib % Provided,
       Dependencies.millTestkit % Test


### PR DESCRIPTION
Drop cross-compile targets that are not used, like commandRunner 2.12+2.13. Fully drops 2.13 from core, and only target Scala 3 and 2.12. Does not impact scala-version support of Stryker4s.
