### PR TITLE
feat(report): support ANSII escape codes in report

### DIFF
--- a/modules/core/src/main/scala/stryker4s/run/testrunner/ProcessTestRunner.scala
+++ b/modules/core/src/main/scala/stryker4s/run/testrunner/ProcessTestRunner.scala
@@ -64,12 +64,7 @@ class ProcessTestRunner(testProcess: TestRunnerConnection) extends TestRunner {
     NonEmptyList
       .fromList(
         failedTests
-          .flatMap(test =>
-            test.message.map(msg =>
-              // TODO: change `.plainText` to `.render` when mutation-testing-elements supports rendering ansi-codes https://github.com/stryker-mutator/mutation-testing-elements/issues/2925
-              fansi.Str(test.name, ": ", msg).plainText
-            )
-          )
+          .flatMap(test => test.message.map(msg => fansi.Str(test.name, ": ", msg).render))
           .toList
       )
       .map(_.mkString_("\n\n"))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -42,9 +42,9 @@ object Dependencies {
 
     val mill = "1.1.7"
 
-    val mutationTestingElements = "3.8.4"
+    val mutationTestingElements = "3.9.0"
 
-    val mutationTestingMetrics = "3.8.4"
+    val mutationTestingMetrics = "3.9.0"
 
     val scalameta = "4.17.3"
 


### PR DESCRIPTION
<img width="3414" height="2148" alt="image" src="https://github.com/user-attachments/assets/0930c30e-bb45-4682-8197-733cd075a706" />
