### PR TITLE
fix(testrunner): create new framework instance for each run (fixing Weaver compatibility)

### DIFF
--- a/modules/testRunner/src/main/scala/stryker4s/package.scala
+++ b/modules/testRunner/src/main/scala/stryker4s/package.scala
@@ -2,8 +2,9 @@ import stryker4s.model.MutantId
 import stryker4s.testrunner.TestInterfaceMapper
 import stryker4s.testrunner.api.{CoverageTestNameMap, TestDefinition, TestFile, TestFileId}
 
+import java.util.Collections
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReference}
-import java.util.concurrent.{ConcurrentLinkedQueue, TimeUnit}
+import java.util.concurrent.{ConcurrentHashMap, TimeUnit}
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration.FiniteDuration
 
@@ -15,7 +16,7 @@ package object stryker4s {
 
     /** We have no idea how tests will run their code, so the coverage analysis needs to be able to handle concurrency
       */
-    private val mutantCoverage = TrieMap.empty[MutantId, ConcurrentLinkedQueue[TestFileId]]
+    private val mutantCoverage = TrieMap.empty[MutantId, java.util.Set[TestFileId]]
 
     private val tests = TrieMap.empty[TestFileId, TestFile]
 
@@ -32,11 +33,10 @@ package object stryker4s {
         val currentTest = activeTest.get
         if (currentTest.value != -1) {
           ids.foreach { id =>
-            val currentCovered = mutantCoverage.getOrElseUpdate(MutantId(id), new ConcurrentLinkedQueue())
-            if (!currentCovered.contains(currentTest)) {
-              currentCovered.add(currentTest)
-              ()
-            }
+            val currentCovered =
+              mutantCoverage.getOrElseUpdate(MutantId(id), Collections.newSetFromMap(new ConcurrentHashMap()))
+            currentCovered.add(currentTest)
+            ()
           }
         }
       }
@@ -50,8 +50,9 @@ package object stryker4s {
       if (collectCoverage.get()) {
         val currentTestId = activeTest.get
         synchronized {
-          val test = tests(currentTestId)
-          tests.update(currentTestId, test.addDefinitions(definition))
+          tests.get(currentTestId).foreach { test =>
+            tests.update(currentTestId, test.addDefinitions(definition))
+          }
         }
       }
 
@@ -65,8 +66,8 @@ package object stryker4s {
       if (collectCoverage.get()) {
         val testId = TestFileId(testIds.getAndIncrement())
         val test = TestFile(testName, Seq.empty)
-        activeTest.set(testId)
         tests.update(testId, test)
+        activeTest.set(testId)
       }
 
     /** Collect coverage analysis during the provided function and return it in a tuple

--- a/modules/testRunner/src/main/scala/stryker4s/testrunner/TestRunner.scala
+++ b/modules/testRunner/src/main/scala/stryker4s/testrunner/TestRunner.scala
@@ -18,44 +18,55 @@ private[stryker4s] case class TestRunResult(status: Status, testsCompleted: Int,
 
 class SbtTestInterfaceRunner(context: TestProcessContext) extends TestRunner with TestInterfaceMapper {
 
-  val testFunctions: Option[(MutantId, Seq[String])] => TestRunResult = {
-    val tasks = {
-      val cl = getClass().getClassLoader()
-      context.testGroups.flatMap { testGroup =>
+  private val classLoader = getClass().getClassLoader()
+
+  /** Create a new Test framework instance, create task definitions (filtered for coverage), and runs the tests for a
+    * mutation (or the initial test-run when `mutation` is `None`).
+    */
+  private def runTestFunction(mutation: Option[(MutantId, Seq[String])]): TestRunResult = {
+    val testsCompleted = new AtomicInteger(0)
+    val statusRef = new AtomicReference[Status](Status.Success)
+    val failedTestsRef = new AtomicReference[Seq[FailedTestDefinition]](Vector.empty)
+
+    val eventHandler = mutation match {
+      case Some(_) => new MutantRunEventHandler(statusRef, testsCompleted, failedTestsRef)
+      case None    => new InitialTestRunEventHandler(statusRef)
+    }
+
+    mutation.foreach { case (mutantId, _) => stryker4s.activeMutation = mutantId.value }
+
+    val coveredTestNames: Option[Set[String]] = mutation.map(_._2.toSet)
+
+    context.testGroups.foreach { testGroup =>
+      val taskDefs =
+        testGroup.taskDefs.filter(td => coveredTestNames.forall(_.contains(td.fullyQualifiedName)))
+
+      // Skip running if there are no tests to run, or if another test group has already failed
+      if (taskDefs.nonEmpty && statusRef.get() != Status.Failure && statusRef.get() != Status.Error) {
         val RunnerOptions(args, remoteArgs) = testGroup.runnerOptions.get
-        val framework = cl.loadClass(testGroup.frameworkClass).getConstructor().newInstance().asInstanceOf[Framework]
-        val runner = framework.runner(args.toArray, remoteArgs.toArray, cl)
-        runner.tasks(testGroup.taskDefs.map(toSbtTaskDef).toArray)
+        val framework =
+          classLoader.loadClass(testGroup.frameworkClass).getConstructor().newInstance().asInstanceOf[Framework]
+        val runner = framework.runner(args.toArray, remoteArgs.toArray, classLoader)
+        try {
+          val tasks = runner.tasks(taskDefs.map(toSbtTaskDef).toArray)
+          val _ = runTests(tasks.toIndexedSeq, statusRef, eventHandler)
+        } finally {
+          // Signal the framework that the run is done so it can release any (background) resources it allocated.
+          val doneMessage = runner.done()
+          if (doneMessage.nonEmpty) println(doneMessage)
+        }
       }
     }
-    (mutation: Option[(MutantId, Seq[String])]) => {
-      val tasksToRun = mutation match {
-        case Some((_, testNames)) =>
-          tasks.filter(t => testNames.contains(t.taskDef().fullyQualifiedName()))
-        case None => tasks
-      }
-      val testsCompleted = new AtomicInteger(0)
-      val statusRef = new AtomicReference[Status](Status.Success)
-      val failedTestsRef = new AtomicReference[Seq[FailedTestDefinition]](Vector.empty)
 
-      val eventHandler = mutation match {
-        case Some(_) => new MutantRunEventHandler(statusRef, testsCompleted, failedTestsRef)
-        case None    => new InitialTestRunEventHandler(statusRef)
-      }
-
-      mutation.foreach { case (mutantId, _) => stryker4s.activeMutation = mutantId.value }
-      val status = runTests(tasksToRun, statusRef, eventHandler)
-
-      TestRunResult(status, testsCompleted.get(), failedTestsRef.get())
-    }
+    TestRunResult(statusRef.get(), testsCompleted.get(), failedTestsRef.get())
   }
 
   override def runMutation(mutation: MutantId, testNames: Seq[String]): TestRunResult = {
-    testFunctions(Some((mutation, testNames)))
+    runTestFunction(Some((mutation, testNames)))
   }
 
   override def initialTestRun(): TestRunResult = {
-    testFunctions(None)
+    runTestFunction(None)
   }
 
   private def runTests(


### PR DESCRIPTION
Instantiate a new `Framework` and `Runner` for each test run instead of reusing the same instances. Some test frameworks (e.g. Weaver) produce single-use tasks. Reusing the tasks would hang forever.

Also properly call `.done` on the `Runner` after to close any resources.
