### PR TITLE
chore: minor refactors

### DIFF
--- a/maven/src/test/scala/stryker4s/maven/runner/MavenTestDiscoveryTest.scala
+++ b/maven/src/test/scala/stryker4s/maven/runner/MavenTestDiscoveryTest.scala
@@ -30,11 +30,9 @@ class MavenTestDiscoveryTest extends Stryker4sIOSuite with LogMatchers {
   test("warns when no test frameworks are found on the classpath") {
     MavenTestDiscovery
       .discover(Seq(testClassesDir), fullClasspath, frameworkNames = Seq("does.not.Exist"))
-      .map { groups =>
-        assertEquals(groups, Seq.empty)
-        assertLoggedWarn("No sbt.testing test frameworks found on the test classpath")
-        assertLoggedWarn("Will likely result in no tests being run and a NoCoverage result for all mutants.")
-      }
+      .assertEquals(Seq.empty)
+      .assertLoggedWarn("No sbt.testing test frameworks found on the test classpath")
+      .assertLoggedWarn("Will likely result in no tests being run and a NoCoverage result for all mutants.")
   }
 
   test("a framework name that resolves to a non-Framework class is skipped without failing") {

--- a/modules/core/src/main/scala/stryker4s/extension/DurationExtensions.scala
+++ b/modules/core/src/main/scala/stryker4s/extension/DurationExtensions.scala
@@ -1,7 +1,8 @@
 package stryker4s.extension
 
 import cats.data.Chain
-import cats.syntax.foldable.*
+import cats.data.Chain.*
+import cats.syntax.all.*
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.Duration
@@ -9,28 +10,29 @@ import scala.concurrent.duration.Duration
 object DurationExtensions {
   implicit final class HumanReadableExtension(val duration: Duration) extends AnyVal {
     final def toHumanReadable: String = {
-      val units = Seq(TimeUnit.DAYS, TimeUnit.HOURS, TimeUnit.MINUTES, TimeUnit.SECONDS, TimeUnit.MILLISECONDS)
+      val units = Chain(TimeUnit.DAYS, TimeUnit.HOURS, TimeUnit.MINUTES, TimeUnit.SECONDS, TimeUnit.MILLISECONDS)
 
+      // Walk the units largest-first, emitting a part per non-zero unit.
       val timeStrings = units
-        .foldLeft((Chain.empty[String], duration.toMillis)) { case ((humanReadable, rest), unit) =>
+        .mapAccumulate(duration.toMillis) { (rest, unit) =>
           val name = unit.toString().toLowerCase()
           val result = unit.convert(rest, TimeUnit.MILLISECONDS)
           val diff = rest - TimeUnit.MILLISECONDS.convert(result, unit)
           val str = result match {
-            case 0    => humanReadable
-            case 1    => humanReadable :+ s"1 ${name.init}" // Drop last 's'
-            case more => humanReadable :+ s"$more $name"
+            case 0    => none
+            case 1    => s"1 ${name.init}".some // Drop last 's'
+            case more => s"$more $name".some
           }
-          (str, diff)
+          (diff, str)
         }
-        ._1
+        ._2
+        .flattenOption
 
-      timeStrings match {
-        case Chain()  => "0 seconds"
-        case Chain(a) => a
-        case _        =>
-          val (strings, last) = timeStrings.initLast.get
-          strings.mkString_(", ") + " and " + last
+      // `Chain`'s extractors aren't exhaustivity-aware, but these arms cover empty/one/many.
+      (timeStrings: @unchecked) match {
+        case Chain()       => "0 seconds"
+        case Chain(a)      => a
+        case init :== last => init.mkString_(", ") + " and " + last
       }
     }
   }

--- a/modules/core/src/main/scala/stryker4s/extension/TreeExtensions.scala
+++ b/modules/core/src/main/scala/stryker4s/extension/TreeExtensions.scala
@@ -1,8 +1,8 @@
 package stryker4s.extension
 
-import cats.Eval
 import cats.data.{Chain, State}
 import cats.syntax.all.*
+import cats.{Eq, Eval}
 import mutationtesting.Location
 import mutationtesting.cats.*
 
@@ -31,7 +31,7 @@ object TreeExtensions {
       */
     final def find[T <: Tree](toFind: T)(implicit classTag: ClassTag[T]): Option[T] =
       thisTree.collectFirst {
-        case found: T if found.isEqual(toFind) => found
+        case found: T if found === toFind => found
       }
 
   }
@@ -99,12 +99,9 @@ object TreeExtensions {
 
   }
 
-  implicit final class IsEqualExtension(val thisTree: Tree) extends AnyVal {
-
-    /** Structural equality for Trees
-      */
-    final def isEqual(other: Tree): Boolean = thisTree == other || thisTree.structure == other.structure
-  }
+  /** Structural equality for `Tree`s
+    */
+  implicit def treeEq[A <: Tree]: Eq[A] = Eq.instance((x, y) => x == y || x.structure == y.structure)
 
   implicit final class CollectFirstExtension(tree: Tree) {
     final def collectFirst[T](pf: PartialFunction[Tree, T]): Option[T] = {

--- a/modules/core/src/main/scala/stryker4s/extension/TreeExtensions.scala
+++ b/modules/core/src/main/scala/stryker4s/extension/TreeExtensions.scala
@@ -12,12 +12,14 @@ import scala.meta.transversers.SimpleTraverser
 import scala.reflect.ClassTag
 
 object TreeExtensions {
+
+  /** Searches up the tree for the closest parent of type `T`, if any. */
   @tailrec
-  private def mapParent[T <: Tree, U](tree: Tree, ifFound: T => U, notFound: => U)(implicit classTag: ClassTag[T]): U =
+  private def parentOfType[T <: Tree](tree: Tree)(implicit classTag: ClassTag[T]): Option[T] =
     tree.parent match {
-      case Some(value: T)   => ifFound(value)
-      case Some(otherValue) => mapParent(otherValue, ifFound, notFound)
-      case _                => notFound
+      case Some(value: T)   => value.some
+      case Some(otherValue) => parentOfType(otherValue)
+      case _                => none
     }
 
   implicit final class FindExtension(val thisTree: Tree) extends AnyVal {
@@ -76,7 +78,7 @@ object TreeExtensions {
       * found.
       */
     final def isIn[T <: Tree](implicit classTag: ClassTag[T]): Boolean =
-      mapParent[T, Boolean](thisTree, _ => true, false)
+      parentOfType[T](thisTree).isDefined
   }
 
   implicit final class GetMods(val tree: Tree) extends AnyVal {
@@ -109,7 +111,7 @@ object TreeExtensions {
       val fn = pf.lift
       object traverser extends SimpleTraverser {
         override def apply(t: Tree): Unit = {
-          result = if (result.isEmpty) fn(t).orElse(result) else result
+          result = result.orElse(fn(t))
           super.apply(t)
         }
       }

--- a/modules/core/src/main/scala/stryker4s/extension/TreeExtensions.scala
+++ b/modules/core/src/main/scala/stryker4s/extension/TreeExtensions.scala
@@ -1,7 +1,7 @@
 package stryker4s.extension
 
 import cats.Eval
-import cats.data.{Chain, OptionT}
+import cats.data.{Chain, State}
 import cats.syntax.all.*
 import mutationtesting.Location
 import mutationtesting.cats.*
@@ -130,23 +130,22 @@ object TreeExtensions {
         buildContext: PartialFunction[Tree, C]
     )(collectFn: PartialFunction[Tree, C => T]): Seq[T] = {
       val collectFnLifted = collectFn.lift
-      val buildContextLifted = buildContext.andThen(_.some.pure[Eval])
+      val buildContextLifted = buildContext.lift
 
-      def traverse(tree: Tree, context: Eval[Option[C]]): Eval[Chain[T]] = {
-        // Either match on the context of the currently-visiting tree, or go looking upwards for one (that's what the context param does)
-        val newContext = Eval.defer(buildContextLifted.applyOrElse(tree, (_: Tree) => context))
+      def traverse(tree: Tree): State[Eval[Option[C]], Chain[T]] =
+        State.get[Eval[Option[C]]].flatMap { inherited =>
+          // The context for this node and its descendants
+          val contextEval = Eval.defer(buildContextLifted(tree).fold(inherited)(_.some.pure[Eval])).memoize
 
-        val findAndCollect = for {
-          collectTreeFn <- collectFnLifted(tree).toOptionT[Eval]
-          contextForTree <- OptionT(newContext)
-        } yield collectTreeFn(contextForTree)
+          // Only read the context when this node actually collects something.
+          val collected = collectFnLifted(tree).foldMap(collect => Chain.fromOption(contextEval.value.map(collect)))
 
-        findAndCollect.value.map(Chain.fromOption) |+|
-          Chain.fromSeq(tree.children).flatTraverse(traverse(_, newContext))
-      }
+          // Each child starts from this node's context, independent of its siblings.
+          tree.children.foldMapM(child => State.set(contextEval) *> traverse(child)).map(collected ++ _)
+        }
 
       // Traverse the tree, starting with an empty context
-      traverse(tree, none.pure[Eval]).value.toVector
+      traverse(tree).runA(none.pure[Eval]).value.toVector
     }
 
   }

--- a/modules/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
+++ b/modules/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
@@ -5,7 +5,7 @@ import cats.syntax.all.*
 import mutationtesting.cats.*
 import stryker4s.config.{Config, ExcludedMutation}
 import stryker4s.extension.PartialFunctionOps.*
-import stryker4s.extension.TreeExtensions.{IsEqualExtension, PositionExtension, TransformOnceExtension}
+import stryker4s.extension.TreeExtensions.{treeEq, PositionExtension, TransformOnceExtension}
 import stryker4s.model.*
 import stryker4s.mutants.tree.{IgnoredMutation, IgnoredMutations, Mutations}
 import stryker4s.mutation.*
@@ -161,7 +161,7 @@ class MutantMatcherImpl()(implicit config: Config) extends MutantMatcher {
       )
       val mutatedTopStatement = placeableTree.tree
         .transformExactlyOnce {
-          case t if t.isEqual(original) && t.pos == original.pos =>
+          case t if t === original && t.pos == original.pos =>
             tree
         }
         .getOrElse(

--- a/modules/core/src/main/scala/stryker4s/mutants/tree/MutantInstrumenter.scala
+++ b/modules/core/src/main/scala/stryker4s/mutants/tree/MutantInstrumenter.scala
@@ -4,7 +4,7 @@ import cats.data.Ior.Both
 import cats.data.{Ior, NonEmptyList, NonEmptyVector}
 import cats.syntax.all.*
 import stryker4s.exception.{Stryker4sException, UnableToBuildPatternMatchException}
-import stryker4s.extension.TreeExtensions.{IsEqualExtension, TransformOnceExtension}
+import stryker4s.extension.TreeExtensions.{treeEq, TransformOnceExtension}
 import stryker4s.log.Logger
 import stryker4s.model.*
 
@@ -97,10 +97,10 @@ class MutantInstrumenter(options: InstrumenterOptions)(implicit log: Logger) {
     */
   def attemptRemoveMutant(errors: NonEmptyList[CompilerErrMsg]): PartialFunction[Tree, Tree] = {
     // Match on mutation switching trees
-    case tree: Term.Match if tree.expr.isEqual(options.mutationContext) =>
+    case tree: Term.Match if tree.expr === options.mutationContext =>
       // Filter out any cases that are in the same range as a compile error
       val newCases = tree.casesBlock.cases.filterNot(caze =>
-        !caze.pat.isEqual(Pat.Wildcard()) && errors.exists(compileErrorIsInCaseStatement(caze, _))
+        (caze.pat =!= Pat.Wildcard()) && errors.exists(compileErrorIsInCaseStatement(caze, _))
       )
 
       tree.copy(cases = newCases)
@@ -109,9 +109,9 @@ class MutantInstrumenter(options: InstrumenterOptions)(implicit log: Logger) {
   def mutantIdsForCompileErrors(tree: Tree, errors: NonEmptyList[CompilerErrMsg]) = {
     val mutationSwitchingCases: List[Case] = tree.collect {
       // Match on mutation switching trees
-      case tree: Term.Match if tree.expr.isEqual(options.mutationContext) =>
+      case tree: Term.Match if tree.expr === options.mutationContext =>
         // Filter out default case as it's not mutated
-        tree.casesBlock.cases.filterNot(_.pat.isEqual(Pat.Wildcard()))
+        tree.casesBlock.cases.filterNot(_.pat === Pat.Wildcard())
     }.flatten
 
     errors

--- a/modules/core/src/main/scala/stryker4s/mutation/ArgMethodExpression.scala
+++ b/modules/core/src/main/scala/stryker4s/mutation/ArgMethodExpression.scala
@@ -1,7 +1,7 @@
 package stryker4s.mutation
 
-import cats.syntax.option.*
-import stryker4s.extension.TreeExtensions.IsEqualExtension
+import cats.syntax.all.*
+import stryker4s.extension.TreeExtensions.treeEq
 
 import scala.meta.Term.*
 import scala.meta.{Lit, Term, Type}
@@ -56,7 +56,7 @@ sealed trait ArgMethodExpression extends MethodExpression {
 
       // foo filter( a => a > 0 )
       case term @ ApplyInfix.After_4_6_0(_, Name(`methodName`), Type.ArgClause(Nil), ArgClause(arg :: Nil, _))
-          if !arg.isEqual(Lit.Unit()) =>
+          if arg =!= Lit.Unit() =>
         Option(
           (
             term,

--- a/modules/core/src/main/scala/stryker4s/mutation/MutationTypes.scala
+++ b/modules/core/src/main/scala/stryker4s/mutation/MutationTypes.scala
@@ -1,7 +1,7 @@
 package stryker4s.mutation
 
-import cats.syntax.option.*
-import stryker4s.extension.TreeExtensions.IsEqualExtension
+import cats.syntax.all.*
+import stryker4s.extension.TreeExtensions.treeEq
 
 import scala.meta.*
 import scala.meta.internal.trees.XtensionTreesName
@@ -42,7 +42,7 @@ trait SubstitutionMutation[T <: Tree] extends Mutation[T] with NoInvalidPlacemen
 
   override def unapply(arg: T): Option[T] =
     arg.some
-      .filter(_.isEqual(tree))
+      .filter(_ === tree)
       .flatMap(super.unapply)
 }
 

--- a/modules/core/src/main/scala/stryker4s/mutation/StringLiteral.scala
+++ b/modules/core/src/main/scala/stryker4s/mutation/StringLiteral.scala
@@ -30,10 +30,11 @@ case object NonEmptyString extends NoInvalidPlacement[Lit.String] {
 /** Not a mutation, just an extractor for pattern matching on interpolated strings
   */
 case object StringInterpolation extends NoInvalidPlacement[Term.Interpolate] {
-  import stryker4s.extension.TreeExtensions.IsEqualExtension
+  import cats.syntax.all.*
+  import stryker4s.extension.TreeExtensions.treeEq
 
   override def unapply(arg: Term.Interpolate): Option[Term.Interpolate] =
-    super.unapply(arg).filter(_.prefix.isEqual(Term.Name("s")))
+    super.unapply(arg).filter(_.prefix === Term.Name("s"))
 }
 
 private object ParentIsInterpolatedString {

--- a/modules/core/src/test/scala/stryker4s/config/ConfigLoaderTest.scala
+++ b/modules/core/src/test/scala/stryker4s/config/ConfigLoaderTest.scala
@@ -9,11 +9,10 @@ import stryker4s.testkit.{LogMatchers, Stryker4sIOSuite}
 class ConfigLoaderTest extends Stryker4sIOSuite with LogMatchers {
   test("combines a ConfigSource into Config") {
     val result = ConfigLoader.loadAll[IO](List.empty)
-    result.assertEquals(Config.default) *>
-      IO(
-        assertLoggedInfo(
-          "Loading config. Read how to configure Stryker4s here: https://stryker-mutator.io/docs/stryker4s/configuration/"
-        )
+    result
+      .assertEquals(Config.default)
+      .assertLoggedInfo(
+        "Loading config. Read how to configure Stryker4s here: https://stryker-mutator.io/docs/stryker4s/configuration/"
       )
   }
 

--- a/modules/core/src/test/scala/stryker4s/config/source/AggregateConfigSourceTest.scala
+++ b/modules/core/src/test/scala/stryker4s/config/source/AggregateConfigSourceTest.scala
@@ -20,25 +20,27 @@ class AggregateConfigSourceTest extends Stryker4sIOSuite with LogMatchers {
     val aggregate = new AggregateConfigSource[IO](NonEmptyList.of(file, cli, defaults))
 
     // file
-    aggregate.timeout.load.assertEquals(6.seconds) *>
-      IO(assertLoggedDebug(s"Loaded ${Color.Magenta("timeout")} from ${Color.Cyan("file config")}: 6 seconds")) *>
+    aggregate.timeout.load
+      .assertEquals(6.seconds)
+      .assertLoggedDebug(s"Loaded ${Color.Magenta("timeout")} from ${Color.Cyan("file config")}: 6 seconds") *>
       // cli
-      aggregate.baseDir.load.assertEquals(Path("/tmp/project")) *>
-      IO(assertLoggedDebug(s"Loaded ${Color.Magenta("baseDir")} from ${Color.Cyan("CLI arguments")}: $path")) *>
+      aggregate.baseDir.load
+        .assertEquals(Path("/tmp/project"))
+        .assertLoggedDebug(s"Loaded ${Color.Magenta("baseDir")} from ${Color.Cyan("CLI arguments")}: $path") *>
       // defaults
-      aggregate.thresholdsHigh.load.assertEquals(80) *>
-      IO(assertLoggedDebug(s"Loaded ${Color.Magenta("thresholdsHigh")} from ${Color.Cyan("defaults")}: 80"))
+      aggregate.thresholdsHigh.load
+        .assertEquals(80)
+        .assertLoggedDebug(s"Loaded ${Color.Magenta("thresholdsHigh")} from ${Color.Cyan("defaults")}: 80")
   }
 
   test("aggregate combines given sources and defaults") {
     val cli = new CliConfigSource[IO](Seq("--base-dir=/tmp/project"))
-    ConfigSource.aggregate(List(cli)).flatMap { conf =>
-      conf.baseDir.load.assertEquals(Path("/tmp/project")) *>
-        conf.thresholdsHigh.load.assertEquals(80)
-    } *> IO(
-      assertLoggedDebug(
-        s"Loaded config sources '${Color.Cyan("CLI arguments")}', '${Color.Cyan("file config")}'"
-      )
-    )
+    ConfigSource
+      .aggregate(List(cli))
+      .flatMap { conf =>
+        conf.baseDir.load.assertEquals(Path("/tmp/project")) *>
+          conf.thresholdsHigh.load.assertEquals(80)
+      }
+      .assertLoggedDebug(s"Loaded config sources '${Color.Cyan("CLI arguments")}', '${Color.Cyan("file config")}'")
   }
 }

--- a/modules/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
+++ b/modules/core/src/test/scala/stryker4s/mutants/MutatorTest.scala
@@ -107,12 +107,13 @@ class MutatorTest extends Stryker4sIOSuite with LogMatchers {
       )
       val files = Stream(FileUtil.getResource("scalaFiles/simpleFile.scala"))
 
-      sut.go(files).asserting { _ =>
-        assertLoggedInfo(s"Found ${Cyan("1")} file(s) to be mutated.")
-        assertLoggedInfo(s"${Cyan("4")} mutant(s) generated. Of which ${LightRed("3")} mutant(s) are excluded.")
-        assertNotLoggedWarn("Files to be mutated are found, but no mutations were found in those files.")
-        assertNotLoggedWarn("If this is not intended, please check your configuration and try again.")
-      }
+      sut
+        .go(files)
+        .assertLoggedInfo(s"Found ${Cyan("1")} file(s) to be mutated.")
+        .assertLoggedInfo(s"${Cyan("4")} mutant(s) generated. Of which ${LightRed("3")} mutant(s) are excluded.")
+        .assertNotLoggedWarn("Files to be mutated are found, but no mutations were found in those files.")
+        .assertNotLoggedWarn("If this is not intended, please check your configuration and try again.")
+
     }
 
     test("should log a warning if no mutants are found") {
@@ -124,12 +125,12 @@ class MutatorTest extends Stryker4sIOSuite with LogMatchers {
       )
       val files = Stream(FileUtil.getResource("fileTests/filledDir/src/main/scala/package/someFile.scala"))
 
-      sut.go(files).asserting { _ =>
-        assertLoggedInfo(s"Found ${Cyan("1")} file(s) to be mutated.")
-        assertLoggedInfo(s"${Cyan("0")} mutant(s) generated.")
-        assertLoggedWarn("Files to be mutated are found, but no mutations were found in those files.")
-        assertLoggedWarn("If this is not intended, please check your configuration and try again.")
-      }
+      sut
+        .go(files)
+        .assertLoggedInfo(s"Found ${Cyan("1")} file(s) to be mutated.")
+        .assertLoggedInfo(s"${Cyan("0")} mutant(s) generated.")
+        .assertLoggedWarn("Files to be mutated are found, but no mutations were found in those files.")
+        .assertLoggedWarn("If this is not intended, please check your configuration and try again.")
     }
 
     test("should log if all mutations are excluded") {
@@ -143,16 +144,16 @@ class MutatorTest extends Stryker4sIOSuite with LogMatchers {
       )
       val files = Stream(FileUtil.getResource("scalaFiles/simpleFile.scala"))
 
-      sut.go(files).asserting { _ =>
-        assertLoggedInfo(s"Found ${Cyan("1")} file(s) to be mutated.")
-        assertLoggedInfo(s"${Cyan("4")} mutant(s) generated. Of which ${LightRed("4")} mutant(s) are excluded.")
-        assertLoggedWarn(
+      sut
+        .go(files)
+        .assertLoggedInfo(s"Found ${Cyan("1")} file(s) to be mutated.")
+        .assertLoggedInfo(s"${Cyan("4")} mutant(s) generated. Of which ${LightRed("4")} mutant(s) are excluded.")
+        .assertLoggedWarn(
           s"""All found mutations are excluded. Stryker4s will perform a dry-run without actually mutating anything.
              |You can configure the `mutate` or `excluded-mutations` property in your configuration""".stripMargin
         )
-        assertNotLoggedWarn("Files to be mutated are found, but no mutations were found in those files.")
-        assertNotLoggedWarn("If this is not intended, please check your configuration and try again.")
-      }
+        .assertNotLoggedWarn("Files to be mutated are found, but no mutations were found in those files.")
+        .assertNotLoggedWarn("If this is not intended, please check your configuration and try again.")
     }
   }
 }

--- a/modules/core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala
+++ b/modules/core/src/test/scala/stryker4s/mutants/findmutants/MutantFinderTest.scala
@@ -72,11 +72,9 @@ class MutantFinderTest extends Stryker4sIOSuite with LogMatchers {
       sut
         .parseFile(noFile)
         .intercept[ParseException]
-        .asserting { _ =>
-          assertLoggedError(
-            s"Error while parsing file '${noFile.relativePath}', illegal start of definition `identifier`"
-          )
-        }
+        .assertLoggedError(
+          s"Error while parsing file '${noFile.relativePath}', illegal start of definition `identifier`"
+        )
     }
   }
 }

--- a/modules/core/src/test/scala/stryker4s/mutation/MethodExpressionTest.scala
+++ b/modules/core/src/test/scala/stryker4s/mutation/MethodExpressionTest.scala
@@ -5,149 +5,149 @@ import stryker4s.testkit.Stryker4sSuite
 class MethodExpressionTest extends Stryker4sSuite {
   describe("ArgMethodExpression") {
     test("should match with a filter call (one argument)") {
-      assertMatchPattern("list.filter( _ => true )".parseTerm, { case Filter(_, _) => })
+      assertMatches("list.filter( _ => true )".parseTerm) { case Filter(_, _) => true }
     }
 
     test("should match with an infix filter call (one argument)") {
-      assertMatchPattern("list filter( _ => true )".parseTerm, { case Filter(_, _) => })
+      assertMatches("list filter( _ => true )".parseTerm) { case Filter(_, _) => true }
     }
 
     test("should match with a filter call (block with one argument)") {
-      assertMatchPattern("list.filter { _ => true }".parseTerm, { case Filter(_, _) => })
+      assertMatches("list.filter { _ => true }".parseTerm) { case Filter(_, _) => true }
     }
 
     test("should match with an infix filter call (block with one argument)") {
-      assertMatchPattern("list filter { _ => true }".parseTerm, { case Filter(_, _) => })
+      assertMatches("list filter { _ => true }".parseTerm) { case Filter(_, _) => true }
     }
 
     test("should match with a filter call (partial function)") {
-      assertMatchPattern("list.filter { case Foo(a, b) => true }".parseTerm, { case Filter(_, _) => })
+      assertMatches("list.filter { case Foo(a, b) => true }".parseTerm) { case Filter(_, _) => true }
     }
 
     test("should match with an infix filter call (partial function)") {
-      assertMatchPattern("list filter { case Foo(a, b) => true }".parseTerm, { case Filter(_, _) => })
+      assertMatches("list filter { case Foo(a, b) => true }".parseTerm) { case Filter(_, _) => true }
     }
 
     test("should match with a filter call (aux function)") {
-      assertMatchPattern("list.filter(isBig)".parseTerm, { case Filter(_, _) => })
+      assertMatches("list.filter(isBig)".parseTerm) { case Filter(_, _) => true }
     }
 
     test("should match with an infix filter call (aux function)") {
-      assertMatchPattern("list filter(isBig)".parseTerm, { case Filter(_, _) => })
+      assertMatches("list filter(isBig)".parseTerm) { case Filter(_, _) => true }
     }
 
     test("should not match with an infix filter call (non arguments)") {
-      assertNotMatchPattern("list filter()".parseTerm, { case Filter(_, _) => })
+      assertNoMatches("list filter()".parseTerm) { case Filter(_, _) => true }
     }
 
     test("should not match with a filter call (more than one argument)") {
-      assertNotMatchPattern("list.filter((foo, bar) => true)".parseTerm, { case Filter(_, _) => })
+      assertNoMatches("list.filter((foo, bar) => true)".parseTerm) { case Filter(_, _) => true }
     }
 
     test("should not match with an infix filter call (more than one argument)") {
-      assertNotMatchPattern("list filter((foo, bar) => true)".parseTerm, { case Filter(_, _) => })
+      assertNoMatches("list filter((foo, bar) => true)".parseTerm) { case Filter(_, _) => true }
     }
 
     test("should not match with a filter call (more than one argument) 2") {
-      assertNotMatchPattern("list.filter(foo, bar)".parseTerm, { case Filter(_, _) => })
+      assertNoMatches("list.filter(foo, bar)".parseTerm) { case Filter(_, _) => true }
     }
 
     test("should not match with an infix filter call (more than one argument) 2") {
-      assertNotMatchPattern("list filter(foo, bar)".parseTerm, { case Filter(_, _) => })
+      assertNoMatches("list filter(foo, bar)".parseTerm) { case Filter(_, _) => true }
     }
 
     test("should not match with a filter call (block more than one argument)") {
-      assertNotMatchPattern("list.filter { (foo, bar) => true }".parseTerm, { case Filter(_, _) => })
+      assertNoMatches("list.filter { (foo, bar) => true }".parseTerm) { case Filter(_, _) => true }
     }
 
     test("should not match with a filter property") {
-      assertNotMatchPattern("foo.filter".parseTerm, { case Filter(_, _) => })
+      assertNoMatches("foo.filter".parseTerm) { case Filter(_, _) => true }
     }
 
     test("should not match with an infix filter property") {
-      assertNotMatchPattern("foo filter".parseTerm, { case Filter(_, _) => })
+      assertNoMatches("foo filter".parseTerm) { case Filter(_, _) => true }
     }
 
     test("should not match with a filter import") {
-      assertNotMatchPattern("import foo.bar.filter.baz".parseStat, { case Filter(_, _) => })
+      assertNoMatches("import foo.bar.filter.baz".parseStat) { case Filter(_, _) => true }
     }
 
     test("should not match with a filter variable") {
-      assertNotMatchPattern("filter.foo".parseTerm, { case Filter(_, _) => })
+      assertNoMatches("filter.foo".parseTerm) { case Filter(_, _) => true }
     }
 
     test("should match exists to Exists") {
-      assertMatchPattern("list.exists(_ == 1)".parseTerm, { case Exists(_, _) => })
+      assertMatches("list.exists(_ == 1)".parseTerm) { case Exists(_, _) => true }
     }
 
     test("should match forall to Forall") {
-      assertMatchPattern("list.forall(_ == 1)".parseTerm, { case Forall(_, _) => })
+      assertMatches("list.forall(_ == 1)".parseTerm) { case Forall(_, _) => true }
     }
 
     test("should match take to Take") {
-      assertMatchPattern("list.take(1)".parseTerm, { case Take(_, _) => })
+      assertMatches("list.take(1)".parseTerm) { case Take(_, _) => true }
     }
 
     test("should match drop to Drop") {
-      assertMatchPattern("list.drop(1)".parseTerm, { case Drop(_, _) => })
+      assertMatches("list.drop(1)".parseTerm) { case Drop(_, _) => true }
     }
 
     test("should match takeRight to TakeRight") {
-      assertMatchPattern("list.takeRight(1)".parseTerm, { case TakeRight(_, _) => })
+      assertMatches("list.takeRight(1)".parseTerm) { case TakeRight(_, _) => true }
     }
 
     test("should match dropRight to DropRight") {
-      assertMatchPattern("list.dropRight(1)".parseTerm, { case DropRight(_, _) => })
+      assertMatches("list.dropRight(1)".parseTerm) { case DropRight(_, _) => true }
     }
 
     test("should match takeWhile to TakeWhile") {
-      assertMatchPattern("list.takeWhile(_ < 2)".parseTerm, { case TakeWhile(_, _) => })
+      assertMatches("list.takeWhile(_ < 2)".parseTerm) { case TakeWhile(_, _) => true }
     }
 
     test("should match dropWhile to DropWhile") {
-      assertMatchPattern("list.dropWhile(_ < 2)".parseTerm, { case DropWhile(_, _) => })
+      assertMatches("list.dropWhile(_ < 2)".parseTerm) { case DropWhile(_, _) => true }
     }
   }
 
   describe("NoArgMethodExpression") {
     test("should not match with an isEmpty call (one argument)") {
-      assertNotMatchPattern("list.isEmpty( arg )".parseTerm, { case IsEmpty(_, _) => })
+      assertNoMatches("list.isEmpty( arg )".parseTerm) { case IsEmpty(_, _) => true }
     }
 
     test("should not match with an isEmpty call (block with one argument)") {
-      assertNotMatchPattern("list.isEmpty { arg }".parseTerm, { case IsEmpty(_, _) => })
+      assertNoMatches("list.isEmpty { arg }".parseTerm) { case IsEmpty(_, _) => true }
     }
 
     test("should not match with an isEmpty call (partial function)") {
-      assertNotMatchPattern("list.isEmpty { case Foo(a, b) => true }".parseTerm, { case IsEmpty(_, _) => })
+      assertNoMatches("list.isEmpty { case Foo(a, b) => true }".parseTerm) { case IsEmpty(_, _) => true }
     }
 
     test("should not match with an isEmpty call (aux function)") {
-      assertNotMatchPattern("list.isEmpty(isBig)".parseTerm, { case IsEmpty(_, _) => })
+      assertNoMatches("list.isEmpty(isBig)".parseTerm) { case IsEmpty(_, _) => true }
     }
 
     test("should not match with an isEmpty call (non arguments)") {
-      assertNotMatchPattern("list.isEmpty()".parseTerm, { case IsEmpty(_, _) => })
+      assertNoMatches("list.isEmpty()".parseTerm) { case IsEmpty(_, _) => true }
     }
 
     test("should not match with an isEmpty call (more than one argument)") {
-      assertNotMatchPattern("list.isEmpty((foo, bar) => true)".parseTerm, { case IsEmpty(_, _) => })
+      assertNoMatches("list.isEmpty((foo, bar) => true)".parseTerm) { case IsEmpty(_, _) => true }
     }
 
     test("should not match with an isEmpty call (block more than one argument)") {
-      assertNotMatchPattern("list.isEmpty { (foo, bar) => true }".parseTerm, { case IsEmpty(_, _) => })
+      assertNoMatches("list.isEmpty { (foo, bar) => true }".parseTerm) { case IsEmpty(_, _) => true }
     }
 
     test("should match with an isEmpty property") {
-      assertMatchPattern("foo.isEmpty".parseTerm, { case IsEmpty(_, _) => })
+      assertMatches("foo.isEmpty".parseTerm) { case IsEmpty(_, _) => true }
     }
 
     test("should not match with an isEmpty import") {
-      assertNotMatchPattern("import foo.bar.isEmpty.baz".parseStat, { case IsEmpty(_, _) => })
+      assertNoMatches("import foo.bar.isEmpty.baz".parseStat) { case IsEmpty(_, _) => true }
     }
 
     test("should not match with an isEmpty variable") {
-      assertNotMatchPattern("isEmpty.foo".parseTerm, { case IsEmpty(_, _) => })
+      assertNoMatches("isEmpty.foo".parseTerm) { case IsEmpty(_, _) => true }
     }
   }
 }

--- a/modules/core/src/test/scala/stryker4s/mutation/MutationTypesTest.scala
+++ b/modules/core/src/test/scala/stryker4s/mutation/MutationTypesTest.scala
@@ -7,78 +7,75 @@ import scala.meta.*
 class MutationTypesTest extends Stryker4sSuite {
   describe("EqualityOperator") {
     test("> to GreaterThan") {
-      assertMatchPattern(Term.Name(">"), { case GreaterThan(_) => })
+      assertMatches(Term.Name(">")) { case GreaterThan(_) => true }
     }
 
     test(">= to GreaterThanEqualTo") {
-      assertMatchPattern(Term.Name(">="), { case GreaterThanEqualTo(_) => })
+      assertMatches(Term.Name(">=")) { case GreaterThanEqualTo(_) => true }
     }
 
     test("<= to LesserThanEqualTo") {
-      assertMatchPattern(Term.Name("<="), { case LesserThanEqualTo(_) => })
+      assertMatches(Term.Name("<=")) { case LesserThanEqualTo(_) => true }
     }
 
     test("< to LesserThan") {
-      assertMatchPattern(Term.Name("<"), { case LesserThan(_) => })
+      assertMatches(Term.Name("<")) { case LesserThan(_) => true }
     }
 
     test("== to EqualTo") {
-      assertMatchPattern(Term.Name("=="), { case EqualTo(_) => })
+      assertMatches(Term.Name("==")) { case EqualTo(_) => true }
     }
 
     test("!= to NotEqualTo") {
-      assertMatchPattern(Term.Name("!="), { case NotEqualTo(_) => })
+      assertMatches(Term.Name("!=")) { case NotEqualTo(_) => true }
     }
   }
 
   describe("BooleanLiteral") {
     test("false to False") {
-      assertMatchPattern(Lit.Boolean(false), { case False(_) => })
+      assertMatches(Lit.Boolean(false)) { case False(_) => true }
     }
 
     test("true to True") {
-      assertMatchPattern(Lit.Boolean(true), { case True(_) => })
+      assertMatches(Lit.Boolean(true)) { case True(_) => true }
     }
   }
 
   describe("LogicalOperator") {
     test("&& to And") {
-      assertMatchPattern(Term.Name("&&"), { case And(_) => })
+      assertMatches(Term.Name("&&")) { case And(_) => true }
     }
 
     test("|| to Or") {
-      assertMatchPattern(Term.Name("||"), { case Or(_) => })
+      assertMatches(Term.Name("||")) { case Or(_) => true }
     }
   }
 
   describe("StringLiteral") {
     test("foo string to NonEmptyString") {
-      assertMatchPattern(Lit.String("foo"), { case NonEmptyString(_) => })
+      assertMatches(Lit.String("foo")) { case NonEmptyString(_) => true }
     }
 
     test("empty string to EmptyString") {
-      assertMatchPattern(Lit.String(""), { case EmptyString(_) => })
+      assertMatches(Lit.String("")) { case EmptyString(_) => true }
     }
 
     test("string interpolation to StringInterpolation") {
-      assertMatchPattern(
-        Term.Interpolate(Term.Name("s"), List(Lit.String("foo "), Lit.String("")), List(Term.Name("foo"))),
-        { case StringInterpolation(_) => }
-      )
+      assertMatches(
+        Term.Interpolate(Term.Name("s"), List(Lit.String("foo "), Lit.String("")), List(Term.Name("foo")))
+      ) { case StringInterpolation(_) => true }
     }
 
     test("q interpolation should not match StringInterpolation") {
-      assertNotMatchPattern(
-        Term.Interpolate(Term.Name("q"), List(Lit.String("foo "), Lit.String("")), List(Term.Name("foo"))),
-        { case StringInterpolation(_) => }
-      )
+      assertNoMatches(
+        Term.Interpolate(Term.Name("q"), List(Lit.String("foo "), Lit.String("")), List(Term.Name("foo")))
+      ) { case StringInterpolation(_) => true }
     }
 
     test("t interpolation should not match StringInterpolation") {
-      assertNotMatchPattern(
-        Term.Interpolate(Term.Name("t"), List(Lit.String("scala.util.matching.Regex")), List.empty),
-        { case StringInterpolation(_) => }
-      )
+      assertNoMatches(
+        Term.Interpolate(Term.Name("t"), List(Lit.String("scala.util.matching.Regex")), List.empty)
+      ) { case StringInterpolation(_) => true }
     }
   }
 

--- a/modules/core/src/test/scala/stryker4s/report/AggregateReporterTest.scala
+++ b/modules/core/src/test/scala/stryker4s/report/AggregateReporterTest.scala
@@ -41,10 +41,10 @@ class AggregateReporterTest extends Stryker4sIOSuite with LogMatchers with TestD
       Stream(MutantTestedEvent(1), MutantTestedEvent(2))
         .through(sut.mutantTested)
         .compile
-        .drain *> IO.cede >> {
-        assertLoggedError("Reporter failed to report, java.lang.RuntimeException: Something happened")
-        reporter1.mutantTestedCalls.assert(_.length == 2)
-      }
+        .drain *> IO.cede
+        .assertLoggedError(
+          "Reporter failed to report, java.lang.RuntimeException: Something happened"
+        ) >> reporter1.mutantTestedCalls.assert(_.length == 2)
     }
   }
 
@@ -92,8 +92,9 @@ class AggregateReporterTest extends Stryker4sIOSuite with LogMatchers with TestD
         val sut = new AggregateReporter(List(consoleReporterStub, reporter1))
 
         sut.onRunFinished(runReport) >>
-          consoleReporterStub.onRunFinishedCalls.assert(_.length == 1) >>
-          IO(assertNotLoggedWarn("Reporter failed to report"))
+          consoleReporterStub.onRunFinishedCalls
+            .assert(_.length == 1)
+            .assertNotLoggedWarn("Reporter failed to report")
       }
     }
   }

--- a/modules/core/src/test/scala/stryker4s/report/ConsoleReporterTest.scala
+++ b/modules/core/src/test/scala/stryker4s/report/ConsoleReporterTest.scala
@@ -16,19 +16,23 @@ class ConsoleReporterTest extends Stryker4sIOSuite with LogMatchers {
     test("should log progress") {
       val sut = new ConsoleReporter()
 
-      mutantTestedStream(2).through(sut.mutantTested).compile.drain.asserting { _ =>
-        assertLoggedInfo("Tested mutant 1/2 (50%)")
-        assertLoggedInfo("Tested mutant 2/2 (100%)")
-      }
+      mutantTestedStream(2)
+        .through(sut.mutantTested)
+        .compile
+        .drain
+        .assertLoggedInfo("Tested mutant 1/2 (50%)")
+        .assertLoggedInfo("Tested mutant 2/2 (100%)")
     }
 
     test("should round decimal numbers") {
       val sut = new ConsoleReporter()
 
-      mutantTestedStream(3).through(sut.mutantTested).compile.drain.asserting { _ =>
-        assertLoggedInfo("Tested mutant 1/3 (33%)")
-        assertLoggedInfo("Tested mutant 3/3 (100%)")
-      }
+      mutantTestedStream(3)
+        .through(sut.mutantTested)
+        .compile
+        .drain
+        .assertLoggedInfo("Tested mutant 1/3 (33%)")
+        .assertLoggedInfo("Tested mutant 3/3 (100%)")
     }
     def mutantTestedStream(size: Int) = Stream.constant(()).take(size.toLong).as(MutantTestedEvent(size))
   }
@@ -51,16 +55,15 @@ class ConsoleReporterTest extends Stryker4sIOSuite with LogMatchers {
       val metrics = Metrics.calculateMetrics(results)
       sut
         .onRunFinished(FinishedRunEvent(results, metrics, 15.seconds, config.baseDir))
-        .asserting { _ =>
-          assertLoggedInfo("Mutation run finished! Took 15 seconds")
-          assertLoggedInfo(s"Total mutants: ${Cyan("1")}, detected: ${Green("1")}, undetected: ${Red("0")}")
-          assertLoggedDebug(s"""Detected mutants:
-                               |0. [${Magenta("Killed")}] [${LightGray("BinaryOperator")}]
-                               |${Blue("stryker4s.scala")}:${Yellow("1")}:${Yellow("2")}
-                               |${Red("-\t!=")}
-                               |${Green("+\t==")}
-                               |""".stripMargin)
-        }
+        .assertLoggedInfo("Mutation run finished! Took 15 seconds")
+        .assertLoggedInfo(s"Total mutants: ${Cyan("1")}, detected: ${Green("1")}, undetected: ${Red("0")}")
+        .assertLoggedDebug(s"""Detected mutants:
+                              |0. [${Magenta("Killed")}] [${LightGray("BinaryOperator")}]
+                              |${Blue("stryker4s.scala")}:${Yellow("1")}:${Yellow("2")}
+                              |${Red("-\t!=")}
+                              |${Green("+\t==")}
+                              |""".stripMargin)
+
     }
 
     test("should report a finished run with multiple mutants") {
@@ -87,21 +90,19 @@ class ConsoleReporterTest extends Stryker4sIOSuite with LogMatchers {
       val metrics = Metrics.calculateMetrics(results)
       sut
         .onRunFinished(FinishedRunEvent(results, metrics, 1.minute, config.baseDir))
-        .asserting { _ =>
-          assertLoggedInfo("Mutation run finished! Took 1 minute")
-          assertLoggedInfo(s"Total mutants: ${Cyan("3")}, detected: ${Green("1")}, undetected: ${Red("2")}")
-          assertLoggedInfo(s"""Undetected mutants:
-                              |0. [${Magenta("Survived")}] [${LightGray("BinaryOperator")}]
-                              |${Blue("stryker4s.scala")}:${Yellow("1")}:${Yellow("1")}
-                              |${Red("-\t<")}
-                              |${Green("+\t>")}
-                              |
-                              |2. [${Magenta("Survived")}] [${LightGray("BinaryOperator")}]
-                              |${Blue("subPath/stryker4s.scala")}:${Yellow("1")}:${Yellow("1")}
-                              |${Red("-\t1")}
-                              |${Green("+\t0")}
-                              |""".stripMargin)
-        }
+        .assertLoggedInfo("Mutation run finished! Took 1 minute")
+        .assertLoggedInfo(s"Total mutants: ${Cyan("3")}, detected: ${Green("1")}, undetected: ${Red("2")}")
+        .assertLoggedInfo(s"""Undetected mutants:
+                             |0. [${Magenta("Survived")}] [${LightGray("BinaryOperator")}]
+                             |${Blue("stryker4s.scala")}:${Yellow("1")}:${Yellow("1")}
+                             |${Red("-\t<")}
+                             |${Green("+\t>")}
+                             |
+                             |2. [${Magenta("Survived")}] [${LightGray("BinaryOperator")}]
+                             |${Blue("subPath/stryker4s.scala")}:${Yellow("1")}:${Yellow("1")}
+                             |${Red("-\t1")}
+                             |${Green("+\t0")}
+                             |""".stripMargin)
     }
 
     test("should log mutants sorted by id") {
@@ -133,25 +134,23 @@ class ConsoleReporterTest extends Stryker4sIOSuite with LogMatchers {
       )
       sut
         .onRunFinished(FinishedRunEvent(results, Metrics.calculateMetrics(results), 15.seconds, config.baseDir))
-        .asserting { _ =>
-          assertLoggedInfo(s"Total mutants: ${Cyan("3")}, detected: ${Green("0")}, undetected: ${Red("3")}")
-          assertLoggedInfo(s"""Undetected mutants:
-                              |0. [${Magenta("Survived")}] [${LightGray("BinaryOperator")}]
-                              |${Blue("stryker4s.scala")}:${Yellow("1")}:${Yellow("1")}
-                              |${Red("-\t<")}
-                              |${Green("+\t>")}
-                              |
-                              |1. [${Magenta("Survived")}] [${LightGray("BinaryOperator")}]
-                              |${Blue("stryker4s.scala")}:${Yellow("1")}:${Yellow("2")}
-                              |${Red("-\t!=")}
-                              |${Green("+\t==")}
-                              |
-                              |2. [${Magenta("Survived")}] [${LightGray("BinaryOperator")}]
-                              |${Blue("subPath/stryker4s.scala")}:${Yellow("1")}:${Yellow("1")}
-                              |${Red("-\t1")}
-                              |${Green("+\t0")}
-                              |""".stripMargin)
-        }
+        .assertLoggedInfo(s"Total mutants: ${Cyan("3")}, detected: ${Green("0")}, undetected: ${Red("3")}")
+        .assertLoggedInfo(s"""Undetected mutants:
+                             |0. [${Magenta("Survived")}] [${LightGray("BinaryOperator")}]
+                             |${Blue("stryker4s.scala")}:${Yellow("1")}:${Yellow("1")}
+                             |${Red("-\t<")}
+                             |${Green("+\t>")}
+                             |
+                             |1. [${Magenta("Survived")}] [${LightGray("BinaryOperator")}]
+                             |${Blue("stryker4s.scala")}:${Yellow("1")}:${Yellow("2")}
+                             |${Red("-\t!=")}
+                             |${Green("+\t==")}
+                             |
+                             |2. [${Magenta("Survived")}] [${LightGray("BinaryOperator")}]
+                             |${Blue("subPath/stryker4s.scala")}:${Yellow("1")}:${Yellow("1")}
+                             |${Red("-\t1")}
+                             |${Green("+\t0")}
+                             |""".stripMargin)
     }
 
     test("should report two line mutants properly") {
@@ -177,14 +176,12 @@ class ConsoleReporterTest extends Stryker4sIOSuite with LogMatchers {
       val metrics = Metrics.calculateMetrics(results)
       sut
         .onRunFinished(FinishedRunEvent(results, metrics, 15.seconds, config.baseDir))
-        .asserting { _ =>
-          assertLoggedInfo(s"""Undetected mutants:
-                              |0. [${Magenta("Survived")}] [${LightGray("StringLiteral")}]
-                              |${Blue("stryker4s.scala")}:${Yellow("2")}:${Yellow("1")}
-                              |${Red("-\tbar\n\tbaz")}
-                              |${Green("+\tqux\n\tfoo")}
-                              |""".stripMargin)
-        }
+        .assertLoggedInfo(s"""Undetected mutants:
+                             |0. [${Magenta("Survived")}] [${LightGray("StringLiteral")}]
+                             |${Blue("stryker4s.scala")}:${Yellow("2")}:${Yellow("1")}
+                             |${Red("-\tbar\n\tbaz")}
+                             |${Green("+\tqux\n\tfoo")}
+                             |""".stripMargin)
     }
 
     test("should report multiline mutants properly") {
@@ -210,15 +207,13 @@ class ConsoleReporterTest extends Stryker4sIOSuite with LogMatchers {
       val metrics = Metrics.calculateMetrics(results)
       sut
         .onRunFinished(FinishedRunEvent(results, metrics, 15.seconds, config.baseDir))
-        .asserting { _ =>
-          assertLoggedInfo(s"Total mutants: ${Cyan("1")}, detected: ${Green("0")}, undetected: ${Red("1")}")
-          assertLoggedInfo(s"""Undetected mutants:
-                              |0. [${Magenta("Survived")}] [${LightGray("StringLiteral")}]
-                              |${Blue("stryker4s.scala")}:${Yellow("1")}:${Yellow("2")}
-                              |${Red("-\too\n\tbar\n\tbaz")}
-                              |${Green("+\tux\n\tqux\n\tfoo")}
-                              |""".stripMargin)
-        }
+        .assertLoggedInfo(s"Total mutants: ${Cyan("1")}, detected: ${Green("0")}, undetected: ${Red("1")}")
+        .assertLoggedInfo(s"""Undetected mutants:
+                             |0. [${Magenta("Survived")}] [${LightGray("StringLiteral")}]
+                             |${Blue("stryker4s.scala")}:${Yellow("1")}:${Yellow("2")}
+                             |${Red("-\too\n\tbar\n\tbaz")}
+                             |${Green("+\tux\n\tqux\n\tfoo")}
+                             |""".stripMargin)
     }
 
     test("should round decimal mutation scores") {
@@ -243,9 +238,8 @@ class ConsoleReporterTest extends Stryker4sIOSuite with LogMatchers {
         .onRunFinished(
           FinishedRunEvent(threeReport, Metrics.calculateMetrics(threeReport), 15.seconds, config.baseDir)
         )
-        .asserting { _ =>
-          assertLoggedInfo(s"Mutation score: ${Green("66.67")}%")
-        }
+        .assertLoggedInfo(s"Mutation score: ${Green("66.67")}%")
+
     }
 
     test("should log NaN correctly as n/a") {
@@ -266,9 +260,7 @@ class ConsoleReporterTest extends Stryker4sIOSuite with LogMatchers {
 
       sut
         .onRunFinished(FinishedRunEvent(report, Metrics.calculateMetrics(report), 15.seconds, config.baseDir))
-        .asserting { _ =>
-          assertLoggedInfo(s"Mutation score: ${LightGray("n/a")}")
-        }
+        .assertLoggedInfo(s"Mutation score: ${LightGray("n/a")}")
     }
 
     // 1 killed, 1 survived, mutation score 50
@@ -308,9 +300,7 @@ class ConsoleReporterTest extends Stryker4sIOSuite with LogMatchers {
 
       sut
         .onRunFinished(FinishedRunEvent(report, metrics, 15.seconds, config.baseDir))
-        .asserting { _ =>
-          assertLoggedInfo(s"Mutation score: ${Green("50.0")}%")
-        }
+        .assertLoggedInfo(s"Mutation score: ${Green("50.0")}%")
     }
 
     test("should report the mutation score when it is warning") {
@@ -320,9 +310,7 @@ class ConsoleReporterTest extends Stryker4sIOSuite with LogMatchers {
 
       sut
         .onRunFinished(FinishedRunEvent(report, metrics, 15.seconds, config.baseDir))
-        .asserting { _ =>
-          assertLoggedWarn(s"Mutation score: ${Yellow("50.0")}%")
-        }
+        .assertLoggedWarn(s"Mutation score: ${Yellow("50.0")}%")
     }
 
     test("should report the mutation score when it is dangerously low") {
@@ -332,10 +320,8 @@ class ConsoleReporterTest extends Stryker4sIOSuite with LogMatchers {
 
       sut
         .onRunFinished(FinishedRunEvent(report, metrics, 15.seconds, config.baseDir))
-        .asserting { _ =>
-          assertLoggedError("Mutation score dangerously low! Below the low threshold of 51%")
-          assertLoggedError(s"Mutation score: ${Red("50.0")}%")
-        }
+        .assertLoggedError("Mutation score dangerously low! Below the low threshold of 51%")
+        .assertLoggedError(s"Mutation score: ${Red("50.0")}%")
     }
 
     test("should log when below threshold") {
@@ -345,9 +331,7 @@ class ConsoleReporterTest extends Stryker4sIOSuite with LogMatchers {
 
       sut
         .onRunFinished(FinishedRunEvent(report, metrics, 15.seconds, config.baseDir))
-        .asserting { _ =>
-          assertLoggedError(s"Mutation score below threshold! Mutation score: ${Red("50.0")}%. Threshold: 51%")
-        }
+        .assertLoggedError(s"Mutation score below threshold! Mutation score: ${Red("50.0")}%. Threshold: 51%")
     }
 
     test("should log covered code if it is different to the total") {
@@ -357,9 +341,7 @@ class ConsoleReporterTest extends Stryker4sIOSuite with LogMatchers {
 
       sut
         .onRunFinished(FinishedRunEvent(reportWithNoCoverage, metricsWithNoCoverage, 15.seconds, config.baseDir))
-        .asserting { _ =>
-          assertLoggedWarn(s"Mutation score: ${Yellow("33.33")}% (of total), ${Green("50.0")}% (of covered code)")
-        }
+        .assertLoggedWarn(s"Mutation score: ${Yellow("33.33")}% (of total), ${Green("50.0")}% (of covered code)")
     }
 
     test("should warn when mutation score is n/a") {
@@ -381,14 +363,13 @@ class ConsoleReporterTest extends Stryker4sIOSuite with LogMatchers {
         .onRunFinished(
           FinishedRunEvent(allIgnoredReport, Metrics.calculateMetrics(allIgnoredReport), 15.seconds, config.baseDir)
         )
-        .asserting { _ =>
-          assertLoggedWarn(
-            "It looks like no mutations were actually tested. This could indicate that the test runner is not set up correctly, or that all mutants are excluded from coverage."
-          )
-          assertLoggedWarn(
-            "You can enable 'log-test-runner-stdout' in your configuration to see test runner output. See https://stryker-mutator.io/docs/stryker4s/configuration/ for more information."
-          )
-        }
+        .assertLoggedWarn(
+          "It looks like no mutations were actually tested. This could indicate that the test runner is not set up correctly, or that all mutants are excluded from coverage."
+        )
+        .assertLoggedWarn(
+          "You can enable 'log-test-runner-stdout' in your configuration to see test runner output. See https://stryker-mutator.io/docs/stryker4s/configuration/ for more information."
+        )
+
     }
 
     test("should warn when all mutants survived") {
@@ -411,14 +392,12 @@ class ConsoleReporterTest extends Stryker4sIOSuite with LogMatchers {
         .onRunFinished(
           FinishedRunEvent(allSurvivedReport, Metrics.calculateMetrics(allSurvivedReport), 15.seconds, config.baseDir)
         )
-        .asserting { _ =>
-          assertLoggedWarn(
-            "None of the mutations were detected. This may indicate that your tests are not running, or that the test assertions are too weak to catch mutations."
-          )
-          assertLoggedWarn(
-            "You can enable 'log-test-runner-stdout' in your configuration to see test runner output. See https://stryker-mutator.io/docs/stryker4s/configuration/ for more information."
-          )
-        }
+        .assertLoggedWarn(
+          "None of the mutations were detected. This may indicate that your tests are not running, or that the test assertions are too weak to catch mutations."
+        )
+        .assertLoggedWarn(
+          "You can enable 'log-test-runner-stdout' in your configuration to see test runner output. See https://stryker-mutator.io/docs/stryker4s/configuration/ for more information."
+        )
     }
   }
 }

--- a/modules/core/src/test/scala/stryker4s/report/DashboardReporterTest.scala
+++ b/modules/core/src/test/scala/stryker4s/report/DashboardReporterTest.scala
@@ -84,9 +84,7 @@ class DashboardReporterTest extends Stryker4sIOSuite with LogMatchers with Circe
 
       sut
         .onRunFinished(runReport)
-        .asserting { _ =>
-          assertLoggedInfo("Sent report to dashboard. Available at https://hrefHere.com")
-        }
+        .assertLoggedInfo("Sent report to dashboard. Available at https://hrefHere.com")
     }
 
     test("log when not being able to resolve dashboard config") {
@@ -97,11 +95,9 @@ class DashboardReporterTest extends Stryker4sIOSuite with LogMatchers with Circe
 
       sut
         .onRunFinished(runReport)
-        .asserting { _ =>
-          assertLoggedWarn(
-            s"Could not resolve dashboard configuration key(s) '${Bold.On("fooConfigKey")}', '${Bold.On("barConfigKey")}'. Not sending report."
-          )
-        }
+        .assertLoggedWarn(
+          s"Could not resolve dashboard configuration key(s) '${Bold.On("fooConfigKey")}', '${Bold.On("barConfigKey")}'. Not sending report."
+        )
     }
 
     test("should log when a response can't be parsed to a href") {
@@ -112,11 +108,9 @@ class DashboardReporterTest extends Stryker4sIOSuite with LogMatchers with Circe
 
       sut
         .onRunFinished(runReport)
-        .asserting { _ =>
-          assertLoggedWarn(
-            "Dashboard report was sent successfully, but could not decode the response: 'some other response'. Error:"
-          )
-        }
+        .assertLoggedWarn(
+          "Dashboard report was sent successfully, but could not decode the response: 'some other response'. Error:"
+        )
     }
 
     test("should log when a 401 is returned by the API") {
@@ -130,12 +124,10 @@ class DashboardReporterTest extends Stryker4sIOSuite with LogMatchers with Circe
 
       sut
         .onRunFinished(runReport)
-        .asserting { _ =>
-          assertLoggedError(
-            s"Error HTTP PUT 'Unauthorized'. Status code ${Red("401 Unauthorized")}. Did you provide the correct api key in the '${Bold
-                .On("STRYKER_DASHBOARD_API_KEY")}' environment variable?"
-          )
-        }
+        .assertLoggedError(
+          s"Error HTTP PUT 'Unauthorized'. Status code ${Red("401 Unauthorized")}. Did you provide the correct api key in the '${Bold
+              .On("STRYKER_DASHBOARD_API_KEY")}' environment variable?"
+        )
     }
 
     test("should log when a error code is returned by the API") {
@@ -149,11 +141,9 @@ class DashboardReporterTest extends Stryker4sIOSuite with LogMatchers with Circe
 
       sut
         .onRunFinished(runReport)
-        .asserting { _ =>
-          assertLoggedError(
-            s"Failed to PUT report to dashboard. Response status code: ${Red("500")}. Response body: 'Internal Server Error'"
-          )
-        }
+        .assertLoggedError(
+          s"Failed to PUT report to dashboard. Response status code: ${Red("500")}. Response body: 'Internal Server Error'"
+        )
     }
   }
 

--- a/modules/core/src/test/scala/stryker4s/report/HtmlReporterTest.scala
+++ b/modules/core/src/test/scala/stryker4s/report/HtmlReporterTest.scala
@@ -25,7 +25,7 @@ class HtmlReporterTest extends Stryker4sIOSuite with LogMatchers {
 
       assertNoDiff(
         result,
-        """      app.report = {"$schema":"https://git.io/mutation-testing-schema","schemaVersion":"2","thresholds":{"high":100,"low":0},"files":{}};"""
+        """app.report = {"$schema":"https://git.io/mutation-testing-schema","schemaVersion":"2","thresholds":{"high":100,"low":0},"files":{}};"""
       )
     }
 
@@ -113,9 +113,7 @@ class HtmlReporterTest extends Stryker4sIOSuite with LogMatchers {
 
       sut
         .onRunFinished(FinishedRunEvent(report, metrics, 10.seconds, fileLocation))
-        .asserting { _ =>
-          assertLoggedInfo(s"Written HTML report to ${(fileLocation / "index.html").toString}")
-        }
+        .assertLoggedInfo(s"Written HTML report to ${(fileLocation / "index.html").toString}")
     }
 
     test("should open the report when openReport is true") {
@@ -161,9 +159,8 @@ class HtmlReporterTest extends Stryker4sIOSuite with LogMatchers {
 
       sut
         .onRunFinished(FinishedRunEvent(report, metrics, 10.seconds, fileLocation)) >>
-        desktopIOStub.openCalls.asserting { _ =>
-          assertLoggedError("Error opening report in browser")
-        }
+        desktopIOStub.openCalls
+          .assertLoggedError("Error opening report in browser")
     }
   }
 }

--- a/modules/core/src/test/scala/stryker4s/run/MutantRunnerTest.scala
+++ b/modules/core/src/test/scala/stryker4s/run/MutantRunnerTest.scala
@@ -174,11 +174,12 @@ class MutantRunnerTest extends Stryker4sIOSuite with LogMatchers with TestData {
     val mutatedFile = MutatedFile(file, "def foo = 4".parseDef, mutants)
 
     sut(Vector(mutatedFile)) *>
-      Files[IO].exists(staticTmpDir).assertEquals(true).asserting { _ =>
-        assertLoggedInfo(
+      Files[IO]
+        .exists(staticTmpDir)
+        .assert
+        .assertLoggedInfo(
           s"Not deleting $staticTmpDir (turn off cleanTmpDir to disable this). Please clean it up manually."
         )
-      }
   }
 
   test("should debug log timing when a mutant is tested") {
@@ -193,10 +194,9 @@ class MutantRunnerTest extends Stryker4sIOSuite with LogMatchers with TestData {
     val mutants = NonEmptyVector.one(mutant)
     val mutatedFile = MutatedFile(file, "def foo = 4".parseDef, mutants)
 
-    sut(Vector(mutatedFile)).asserting { _ =>
-      assertLoggedDebug(s"Running mutant $mutant")
-      assertLoggedDebug("Mutant 1 tested in")
-    }
+    sut(Vector(mutatedFile))
+      .assertLoggedDebug(s"Running mutant $mutant")
+      .assertLoggedDebug("Mutant 1 tested in")
   }
 
   test("should warn when all mutants have no code coverage") {

--- a/modules/core/src/test/scala/stryker4s/run/ResourcePoolTest.scala
+++ b/modules/core/src/test/scala/stryker4s/run/ResourcePoolTest.scala
@@ -23,7 +23,7 @@ class ResourcePoolTest extends Stryker4sIOSuite {
               isClosed.get.assertEquals(false)
           } >>
           // After pool `Resource` is closed
-          isClosed.get.assertEquals(true)
+          isClosed.get.assert
       }
     }
   }

--- a/modules/core/src/test/scala/stryker4s/run/TestRunnerTest.scala
+++ b/modules/core/src/test/scala/stryker4s/run/TestRunnerTest.scala
@@ -5,6 +5,7 @@ import cats.syntax.all.*
 import fansi.Color.*
 import mutationtesting.{MutantResult, MutantStatus}
 import stryker4s.config.Config
+import stryker4s.extension.DurationExtensions.HumanReadableExtension
 import stryker4s.model.{
   InitialTestRunCoverageReport,
   InitialTestRunResult,
@@ -48,10 +49,10 @@ class TestRunnerTest extends Stryker4sIOSuite with LogMatchers with TestData {
           _ <- sut.use(_.initialTestRun())
         } yield timeout
 
-        op.flatMap(_.tryGet).asserting { setTimeout =>
-          assertEquals(setTimeout.value, (reportedTimeout * 1.5) + config.timeout)
-          assertLoggedInfo(s"Timeout set to 8 seconds (${LightGray("net 2 seconds")})")
-        }
+        op.flatMap(_.tryGet)
+          .map(_.value.duration)
+          .assertEquals((reportedTimeout * 1.5) + config.timeout)
+          .assertLoggedInfo(s"Timeout set to 8 seconds (${LightGray("net 2 seconds")})")
       }
 
       test("should not log the timeout setting if timeout has already been completed") {
@@ -62,9 +63,7 @@ class TestRunnerTest extends Stryker4sIOSuite with LogMatchers with TestData {
           _ <- sut.use(_.initialTestRun())
         } yield timeout
 
-        op.asserting { _ =>
-          assertNotLoggedInfo("Timeout set to ")
-        }
+        op.assertNotLoggedInfo("Timeout set to ")
       }
     }
 
@@ -80,13 +79,11 @@ class TestRunnerTest extends Stryker4sIOSuite with LogMatchers with TestData {
           result <- sut.use(_.runMutant(mutant, coverageTestNames))
         } yield result
 
-        op.asserting { result =>
-          assertEquals(
-            result,
+        op
+          .assertEquals(
             mutant.toMutantResult(MutantStatus.Timeout, statusReason = "Timeout of 1 millisecond exceeded.".some)
           )
-          assertLoggedDebug(s"Mutant ${mutant.id} timed out after 1 millisecond")
-        }
+          .assertLoggedDebug(s"Mutant ${mutant.id} timed out after 1 millisecond")
       }
 
       test("should recreate the inner resource after a timeout") {

--- a/modules/testkit/src/main/scala/stryker4s/testkit/LogMatchers.scala
+++ b/modules/testkit/src/main/scala/stryker4s/testkit/LogMatchers.scala
@@ -1,5 +1,6 @@
 package stryker4s.testkit
 
+import cats.effect.IO
 import fansi.Attr
 import fansi.Color.*
 import munit.{BaseFunSuite, Location, Suite, TestTransforms}
@@ -49,6 +50,27 @@ protected[stryker4s] trait LogMatchers extends Suite with TestTransforms {
   def assertNotLoggedInfo(msg: String)(implicit loc: Location): Unit = findForLevel(Level.Info, msg).assertFailure()
   def assertNotLoggedWarn(msg: String)(implicit loc: Location): Unit = findForLevel(Level.Warn, msg).assertFailure()
   def assertNotLoggedError(msg: String)(implicit loc: Location): Unit = findForLevel(Level.Error, msg).assertFailure()
+
+  // Extensions to assert logging after a `IO[A]`
+  implicit class LogAssertionsForIOOps[A](io: IO[A]) {
+    def assertLoggedDebug(msg: String)(implicit loc: Location): IO[Unit] =
+      io *> IO(findForLevel(Level.Debug, msg).assertSuccess())
+    def assertLoggedInfo(msg: String)(implicit loc: Location): IO[Unit] =
+      io *> IO(findForLevel(Level.Info, msg).assertSuccess())
+    def assertLoggedWarn(msg: String)(implicit loc: Location): IO[Unit] =
+      io *> IO(findForLevel(Level.Warn, msg).assertSuccess())
+    def assertLoggedError(msg: String)(implicit loc: Location): IO[Unit] =
+      io *> IO(findForLevel(Level.Error, msg).assertSuccess())
+
+    def assertNotLoggedDebug(msg: String)(implicit loc: Location): IO[Unit] =
+      io *> IO(findForLevel(Level.Debug, msg).assertFailure())
+    def assertNotLoggedInfo(msg: String)(implicit loc: Location): IO[Unit] =
+      io *> IO(findForLevel(Level.Info, msg).assertFailure())
+    def assertNotLoggedWarn(msg: String)(implicit loc: Location): IO[Unit] =
+      io *> IO(findForLevel(Level.Warn, msg).assertFailure())
+    def assertNotLoggedError(msg: String)(implicit loc: Location): IO[Unit] =
+      io *> IO(findForLevel(Level.Error, msg).assertFailure())
+  }
 
   private def findForLevel(expectedLogLevel: Level, expectedLogMessage: String) = {
     testLogger.findEvent(expectedLogMessage) match {

--- a/modules/testkit/src/main/scala/stryker4s/testkit/Stryker4sSuite.scala
+++ b/modules/testkit/src/main/scala/stryker4s/testkit/Stryker4sSuite.scala
@@ -42,11 +42,14 @@ sealed trait Stryker4sAssertions {
     )
   }
 
-  def assertMatchPattern[A](obtained: A, matchFn: PartialFunction[Any, Unit])(implicit loc: Location): Unit =
-    assert(matchFn.isDefinedAt(obtained), s"Expected $obtained to match pattern")
-
-  def assertNotMatchPattern[A <: Any](obtained: A, matchFn: PartialFunction[Any, Unit])(implicit loc: Location): Unit =
-    assert(!matchFn.isDefinedAt(obtained), s"Expected $obtained to not match pattern")
+  /** Inverse of munit's `assertMatches`: asserts the partial function does not match (it's either undefined for the
+    * value, or defined but returns false).
+    */
+  def assertNoMatches[A](value: A, clue: => String = "assertion failed")(
+      predicate: PartialFunction[A, Boolean]
+  )(implicit loc: Location): Unit =
+    if (predicate.applyOrElse(value, (_: A) => false))
+      fail(s"$clue: predicate matched value: $value")
 
   implicit class EitherValues[A, B](either: Either[A, B]) {
 


### PR DESCRIPTION
- **chore: refactor `collectWithContext` to use `cats.data.State`**
- **chore: refactor scala.meta.Tree `isEqual` extension to `cats.Eq`**
- **chore: minor cats refactoring combinators**
- **chore: replace `assertMatchPattern` with MUnit `assertMatches`**
- **chore: add log assertions on IO**
