### PR TITLE
feat: support custom mutators

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ lazy val root = rootProject
     // Publish to .m2 folder for Maven plugin testing
     addCommandAlias(
       "publishM2Local",
-      "set ThisBuild / version := \"SET-BY-SBT-SNAPSHOT\"; core/publishM2; testkit/publishM2"
+      "set ThisBuild / version := \"SET-BY-SBT-SNAPSHOT\"; mutatorApi/publishM2; core/publishM2; testkit/publishM2"
     ),
     // Publish to .ivy folder for command runner local testing
     addCommandAlias(

--- a/build.sbt
+++ b/build.sbt
@@ -31,8 +31,14 @@ lazy val root = rootProject
   .autoAggregate
 
 lazy val core = (projectMatrix in file("modules") / "core")
-  .settings(commonSettings, coreSettings, publishLocalDependsOn(api, testRunnerApi, testRunner))
-  .dependsOn(api, testRunnerApi, testkit % Test)
+  .settings(commonSettings, coreSettings, publishLocalDependsOn(api, testRunnerApi, mutatorApi, testRunner))
+  .dependsOn(api, testRunnerApi, mutatorApi, testkit % Test)
+  .jvmPlatform(scalaVersions = versions.crossScalaVersions)
+
+// Public SPI for custom mutators, depended on by both `core` and third-party mutator authors
+lazy val mutatorApi = (projectMatrix in file("modules") / "mutatorApi")
+  .settings(commonSettings, mutatorApiSettings)
+  .dependsOn(testkit % Test)
   .jvmPlatform(scalaVersions = versions.crossScalaVersions)
 
 lazy val commandRunner = (projectMatrix in file("modules") / "commandRunner")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -172,7 +172,47 @@ With `excluded-mutations`, you can turn off certain mutations in the project. Al
 - `StringLiteral`
 - `MethodExpression`
 
-### `thresholds` (`object`)
+### `custom-mutators` (`Seq[String]`)
+
+**Config file:** `custom-mutators: ["com.example.MyCustomMutator"]`  
+**Sbt:** `strykerCustomMutators := Seq("com.example.MyCustomMutator")`  
+**Mill:** `override def strykerCustomMutators = Some(Seq("com.example.MyCustomMutator"))`  
+**Maven:** `<config><custom-mutators><custom-mutator>com.example.MyCustomMutator</custom-mutator></custom-mutators></config>`  
+**CLI:** `--custom-mutators com.example.MyCustomMutator`  
+**Default value:** `[]`
+
+With `custom-mutators`, you can register additional, project-specific mutators alongside
+Stryker4s's built-in ones. Each entry is the fully-qualified class name of a class implementing
+`stryker4s.mutatorapi.CustomMutator` (from the `stryker4s-mutator-api` artifact), with a public
+no-argument constructor. The class must be present on the project's own compile/test classpath —
+Stryker4s does not fetch or compile it for you.
+
+```scala
+// build.sbt
+libraryDependencies += "io.stryker-mutator" %% "stryker4s-mutator-api" % strykerVersion % Provided
+strykerCustomMutators := Seq("com.example.ArithmeticOperatorMutator")
+```
+
+```scala
+// com/example/ArithmeticOperatorMutator.scala
+package com.example
+
+import stryker4s.mutatorapi.*
+
+class ArithmeticOperatorMutator extends CustomMutator {
+  def matcher: MutationMatcher = {
+    // Match a scalameta Tree and return Either[IgnoredMutations, Mutations] describing the
+    // mutated replacement(s) for that node.
+    case ???
+  }
+}
+```
+
+A custom mutator's replacement(s) must always produce code that still compiles alongside the
+built-in mutants for the same statement (mutation switching compiles every mutant for a given
+line into one pattern match) — the same constraint the built-in mutators already satisfy.
+
+
 
 **Config file:** `thresholds{ high=80, low=60, break=0 }`  
 **Sbt:** `strykerThresholdsHigh := 80; strykerThresholdsLow := 60; strykerThresholdsBreak := 0`  

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -231,6 +231,24 @@ inner `expr.foo` selection emits **two** mutants for one combinator. The second 
 selection and leaves the argument list behind — `IO(a / b)(_ => IO.pure(0))` — which cannot
 compile. Keep the applied and no-argument method names in disjoint sets.
 
+#### Dropping a selection needs a parent guard; renaming one does not
+
+Disjoint name sets are not quite enough for a mutator that *drops* a selection, because a
+no-argument method can still be applied explicitly: `xs.sorted(ordering)`,
+`code.toLowerCase(locale)`. The inner `xs.sorted` selection matches, and dropping it strands the
+argument list as `xs(ordering)`. Guard against being the function of an enclosing call:
+
+```scala
+private def isAppliedTo(term: Term): Boolean =
+  term.parent.exists {
+    case Term.Apply.After_4_6_0(fun, _) => fun eq term
+    case _                              => false
+  }
+```
+
+A mutator that only *renames* a selection — `.head` to `.last`, say — needs no such guard, since
+`xs.last(i)` compiles exactly as `xs.head(i)` does.
+
 A custom mutator's replacement(s) must always produce code that still compiles alongside the
 built-in mutants for the same statement (mutation switching compiles every mutant for a given
 line into one pattern match) — the same constraint the built-in mutators already satisfy.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -197,22 +197,45 @@ strykerCustomMutators := Seq("com.example.ArithmeticOperatorMutator")
 // com/example/ArithmeticOperatorMutator.scala
 package com.example
 
+import cats.data.NonEmptyVector
 import stryker4s.mutatorapi.*
+
+import scala.meta.*
 
 class ArithmeticOperatorMutator extends CustomMutator {
   def matcher: MutationMatcher = {
-    // Match a scalameta Tree and return Either[IgnoredMutations, Mutations] describing the
-    // mutated replacement(s) for that node.
-    case ???
+    case term @ Term.ApplyInfix.After_4_6_0(_, op @ Term.Name("+"), _, _) =>
+      placeableTree =>
+        val mutated = term.copy(op = op.copy(value = "-"))
+        val metadata = MutantMetadata("+", "-", "ArithmeticOperator", term.pos, None)
+        Right(NonEmptyVector.one(MutatedCode(placeableTree.substitute(term, mutated), metadata)))
   }
 }
 ```
+
+#### Returning the whole statement, not just the replacement
+
+A matcher usually matches a small sub-term, but a `MutatedCode` must carry the **entire placeable
+statement** with the mutation applied in place. `PlaceableTree.substitute(original, replacement)`
+does that for you, and is what the built-in mutators use.
+
+Returning the bare replacement instead happens to work when the matched term *is* the whole
+placeable statement, and silently produces mutants that do not compile otherwise. Matching the
+`IO.sleep(d)` inside `IO.sleep(d).as(q).timeout(l)` and returning `IO.unit` yields the statement
+`IO.unit`, where `IO.unit.as(q).timeout(l)` was intended.
+
+#### Match one node per mutation
+
+Stryker4s visits every node in the tree, so a matcher that accepts both `expr.foo(arg)` and its
+inner `expr.foo` selection emits **two** mutants for one combinator. The second drops only the
+selection and leaves the argument list behind — `IO(a / b)(_ => IO.pure(0))` — which cannot
+compile. Keep the applied and no-argument method names in disjoint sets.
 
 A custom mutator's replacement(s) must always produce code that still compiles alongside the
 built-in mutants for the same statement (mutation switching compiles every mutant for a given
 line into one pattern match) — the same constraint the built-in mutators already satisfy.
 
-
+#### thresholds
 
 **Config file:** `thresholds{ high=80, low=60, break=0 }`  
 **Sbt:** `strykerThresholdsHigh := 80; strykerThresholdsLow := 60; strykerThresholdsBreak := 0`  

--- a/maven/src/main/scala/stryker4s/maven/MavenConfigSource.scala
+++ b/maven/src/main/scala/stryker4s/maven/MavenConfigSource.scala
@@ -42,6 +42,8 @@ class MavenConfigSource[F[_]](project: MavenProject) extends ConfigSource[F] wit
   override def excludedMutations: ConfigValue[F, Seq[ExcludedMutation]] =
     notSupported
 
+  override def customMutators: ConfigValue[F, Seq[String]] = notSupported
+
   override def thresholdsHigh: ConfigValue[F, Int] = notSupported
 
   override def thresholdsLow: ConfigValue[F, Int] = notSupported

--- a/maven/src/main/scala/stryker4s/maven/Stryker4sMavenRunner.scala
+++ b/maven/src/main/scala/stryker4s/maven/Stryker4sMavenRunner.scala
@@ -38,6 +38,19 @@ class Stryker4sMavenRunner(
 
   override def extraConfigSources: List[ConfigSource[IO]] = List(new MavenConfigSource[IO](project))
 
+  /** Builds a classloader from the project's compile classpath so `--custom-mutators` classes (and their dependencies,
+    * e.g. `stryker4s-mutator-api`) can be reflectively loaded from wherever the user's project puts them, while keeping
+    * Stryker4s's own classloader as the parent. Parent-first delegation ensures `stryker4s.mutatorapi.*` classes always
+    * resolve to Stryker4s's own copy (satisfying `CustomMutatorLoader`'s `isAssignableFrom` check) rather than a second
+    * copy loaded from the project's own classpath (which would also include `stryker4s-mutator-api` as a compile-time
+    * dependency of the custom mutator), avoiding a classloader-identity mismatch analogous to the one found in the
+    * sbt/Mill runners.
+    */
+  override def customMutatorClassLoader: ClassLoader = {
+    val urls = project.getTestClasspathElements().asScala.map(Path(_).toNioPath.toUri.toURL).toArray
+    new java.net.URLClassLoader(urls, getClass.getClassLoader)
+  }
+
   override def resolveTestRunners(
       tmpDir: Path
   )(using config: Config): Either[NonEmptyList[CompilerErrMsg], NonEmptyList[Resource[IO, TestRunner]]] = {

--- a/modules/core/src/main/scala/stryker4s/config/Config.scala
+++ b/modules/core/src/main/scala/stryker4s/config/Config.scala
@@ -19,6 +19,7 @@ final case class Config(
     reporters: Seq[ReporterType],
     files: Seq[String],
     excludedMutations: Seq[ExcludedMutation],
+    customMutators: Seq[String],
     thresholds: Thresholds,
     dashboard: DashboardOptions,
     timeout: FiniteDuration,

--- a/modules/core/src/main/scala/stryker4s/config/ConfigLoader.scala
+++ b/modules/core/src/main/scala/stryker4s/config/ConfigLoader.scala
@@ -44,6 +44,7 @@ private class ConfigLoader[F[_]](source: ConfigSource[F]) extends CirisConfigDec
     source.reporters,
     source.files,
     source.excludedMutations,
+    source.customMutators,
     thresholds,
     dashboard,
     source.timeout,

--- a/modules/core/src/main/scala/stryker4s/config/codec/CirceConfigEncoder.scala
+++ b/modules/core/src/main/scala/stryker4s/config/codec/CirceConfigEncoder.scala
@@ -12,13 +12,14 @@ import scala.meta.Dialect
   */
 trait CirceConfigEncoder {
   implicit def configEncoder: Encoder[Config] = Encoder
-    .forProduct14(
+    .forProduct15(
       "mutate",
       "test-filter",
       "base-dir",
       "reporters",
       "files",
       "excluded-mutations",
+      "custom-mutators",
       "thresholds",
       "dashboard",
       "timeout",
@@ -35,6 +36,7 @@ trait CirceConfigEncoder {
         c.reporters,
         c.files,
         c.excludedMutations,
+        c.customMutators,
         c.thresholds,
         c.dashboard,
         c.timeout,

--- a/modules/core/src/main/scala/stryker4s/config/source/AggregateConfigSource.scala
+++ b/modules/core/src/main/scala/stryker4s/config/source/AggregateConfigSource.scala
@@ -34,6 +34,9 @@ class AggregateConfigSource[F[_]: Sync](sources: NonEmptyList[ConfigSource[F]])(
   override def excludedMutations: ConfigValue[F, Seq[ExcludedMutation]] =
     loadAndLog(_.excludedMutations)
 
+  override def customMutators: ConfigValue[F, Seq[String]] =
+    loadAndLog(_.customMutators)
+
   override def thresholdsHigh: ConfigValue[F, Int] = loadAndLog(_.thresholdsHigh)
   override def thresholdsLow: ConfigValue[F, Int] = loadAndLog(_.thresholdsLow)
   override def thresholdsBreak: ConfigValue[F, Int] = loadAndLog(_.thresholdsBreak)

--- a/modules/core/src/main/scala/stryker4s/config/source/CliConfigSource.scala
+++ b/modules/core/src/main/scala/stryker4s/config/source/CliConfigSource.scala
@@ -55,6 +55,9 @@ class CliConfigSource[F[_]](args: Seq[String]) extends ConfigSource[F] with Ciri
   override def excludedMutations: ConfigValue[F, Seq[ExcludedMutation]] =
     parseOpt(opts.excludedMutations).as[Seq[ExcludedMutation]]
 
+  override def customMutators: ConfigValue[F, Seq[String]] =
+    parseOpt(opts.customMutators)
+
   override def thresholdsHigh: ConfigValue[F, Int] = parseOpt(opts.thresholdsHigh)
   override def thresholdsLow: ConfigValue[F, Int] = parseOpt(opts.thresholdsLow)
   override def thresholdsBreak: ConfigValue[F, Int] = parseOpt(opts.thresholdsBreak)
@@ -119,6 +122,11 @@ class CliConfigSource[F[_]](args: Seq[String]) extends ConfigSource[F] with Ciri
     val excludedMutations =
       makeRepeatOpt[String](_.opt[String]('e', "excluded-mutations").text("The mutations to exclude."))
 
+    val customMutators =
+      makeRepeatOpt[String](
+        _.opt[String]("custom-mutators").text("Fully-qualified class names of custom mutators to load.")
+      )
+
     val thresholdsHigh = makeOpt[Int](_.opt[Int]("thresholds.high").text("The high threshold."))
     val thresholdsLow = makeOpt[Int](_.opt[Int]("thresholds.low").text("The low threshold."))
     val thresholdsBreak = makeOpt[Int](_.opt[Int]("thresholds.break").text("The break threshold."))
@@ -175,6 +183,7 @@ class CliConfigSource[F[_]](args: Seq[String]) extends ConfigSource[F] with Ciri
             asAnyP(reporters),
             asAnyP(files),
             asAnyP(excludedMutations),
+            asAnyP(customMutators),
             asAnyP(thresholdsHigh),
             asAnyP(thresholdsLow),
             asAnyP(thresholdsBreak),

--- a/modules/core/src/main/scala/stryker4s/config/source/ConfigSource.scala
+++ b/modules/core/src/main/scala/stryker4s/config/source/ConfigSource.scala
@@ -35,6 +35,11 @@ trait ConfigSource[+F[_]] {
 
   def excludedMutations: ConfigValue[F, Seq[ExcludedMutation]]
 
+  /** Fully-qualified class names of custom [[stryker4s.mutatorapi.CustomMutator]] implementations to load, in addition
+    * to the built-in mutators.
+    */
+  def customMutators: ConfigValue[F, Seq[String]]
+
   def thresholdsHigh: ConfigValue[F, Int]
   def thresholdsLow: ConfigValue[F, Int]
   def thresholdsBreak: ConfigValue[F, Int]

--- a/modules/core/src/main/scala/stryker4s/config/source/DefaultsConfigSource.scala
+++ b/modules/core/src/main/scala/stryker4s/config/source/DefaultsConfigSource.scala
@@ -39,6 +39,8 @@ class DefaultsConfigSource[F[_]]() extends ConfigSource[F] {
 
   override def excludedMutations: ConfigValue[F, Seq[ExcludedMutation]] = ConfigValue.default(Seq.empty)
 
+  override def customMutators: ConfigValue[F, Seq[String]] = ConfigValue.default(Seq.empty)
+
   override def thresholdsHigh: ConfigValue[F, Int] = ConfigValue.default(80)
 
   override def thresholdsLow: ConfigValue[F, Int] = ConfigValue.default(60)

--- a/modules/core/src/main/scala/stryker4s/config/source/FileConfigSource.scala
+++ b/modules/core/src/main/scala/stryker4s/config/source/FileConfigSource.scala
@@ -39,6 +39,9 @@ class FileConfigSource[F[_]](h: ConfigValue[F, Hocon.HoconAt])
   override def excludedMutations: ConfigValue[F, Seq[ExcludedMutation]] =
     read("excluded-mutations").as[Seq[ExcludedMutation]]
 
+  override def customMutators: ConfigValue[F, Seq[String]] =
+    read("custom-mutators").as[Seq[String]]
+
   override def thresholdsHigh: ConfigValue[F, Int] = read("thresholds.high").as[Int]
   override def thresholdsLow: ConfigValue[F, Int] = read("thresholds.low").as[Int]
   override def thresholdsBreak: ConfigValue[F, Int] = read("thresholds.break").as[Int]

--- a/modules/core/src/main/scala/stryker4s/exception/stryker4sException.scala
+++ b/modules/core/src/main/scala/stryker4s/exception/stryker4sException.scala
@@ -32,3 +32,18 @@ final case class UnableToFixCompilerErrorsException(errs: NonEmptyList[CompilerE
           .map(err => s"${err.path}: '${err.msg}'")
           .mkString_("\n")
     )
+
+final case class CustomMutatorClassNotFoundException(className: String)
+    extends Stryker4sException(
+      s"Could not find custom mutator class '$className'. Make sure it is fully-qualified and present on the project's classpath."
+    )
+
+final case class CustomMutatorNotAssignableException(className: String)
+    extends Stryker4sException(
+      s"Custom mutator class '$className' does not extend stryker4s.mutatorapi.CustomMutator."
+    )
+
+final case class CustomMutatorInstantiationException(className: String, cause: Throwable)
+    extends Stryker4sException(
+      s"Could not instantiate custom mutator class '$className'. It must have a public no-argument constructor. Cause: ${cause.getMessage}"
+    )

--- a/modules/core/src/main/scala/stryker4s/model/Mutant.scala
+++ b/modules/core/src/main/scala/stryker4s/model/Mutant.scala
@@ -1,11 +1,8 @@
 package stryker4s.model
 
 import cats.syntax.all.*
-import mutationtesting.{Location, MutantResult, MutantStatus}
-import stryker4s.extension.TreeExtensions.PositionExtension
+import mutationtesting.{MutantResult, MutantStatus}
 import stryker4s.testrunner.api.TestDefinitionId
-
-import scala.meta.{Position, Term}
 
 final case class MutantWithId(id: MutantId, mutatedCode: MutatedCode) {
   def toMutantResult(
@@ -27,37 +24,4 @@ final case class MutantWithId(id: MutantId, mutatedCode: MutatedCode) {
       coveredBy = coveredBy.map(_.map(_.toString)),
       killedBy = killedBy.map(_.map(_.toString))
     )
-}
-
-final case class MutatedCode(mutatedStatement: Term, metadata: MutantMetadata)
-
-/** Metadata of [[stryker4s.model.MutatedCode]]
-  *
-  * @param original
-  *   Original code
-  * @param replacement
-  *   Mutated replaced code
-  * @param mutatorName
-  *   Mutator category
-  * @param location
-  *   The location of the mutated code
-  */
-final case class MutantMetadata(
-    original: String,
-    replacement: String,
-    mutatorName: String,
-    location: Location,
-    description: Option[String]
-)
-
-object MutantMetadata {
-  def apply(
-      original: String,
-      replacement: String,
-      mutatorName: String,
-      position: Position,
-      description: Option[String]
-  ): MutantMetadata =
-    MutantMetadata(original, replacement, mutatorName, position.toLocation, description)
-
 }

--- a/modules/core/src/main/scala/stryker4s/model/package.scala
+++ b/modules/core/src/main/scala/stryker4s/model/package.scala
@@ -5,4 +5,24 @@ import mutationtesting.MutantResult
 
 package object model {
   type MutantResultsPerFile = Map[Path, Vector[MutantResult]]
+
+  // The types below now live in the public `stryker4s-mutator-api` module (`stryker4s.mutatorapi`), so that
+  // third-party custom mutators can depend on them without pulling in all of `core`. They're re-exported here
+  // (rather than moving every usage across `core`) to keep this a source-compatible relocation.
+  type PlaceableTree = stryker4s.mutatorapi.PlaceableTree
+  val PlaceableTree: stryker4s.mutatorapi.PlaceableTree.type = stryker4s.mutatorapi.PlaceableTree
+
+  type IgnoredMutationReason = stryker4s.mutatorapi.IgnoredMutationReason
+  val MutationExcluded: stryker4s.mutatorapi.MutationExcluded.type = stryker4s.mutatorapi.MutationExcluded
+  type RegexParseError = stryker4s.mutatorapi.RegexParseError
+  val RegexParseError: stryker4s.mutatorapi.RegexParseError.type = stryker4s.mutatorapi.RegexParseError
+  type NoRegexMutationsFound = stryker4s.mutatorapi.NoRegexMutationsFound
+  val NoRegexMutationsFound: stryker4s.mutatorapi.NoRegexMutationsFound.type =
+    stryker4s.mutatorapi.NoRegexMutationsFound
+
+  type MutantMetadata = stryker4s.mutatorapi.MutantMetadata
+  val MutantMetadata: stryker4s.mutatorapi.MutantMetadata.type = stryker4s.mutatorapi.MutantMetadata
+
+  type MutatedCode = stryker4s.mutatorapi.MutatedCode
+  val MutatedCode: stryker4s.mutatorapi.MutatedCode.type = stryker4s.mutatorapi.MutatedCode
 }

--- a/modules/core/src/main/scala/stryker4s/mutants/findmutants/CustomMutatorLoader.scala
+++ b/modules/core/src/main/scala/stryker4s/mutants/findmutants/CustomMutatorLoader.scala
@@ -1,0 +1,40 @@
+package stryker4s.mutants.findmutants
+
+import stryker4s.exception.{
+  CustomMutatorClassNotFoundException,
+  CustomMutatorInstantiationException,
+  CustomMutatorNotAssignableException
+}
+import stryker4s.mutatorapi.CustomMutator
+
+/** Reflectively instantiates [[stryker4s.mutatorapi.CustomMutator]]s configured via `Config.customMutators`.
+  */
+object CustomMutatorLoader {
+
+  /** Loads the given fully-qualified class names as [[stryker4s.mutatorapi.CustomMutator]] instances, using
+    * `classLoader` to resolve them.
+    *
+    * @throws stryker4s.exception.CustomMutatorClassNotFoundException
+    *   if a class name can not be found on `classLoader`
+    * @throws stryker4s.exception.CustomMutatorNotAssignableException
+    *   if a class does not extend [[stryker4s.mutatorapi.CustomMutator]]
+    * @throws stryker4s.exception.CustomMutatorInstantiationException
+    *   if a class can not be instantiated (e.g. no public no-argument constructor)
+    */
+  def load(classNames: Seq[String], classLoader: ClassLoader): List[CustomMutator] =
+    classNames.map(loadOne(_, classLoader)).toList
+
+  private def loadOne(className: String, classLoader: ClassLoader): CustomMutator = {
+    val clazz =
+      try classLoader.loadClass(className)
+      catch { case _: ClassNotFoundException => throw CustomMutatorClassNotFoundException(className) }
+
+    if (!classOf[CustomMutator].isAssignableFrom(clazz))
+      throw CustomMutatorNotAssignableException(className)
+
+    try clazz.getDeclaredConstructor().newInstance().asInstanceOf[CustomMutator]
+    catch {
+      case e: ReflectiveOperationException => throw CustomMutatorInstantiationException(className, e)
+    }
+  }
+}

--- a/modules/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
+++ b/modules/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
@@ -29,8 +29,11 @@ object MutantMatcher {
     *
     * If the result is a `Left`, it means a mutant was found, but ignored. The ADT
     * [[stryker4s.model.IgnoredMutationReason]] shows the possible reasons.
+    *
+    * Re-exported from the public `stryker4s-mutator-api` module, where third-party
+    * [[stryker4s.mutatorapi.CustomMutator]]s implement the same type.
     */
-  type MutationMatcher = PartialFunction[Tree, PlaceableTree => Either[IgnoredMutations, Mutations]]
+  type MutationMatcher = stryker4s.mutatorapi.MutationMatcher
 
 }
 

--- a/modules/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
+++ b/modules/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
@@ -9,6 +9,7 @@ import stryker4s.extension.TreeExtensions.{treeEq, PositionExtension}
 import stryker4s.model.*
 import stryker4s.mutants.tree.{IgnoredMutation, IgnoredMutations, Mutations}
 import stryker4s.mutation.*
+import stryker4s.mutatorapi.CustomMutator
 
 import scala.annotation.tailrec
 import scala.meta.*
@@ -34,6 +35,15 @@ object MutantMatcher {
     * [[stryker4s.mutatorapi.CustomMutator]]s implement the same type.
     */
   type MutationMatcher = stryker4s.mutatorapi.MutationMatcher
+
+  /** Combines a `MutationMatcher` with the matchers of any configured [[stryker4s.mutatorapi.CustomMutator]]s.
+    *
+    * Like `matchStringsAndRegex` below, matching is combined rather than short-circuited: if a custom mutator matches a
+    * tree that a built-in matcher (or another custom mutator) also matches, the mutations of both are combined instead
+    * of only the first match being used.
+    */
+  def withCustomMutators(matcher: MutationMatcher, customMutators: Seq[CustomMutator]): MutationMatcher =
+    customMutators.foldLeft(matcher)(_ combine _.matcher)
 
 }
 

--- a/modules/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
+++ b/modules/core/src/main/scala/stryker4s/mutants/findmutants/MutantMatcher.scala
@@ -2,10 +2,10 @@ package stryker4s.mutants.findmutants
 
 import cats.data.NonEmptyVector
 import cats.syntax.all.*
-import mutationtesting.cats.*
+
 import stryker4s.config.{Config, ExcludedMutation}
 import stryker4s.extension.PartialFunctionOps.*
-import stryker4s.extension.TreeExtensions.{treeEq, PositionExtension}
+import stryker4s.extension.TreeExtensions.PositionExtension
 import stryker4s.model.*
 import stryker4s.mutants.tree.{IgnoredMutation, IgnoredMutations, Mutations}
 import stryker4s.mutation.*
@@ -156,17 +156,6 @@ class MutantMatcherImpl()(implicit config: Config) extends MutantMatcher {
       replacements: NonEmptyVector[T],
       mutationToTerm: T => Term
   ): PlaceableTree => Either[IgnoredMutations, Mutations] = placeableTree => {
-    // Find the node to replace once, so each replacement only has to look it up by reference
-    val target = placeableTree.tree
-      .dfsCollectFirst {
-        case t if (t eq original) || (t.pos == original.pos && t === original) => t
-      }
-      .getOrElse(
-        throw new RuntimeException(
-          show"Could not transform '${original.text}' in ${placeableTree.tree.text} (${original.pos.toLocation})"
-        )
-      )
-
     val mutations = replacements.map { mutations =>
       val tree = mutationToTerm(mutations)
 
@@ -183,23 +172,8 @@ class MutantMatcherImpl()(implicit config: Config) extends MutantMatcher {
         location,
         description
       )
-      val transformer = new Transformer {
-        override protected def apply(t: Tree): Tree = if (t eq target) tree
-        else super.apply(t)
-      }
 
-      transformer.transform(placeableTree.tree) match {
-        case t if t eq placeableTree.tree =>
-          throw new RuntimeException(
-            show"Could not transform '${original.text}' in ${placeableTree.tree.text} (${metadata.location})"
-          )
-        case t: Term => MutatedCode(t, metadata)
-        case t       =>
-          throw new RuntimeException(
-            show"Could not transform '${original.text}' in ${placeableTree.tree.text} (${metadata.location}). Expected a Term, but was a ${t.getClass().getSimpleName}"
-          )
-      }
-
+      MutatedCode(placeableTree.substitute(original, tree), metadata)
     }
     filterExclusions(mutations, replacements.head, original)
 

--- a/modules/core/src/main/scala/stryker4s/mutants/tree/package.scala
+++ b/modules/core/src/main/scala/stryker4s/mutants/tree/package.scala
@@ -1,20 +1,18 @@
 package stryker4s.mutants
 
 import cats.data.{NonEmptyList, NonEmptyVector}
-import stryker4s.model.{IgnoredMutationReason, MutantWithId, MutatedCode, PlaceableTree}
+import stryker4s.model.MutantWithId
 
-import scala.meta.{Term, Tree}
+import scala.meta.Term
 
 package object tree {
 
-  type Mutations = NonEmptyVector[MutatedCode]
-
-  type IgnoredMutation = (MutatedCode, IgnoredMutationReason)
-  type IgnoredMutations = NonEmptyVector[IgnoredMutation]
+  // Re-exported from the public `stryker4s-mutator-api` module (see `stryker4s.model.package` for the same pattern)
+  type Mutations = stryker4s.mutatorapi.Mutations
+  type IgnoredMutation = stryker4s.mutatorapi.IgnoredMutation
+  type IgnoredMutations = stryker4s.mutatorapi.IgnoredMutations
 
   type MutantsWithId = NonEmptyVector[MutantWithId]
-
-  type MutationMatcher = PartialFunction[Tree, PlaceableTree => Mutations]
 
   type MutantCoverageTermFn = (NonEmptyList[Int]) => Term
 

--- a/modules/core/src/main/scala/stryker4s/run/Stryker4sRunner.scala
+++ b/modules/core/src/main/scala/stryker4s/run/Stryker4sRunner.scala
@@ -9,7 +9,7 @@ import stryker4s.config.source.ConfigSource
 import stryker4s.files.*
 import stryker4s.log.{Logger, SttpLogWrapper}
 import stryker4s.model.CompilerErrMsg
-import stryker4s.mutants.findmutants.{MutantFinder, MutantMatcherImpl}
+import stryker4s.mutants.findmutants.{CustomMutatorLoader, MutantFinder, MutantMatcher, MutantMatcherImpl}
 import stryker4s.mutants.tree.{InstrumenterOptions, MutantCollector, MutantInstrumenter}
 import stryker4s.mutants.{Mutator, TreeTraverserImpl}
 import stryker4s.report.*
@@ -35,11 +35,20 @@ abstract class Stryker4sRunner(implicit log: Logger) {
 
     val instrumenter = new MutantInstrumenter(instrumenterOptions)
 
+    val customMutators = CustomMutatorLoader.load(config.customMutators, customMutatorClassLoader)
+    val matcher: MutantMatcher.MutationMatcher =
+      MutantMatcher.withCustomMutators(new MutantMatcherImpl().allMatchers, customMutators)
+
     val stryker4s = new Stryker4s(
       GlobFileResolver.forMutate(),
       new Mutator(
         new MutantFinder(),
-        new MutantCollector(new TreeTraverserImpl(), new MutantMatcherImpl()),
+        new MutantCollector(
+          new TreeTraverserImpl(),
+          new MutantMatcher {
+            override def allMatchers: MutantMatcher.MutationMatcher = matcher
+          }
+        ),
         instrumenter
       ),
       new MutantRunner(
@@ -95,4 +104,9 @@ abstract class Stryker4sRunner(implicit log: Logger) {
   def instrumenterOptions(implicit config: Config): InstrumenterOptions
 
   def extraConfigSources: List[ConfigSource[IO]]
+
+  /** The `ClassLoader` used to reflectively load [[stryker4s.mutatorapi.CustomMutator]]s configured via
+    * `Config.customMutators`. Must be able to resolve classes on the target project's classpath.
+    */
+  def customMutatorClassLoader: ClassLoader = getClass.getClassLoader
 }

--- a/modules/core/src/test/scala/stryker4s/config/circe/ConfigEncoderTest.scala
+++ b/modules/core/src/test/scala/stryker4s/config/circe/ConfigEncoderTest.scala
@@ -18,7 +18,7 @@ class ConfigEncoderTest extends Stryker4sSuite with CirceConfigEncoder {
       s"""{"mutate":["**/main/scala/**.scala"],"test-filter":[],"base-dir":"${workspaceLocation.replace(
           "\\",
           "\\\\"
-        )}","reporters":["console","html"],"files":["**","!target/**","!project/**","!.metals/**","!.bloop/**","!.idea/**"],"excluded-mutations":[],"thresholds":{"high":80,"low":60,"break":0},"dashboard":{"base-url":"https://dashboard.stryker-mutator.io","report-type":"full"},"timeout":5000,"timeout-factor":1.5,"legacy-test-runner":false,"scala-dialect":"scala213source3","debug":{"log-test-runner-stdout":false,"debug-test-runner":false}}"""
+        )}","reporters":["console","html"],"files":["**","!target/**","!project/**","!.metals/**","!.bloop/**","!.idea/**"],"excluded-mutations":[],"custom-mutators":[],"thresholds":{"high":80,"low":60,"break":0},"dashboard":{"base-url":"https://dashboard.stryker-mutator.io","report-type":"full"},"timeout":5000,"timeout-factor":1.5,"legacy-test-runner":false,"scala-dialect":"scala213source3","debug":{"log-test-runner-stdout":false,"debug-test-runner":false}}"""
     )
   }
 
@@ -67,7 +67,7 @@ class ConfigEncoderTest extends Stryker4sSuite with CirceConfigEncoder {
       s"""{"mutate":["**/main/scala/**.scala"],"test-filter":["foo.scala"],"base-dir":"${workspaceLocation.replace(
           "\\",
           "\\\\"
-        )}","reporters":["console","html"],"files":["file.scala"],"excluded-mutations":["bar.scala"],"thresholds":{"high":80,"low":60,"break":0},"dashboard":{"base-url":"https://dashboard.stryker-mutator.io","report-type":"full","project":"myProject","version":"1.3.3.7","module":"myModule"},"timeout":5000,"timeout-factor":1.5,"max-test-runner-reuse":2,"legacy-test-runner":false,"scala-dialect":"scala213source3","debug":{"log-test-runner-stdout":true,"debug-test-runner":true}}"""
+        )}","reporters":["console","html"],"files":["file.scala"],"excluded-mutations":["bar.scala"],"custom-mutators":[],"thresholds":{"high":80,"low":60,"break":0},"dashboard":{"base-url":"https://dashboard.stryker-mutator.io","report-type":"full","project":"myProject","version":"1.3.3.7","module":"myModule"},"timeout":5000,"timeout-factor":1.5,"max-test-runner-reuse":2,"legacy-test-runner":false,"scala-dialect":"scala213source3","debug":{"log-test-runner-stdout":true,"debug-test-runner":true}}"""
     )
   }
 
@@ -87,6 +87,7 @@ class ConfigEncoderTest extends Stryker4sSuite with CirceConfigEncoder {
     "base-dir" -> fromString(workspaceLocation),
     "reporters" -> arr(fromString("console"), fromString("html")),
     "excluded-mutations" -> arr(),
+    "custom-mutators" -> arr(),
     "thresholds" -> obj(
       "high" -> fromInt(80),
       "low" -> fromInt(60),

--- a/modules/core/src/test/scala/stryker4s/exception/Stryker4sExceptionTest.scala
+++ b/modules/core/src/test/scala/stryker4s/exception/Stryker4sExceptionTest.scala
@@ -66,4 +66,26 @@ class Stryker4sExceptionTest extends Stryker4sSuite {
         |/src/main/scala/com/company/strykerTest/TestObj2.scala: 'yet another error with symbols $#'%%$~@1'""".stripMargin
     )
   }
+
+  test("CustomMutatorClassNotFoundException should have the correct message") {
+    assertNoDiff(
+      CustomMutatorClassNotFoundException("com.example.MyMutator").getMessage,
+      "Could not find custom mutator class 'com.example.MyMutator'. Make sure it is fully-qualified and present on the project's classpath."
+    )
+  }
+
+  test("CustomMutatorNotAssignableException should have the correct message") {
+    assertNoDiff(
+      CustomMutatorNotAssignableException("com.example.MyMutator").getMessage,
+      "Custom mutator class 'com.example.MyMutator' does not extend stryker4s.mutatorapi.CustomMutator."
+    )
+  }
+
+  test("CustomMutatorInstantiationException should have the correct message") {
+    val cause = new RuntimeException("no default constructor")
+    assertNoDiff(
+      CustomMutatorInstantiationException("com.example.MyMutator", cause).getMessage,
+      "Could not instantiate custom mutator class 'com.example.MyMutator'. It must have a public no-argument constructor. Cause: no default constructor"
+    )
+  }
 }

--- a/modules/core/src/test/scala/stryker4s/mutants/findmutants/CustomMutatorLoaderTest.scala
+++ b/modules/core/src/test/scala/stryker4s/mutants/findmutants/CustomMutatorLoaderTest.scala
@@ -1,0 +1,68 @@
+package stryker4s.mutants.findmutants
+
+import stryker4s.exception.{
+  CustomMutatorClassNotFoundException,
+  CustomMutatorInstantiationException,
+  CustomMutatorNotAssignableException
+}
+import stryker4s.mutatorapi.CustomMutator
+import stryker4s.testkit.Stryker4sSuite
+
+class CustomMutatorLoaderTest extends Stryker4sSuite {
+  private def classLoader = getClass.getClassLoader
+
+  test("load should instantiate a valid CustomMutator by fully-qualified class name") {
+    val result =
+      CustomMutatorLoader.load(Seq(classOf[CustomMutatorLoaderTestFixture].getName), classLoader)
+
+    assertEquals(result.length, 1)
+    assert(result.head.isInstanceOf[CustomMutatorLoaderTestFixture])
+  }
+
+  test("load should return an empty list when given no class names") {
+    assertEquals(CustomMutatorLoader.load(Seq.empty, classLoader), Nil)
+  }
+
+  test("load should instantiate multiple CustomMutators in order") {
+    val result = CustomMutatorLoader.load(
+      Seq(classOf[CustomMutatorLoaderTestFixture].getName, classOf[CustomMutatorLoaderTestFixture].getName),
+      classLoader
+    )
+
+    assertEquals(result.length, 2)
+  }
+
+  test("load should throw CustomMutatorClassNotFoundException for an unknown class name") {
+    intercept[CustomMutatorClassNotFoundException] {
+      CustomMutatorLoader.load(Seq("com.example.DoesNotExist"), classLoader)
+    }
+  }
+
+  test("load should throw CustomMutatorNotAssignableException for a class not extending CustomMutator") {
+    intercept[CustomMutatorNotAssignableException] {
+      CustomMutatorLoader.load(Seq(classOf[NotACustomMutatorFixture].getName), classLoader)
+    }
+  }
+
+  test("load should throw CustomMutatorInstantiationException for a class without a no-arg constructor") {
+    intercept[CustomMutatorInstantiationException] {
+      CustomMutatorLoader.load(Seq(classOf[NoNoArgConstructorFixture].getName), classLoader)
+    }
+  }
+}
+
+/** Fixture: a valid, no-arg-constructible [[CustomMutator]]. */
+class CustomMutatorLoaderTestFixture extends CustomMutator {
+  def matcher: stryker4s.mutatorapi.MutationMatcher = PartialFunction.empty
+}
+
+/** Fixture: a class that does not extend [[CustomMutator]]. */
+class NotACustomMutatorFixture
+
+/** Fixture: extends [[CustomMutator]] but has no no-argument constructor. */
+class NoNoArgConstructorFixture(unused: String) extends CustomMutator {
+  def matcher: stryker4s.mutatorapi.MutationMatcher = {
+    val _ = unused
+    PartialFunction.empty
+  }
+}

--- a/modules/core/src/test/scala/stryker4s/mutants/findmutants/MutantMatcherTest.scala
+++ b/modules/core/src/test/scala/stryker4s/mutants/findmutants/MutantMatcherTest.scala
@@ -1,12 +1,21 @@
 package stryker4s.mutants.findmutants
 
 import munit.Location
+import cats.data.NonEmptyVector
 import stryker4s.config.{Config, ExcludedMutation}
 import stryker4s.extension.TreeExtensions.FindExtension
-import stryker4s.model.{MutationExcluded, NoRegexMutationsFound, PlaceableTree, RegexParseError}
+import stryker4s.model.{
+  MutantMetadata,
+  MutatedCode,
+  MutationExcluded,
+  NoRegexMutationsFound,
+  PlaceableTree,
+  RegexParseError
+}
 import stryker4s.mutants.findmutants.MutantMatcher.MutationMatcher
 import stryker4s.mutants.tree.{IgnoredMutations, Mutations}
 import stryker4s.mutation.*
+import stryker4s.mutatorapi.CustomMutator
 import stryker4s.testkit.Stryker4sSuite
 
 import scala.meta.*
@@ -769,5 +778,38 @@ class MutantMatcherTest extends Stryker4sSuite {
 
     assertEquals(reason.pattern, "[[]]")
     assert(reason.message.contains("expectations:"))
+  }
+
+  test("withCustomMutators should add mutations from a custom mutator to the built-in matcher") {
+    val tree = "def foo = y <= 5".parseStat
+    val original = tree.find(Term.Name("<=")).value
+
+    val customMutator = new CustomMutator {
+      override def matcher: MutationMatcher = { case orig @ Term.Name("<=") =>
+        placeableTree =>
+          val target = placeableTree.tree.find(orig).value
+          val transformer = new Transformer {
+            override protected def apply(t: Tree): Tree =
+              if (t eq target) Term.Name("!=") else super.apply(t)
+          }
+          val mutatedStatement = transformer.transform(placeableTree.tree).asInstanceOf[Term]
+          Right(
+            NonEmptyVector.one(
+              MutatedCode(mutatedStatement, MutantMetadata(orig.value, "!=", "CustomNotEqual", orig.pos, None))
+            )
+          )
+      }
+    }
+
+    val combinedMatcher = MutantMatcher.withCustomMutators(sut.allMatchers, List(customMutator))
+
+    expectMutations(combinedMatcher, tree.asInstanceOf[Defn.Def], original, "y != 5".parseTerm)("CustomNotEqual")
+    // The built-in EqualityOperator mutations for `<=` should still be present alongside the custom one
+    expectMutations(combinedMatcher, tree.asInstanceOf[Defn.Def], original, "y < 5".parseTerm)("EqualityOperator")
+  }
+
+  test("withCustomMutators should return the original matcher unchanged when there are no custom mutators") {
+    val matcher = sut.allMatchers
+    assertEquals(MutantMatcher.withCustomMutators(matcher, Nil), matcher)
   }
 }

--- a/modules/mill/src/main/scala/stryker4s/mill/MillConfigSource.scala
+++ b/modules/mill/src/main/scala/stryker4s/mill/MillConfigSource.scala
@@ -21,6 +21,7 @@ class MillConfigSource[F[_]](
     testFilterValue: Option[Seq[String]],
     reportersValue: Option[Seq[String]],
     excludedMutationsValue: Option[Seq[String]],
+    customMutatorsValue: Option[Seq[String]],
     thresholdsHighValue: Option[Int],
     thresholdsLowValue: Option[Int],
     thresholdsBreakValue: Option[Int],
@@ -68,6 +69,9 @@ class MillConfigSource[F[_]](
 
   override def excludedMutations: ConfigValue[F, Seq[ExcludedMutation]] =
     millValue(excludedMutationsValue, "strykerExcludedMutations").as[Seq[ExcludedMutation]]
+
+  override def customMutators: ConfigValue[F, Seq[String]] =
+    millValue(customMutatorsValue, "strykerCustomMutators")
 
   override def thresholdsHigh: ConfigValue[F, Int] = millValue(thresholdsHighValue, "strykerThresholdsHigh")
   override def thresholdsLow: ConfigValue[F, Int] = millValue(thresholdsLowValue, "strykerThresholdsLow")

--- a/modules/mill/src/main/scala/stryker4s/mill/Stryker4sModule.scala
+++ b/modules/mill/src/main/scala/stryker4s/mill/Stryker4sModule.scala
@@ -67,6 +67,9 @@ trait Stryker4sModule extends ScalaModule {
   /** Mutations to exclude from mutation testing */
   def strykerExcludedMutations: T[Option[Seq[String]]] = None
 
+  /** Fully-qualified class names of custom mutators to load, in addition to the built-in mutators */
+  def strykerCustomMutators: T[Option[Seq[String]]] = None
+
   /** Threshold for high mutation score */
   def strykerThresholdsHigh: T[Option[Int]] = None
 
@@ -161,6 +164,7 @@ trait Stryker4sModule extends ScalaModule {
       testFilterValue = strykerTestFilter(),
       reportersValue = strykerReporters(),
       excludedMutationsValue = strykerExcludedMutations(),
+      customMutatorsValue = strykerCustomMutators(),
       thresholdsHighValue = strykerThresholdsHigh(),
       thresholdsLowValue = strykerThresholdsLow(),
       thresholdsBreakValue = strykerThresholdsBreak(),

--- a/modules/mill/src/main/scala/stryker4s/mill/runner/Stryker4sMillRunner.scala
+++ b/modules/mill/src/main/scala/stryker4s/mill/runner/Stryker4sMillRunner.scala
@@ -142,6 +142,16 @@ class Stryker4sMillRunner(
 
   override def instrumenterOptions(using Config): InstrumenterOptions =
     InstrumenterOptions.testRunner
+
+  /** Builds a `URLClassLoader` from the module's test-run classpath, with Stryker4s's own classloader as parent, so
+    * `stryker4s.mutatorapi.CustomMutator` always resolves to the same `Class` instance Stryker4s uses (avoiding a
+    * classloader-identity mismatch if the project also depends on `stryker4s-mutator-api` to compile against
+    * `CustomMutator`), while user-defined custom mutator classes still load from the project's classpath.
+    */
+  override def customMutatorClassLoader: ClassLoader = {
+    val urls = ctx.testRunClasspath.map(_.toNIO.toUri.toURL).toArray
+    new java.net.URLClassLoader(urls, getClass.getClassLoader)
+  }
 }
 
 /** Collects compile errors, relativized to the mutation tmpDir, so failing mutants can be rolled back.

--- a/modules/mill/src/mill-test/mutate/bar/src/bar/ArithmeticOperatorMutator.scala
+++ b/modules/mill/src/mill-test/mutate/bar/src/bar/ArithmeticOperatorMutator.scala
@@ -24,6 +24,6 @@ class ArithmeticOperatorMutator extends CustomMutator {
     val from = term.op.value
     val mutated = term.copyWithComments(op = term.op.copyWithComments(value = to))
     val metadata = MutantMetadata(from, to, "ArithmeticOperator", term.pos, None)
-    Right(NonEmptyVector.one(MutatedCode(mutated, metadata)))
+    Right(NonEmptyVector.one(MutatedCode(placeableTree.substitute(term, mutated), metadata)))
   }
 }

--- a/modules/mill/src/mill-test/mutate/bar/src/bar/ArithmeticOperatorMutator.scala
+++ b/modules/mill/src/mill-test/mutate/bar/src/bar/ArithmeticOperatorMutator.scala
@@ -7,8 +7,8 @@ import scala.meta.*
 
 /** Example custom mutator: swaps `+` for `-` (and vice versa) in `Int` arithmetic expressions.
   *
-  * Demonstrates the "Arithmetic Operator" mutator category that Stryker4s does not ship built-in, registered here
-  * via the `strykerCustomMutators` Mill setting.
+  * Demonstrates the "Arithmetic Operator" mutator category that Stryker4s does not ship built-in, registered here via
+  * the `strykerCustomMutators` Mill setting.
   */
 class ArithmeticOperatorMutator extends CustomMutator {
   def matcher: MutationMatcher = {

--- a/modules/mill/src/mill-test/mutate/bar/src/bar/ArithmeticOperatorMutator.scala
+++ b/modules/mill/src/mill-test/mutate/bar/src/bar/ArithmeticOperatorMutator.scala
@@ -1,4 +1,4 @@
-package example
+package bar
 
 import cats.data.NonEmptyVector
 import stryker4s.mutatorapi.*
@@ -7,8 +7,8 @@ import scala.meta.*
 
 /** Example custom mutator: swaps `+` for `-` (and vice versa) in `Int` arithmetic expressions.
   *
-  * This demonstrates the "Arithmetic Operator" mutator category that Stryker4s does not ship built-in, registered here
-  * via the `strykerCustomMutators` sbt setting.
+  * Demonstrates the "Arithmetic Operator" mutator category that Stryker4s does not ship built-in, registered here
+  * via the `strykerCustomMutators` Mill setting.
   */
 class ArithmeticOperatorMutator extends CustomMutator {
   def matcher: MutationMatcher = {

--- a/modules/mill/src/mill-test/mutate/bar/src/bar/Calc.scala
+++ b/modules/mill/src/mill-test/mutate/bar/src/bar/Calc.scala
@@ -1,0 +1,6 @@
+package bar
+
+object Calc {
+  def add(a: Int, b: Int): Int = a + b
+  def subtract(a: Int, b: Int): Int = a - b
+}

--- a/modules/mill/src/mill-test/mutate/bar/test/src/bar/CalcTest.scala
+++ b/modules/mill/src/mill-test/mutate/bar/test/src/bar/CalcTest.scala
@@ -1,0 +1,13 @@
+package bar
+
+class CalcTest extends munit.FunSuite {
+  test("add") {
+    assertEquals(Calc.add(2, 3), 5)
+    assertEquals(Calc.add(-1, 1), 0)
+  }
+
+  test("subtract") {
+    assertEquals(Calc.subtract(5, 3), 2)
+    assertEquals(Calc.subtract(1, 1), 0)
+  }
+}

--- a/modules/mill/src/mill-test/mutate/build.mill
+++ b/modules/mill/src/mill-test/mutate/build.mill
@@ -1,5 +1,6 @@
 //| mvnDeps:
 //| - io.stryker-mutator::mill-stryker4s::@STRYKER4S_VERSION@
+
 package build
 
 import mill.*, scalalib.*
@@ -16,5 +17,24 @@ object foo extends ScalaModule with Stryker4sModule {
   object test extends ScalaTests {
     def testFramework = "munit.Framework"
     def mvnDeps = Seq(mvn"org.scalameta::munit:1.3.6")
+  }
+}
+
+// Sanity-check custom mutator support: registers bar.ArithmeticOperatorMutator (an example
+// mutator matching the "Arithmetic Operator" category Stryker4s does not ship built-in) and
+// asserts the generated JSON report contains mutants it produced.
+object bar extends ScalaModule with Stryker4sModule {
+  def scalaVersion = "3.3.8"
+
+  def mvnDeps = Seq(mvn"io.stryker-mutator::stryker4s-mutator-api::@STRYKER4S_VERSION@")
+
+  def strykerCustomMutators = Some(Seq("bar.ArithmeticOperatorMutator"))
+  def strykerMutate = Some(Seq("src/bar/Calc.scala"))
+  def strykerReporters = Some(Seq("json"))
+  def strykerThresholdsBreak = Some(50)
+
+  object test extends ScalaTests {
+    def testFramework = "munit.Framework"
+    def mvnDeps = Seq(mvn"org.scalameta::munit:1.3.5")
   }
 }

--- a/modules/mill/src/test/scala/stryker4s/mill/MillConfigSourceTest.scala
+++ b/modules/mill/src/test/scala/stryker4s/mill/MillConfigSourceTest.scala
@@ -20,6 +20,7 @@ class MillConfigSourceTest extends Stryker4sIOSuite {
     testFilterValue = None,
     reportersValue = None,
     excludedMutationsValue = None,
+    customMutatorsValue = None,
     thresholdsHighValue = None,
     thresholdsLowValue = None,
     thresholdsBreakValue = None,
@@ -48,6 +49,7 @@ class MillConfigSourceTest extends Stryker4sIOSuite {
       testFilterValue = Some(Seq("*MyTest")),
       reportersValue = Some(Seq("html", "console")),
       excludedMutationsValue = Some(Seq("BooleanLiteral")),
+      customMutatorsValue = Some(Seq("com.example.MyCustomMutator")),
       thresholdsHighValue = Some(85),
       thresholdsLowValue = Some(60),
       thresholdsBreakValue = Some(0),
@@ -74,6 +76,7 @@ class MillConfigSourceTest extends Stryker4sIOSuite {
       _ <- config.testFilter.load.assertEquals(Seq("*MyTest"))
       _ <- config.reporters.load.assertEquals(Seq[ReporterType](Html, Console))
       _ <- config.excludedMutations.load.assertEquals(Seq(ExcludedMutation("BooleanLiteral")))
+      _ <- config.customMutators.load.assertEquals(Seq("com.example.MyCustomMutator"))
       _ <- config.thresholdsHigh.load.assertEquals(85)
       _ <- config.thresholdsLow.load.assertEquals(60)
       _ <- config.thresholdsBreak.load.assertEquals(0)
@@ -108,6 +111,7 @@ class MillConfigSourceTest extends Stryker4sIOSuite {
       source.testFilter -> "strykerTestFilter",
       source.reporters -> "strykerReporters",
       source.excludedMutations -> "strykerExcludedMutations",
+      source.customMutators -> "strykerCustomMutators",
       source.thresholdsHigh -> "strykerThresholdsHigh",
       source.thresholdsLow -> "strykerThresholdsLow",
       source.thresholdsBreak -> "strykerThresholdsBreak",

--- a/modules/mutatorApi/src/main/scala/stryker4s/mutatorapi/CustomMutator.scala
+++ b/modules/mutatorApi/src/main/scala/stryker4s/mutatorapi/CustomMutator.scala
@@ -1,0 +1,23 @@
+package stryker4s.mutatorapi
+
+/** Public extension point for third-party mutators.
+  *
+  * Implementations are registered by fully-qualified class name via the `customMutators` configuration option, and
+  * must have a public no-argument constructor so Stryker4s can instantiate them reflectively.
+  *
+  * Example:
+  * {{{
+  * class MyCustomMutator extends CustomMutator {
+  *   def matcher: MutationMatcher = {
+  *     case ... => placeableTree => ...
+  *   }
+  * }
+  * }}}
+  */
+trait CustomMutator {
+
+  /** The matcher this custom mutator contributes. It is combined with Stryker4s's built-in matchers (and any other
+    * configured custom mutators) before mutants are collected.
+    */
+  def matcher: MutationMatcher
+}

--- a/modules/mutatorApi/src/main/scala/stryker4s/mutatorapi/CustomMutator.scala
+++ b/modules/mutatorApi/src/main/scala/stryker4s/mutatorapi/CustomMutator.scala
@@ -9,10 +9,22 @@ package stryker4s.mutatorapi
   * {{{
   * class MyCustomMutator extends CustomMutator {
   *   def matcher: MutationMatcher = {
-  *     case ... => placeableTree => ...
+  *     case term @ Term.ApplyInfix.After_4_6_0(_, op @ Term.Name("+"), _, _) =>
+  *       placeableTree =>
+  *         val mutated = term.copy(op = op.copy(value = "-"))
+  *         val metadata = MutantMetadata("+", "-", "ArithmeticOperator", term.pos, None)
+  *         Right(NonEmptyVector.one(MutatedCode(placeableTree.substitute(term, mutated), metadata)))
   *   }
   * }
   * }}}
+  *
+  * Two things are easy to get wrong, and neither shows up until a mutant fails to compile:
+  *
+  *   - A [[MutatedCode]] carries the whole placeable statement, not just the replacement sub-term. Build it with
+  *     [[PlaceableTree.substitute]] rather than returning the replacement directly.
+  *   - Stryker4s visits every node of the tree, so a matcher that accepts both `expr.foo(arg)` and its inner `expr.foo`
+  *     selection emits two mutants for one combinator, the second of which leaves the argument list dangling. Keep
+  *     applied and no-argument method names in disjoint sets.
   */
 trait CustomMutator {
 

--- a/modules/mutatorApi/src/main/scala/stryker4s/mutatorapi/CustomMutator.scala
+++ b/modules/mutatorApi/src/main/scala/stryker4s/mutatorapi/CustomMutator.scala
@@ -2,8 +2,8 @@ package stryker4s.mutatorapi
 
 /** Public extension point for third-party mutators.
   *
-  * Implementations are registered by fully-qualified class name via the `customMutators` configuration option, and
-  * must have a public no-argument constructor so Stryker4s can instantiate them reflectively.
+  * Implementations are registered by fully-qualified class name via the `customMutators` configuration option, and must
+  * have a public no-argument constructor so Stryker4s can instantiate them reflectively.
   *
   * Example:
   * {{{

--- a/modules/mutatorApi/src/main/scala/stryker4s/mutatorapi/IgnoredMutationReason.scala
+++ b/modules/mutatorApi/src/main/scala/stryker4s/mutatorapi/IgnoredMutationReason.scala
@@ -1,4 +1,4 @@
-package stryker4s.model
+package stryker4s.mutatorapi
 
 /** Reason why a mutator did not produce a mutant
   */

--- a/modules/mutatorApi/src/main/scala/stryker4s/mutatorapi/MutantMetadata.scala
+++ b/modules/mutatorApi/src/main/scala/stryker4s/mutatorapi/MutantMetadata.scala
@@ -1,0 +1,43 @@
+package stryker4s.mutatorapi
+
+import mutationtesting.{Location, Position => MTPosition}
+
+import scala.meta.Position
+
+/** Metadata of a [[stryker4s.mutatorapi.MutatedCode]]
+  *
+  * @param original
+  *   Original code
+  * @param replacement
+  *   Mutated replaced code
+  * @param mutatorName
+  *   Mutator category
+  * @param location
+  *   The location of the mutated code
+  */
+final case class MutantMetadata(
+    original: String,
+    replacement: String,
+    mutatorName: String,
+    location: Location,
+    description: Option[String]
+)
+
+object MutantMetadata {
+
+  /** Convenience constructor that converts a scalameta `Position` to the `Location` used in reports.
+    */
+  def apply(
+      original: String,
+      replacement: String,
+      mutatorName: String,
+      position: Position,
+      description: Option[String]
+  ): MutantMetadata =
+    MutantMetadata(original, replacement, mutatorName, toLocation(position), description)
+
+  private def toLocation(pos: Position): Location = Location(
+    start = MTPosition(line = pos.startLine + 1, column = pos.startColumn + 1),
+    end = MTPosition(line = pos.endLine + 1, column = pos.endColumn + 1)
+  )
+}

--- a/modules/mutatorApi/src/main/scala/stryker4s/mutatorapi/MutantMetadata.scala
+++ b/modules/mutatorApi/src/main/scala/stryker4s/mutatorapi/MutantMetadata.scala
@@ -1,6 +1,6 @@
 package stryker4s.mutatorapi
 
-import mutationtesting.{Location, Position => MTPosition}
+import mutationtesting.{Location, Position as MTPosition}
 
 import scala.meta.Position
 

--- a/modules/mutatorApi/src/main/scala/stryker4s/mutatorapi/MutatedCode.scala
+++ b/modules/mutatorApi/src/main/scala/stryker4s/mutatorapi/MutatedCode.scala
@@ -1,0 +1,9 @@
+package stryker4s.mutatorapi
+
+import scala.meta.Term
+
+/** A mutated version of a piece of code, together with metadata describing the mutation.
+  *
+  * This is the result type a [[stryker4s.mutatorapi.CustomMutator]] produces for each place it finds a mutation.
+  */
+final case class MutatedCode(mutatedStatement: Term, metadata: MutantMetadata)

--- a/modules/mutatorApi/src/main/scala/stryker4s/mutatorapi/PlaceableTree.scala
+++ b/modules/mutatorApi/src/main/scala/stryker4s/mutatorapi/PlaceableTree.scala
@@ -1,9 +1,52 @@
 package stryker4s.mutatorapi
 
-import scala.meta.Tree
+import scala.meta.{Term, Transformer, Tree}
+import scala.meta.prettyprinters.{XtensionStructure, XtensionSyntax}
 
 /** A `Tree` where a mutation can be placed
   */
 final case class PlaceableTree(tree: Tree) extends AnyVal {
   override def toString() = tree.toString()
+
+  /** Builds the full mutated statement for a mutation, by replacing `original` with `replacement` inside this tree.
+    *
+    * A [[CustomMutator]] usually matches on a small sub-term (say the `IO.sleep(d)` inside
+    * `IO.sleep(d).as(q).timeout(l)`), but a [[MutatedCode]] must carry the *whole* placeable statement, with the
+    * mutation applied in place. Returning only the replacement sub-term produces a mutant that does not compile
+    * whenever the matched term is not the entire placeable tree.
+    *
+    * @throws IllegalArgumentException
+    *   if `original` cannot be found inside this tree, or if substituting into it does not yield a `Term`.
+    */
+  def substitute(original: Term, replacement: Term): Term = {
+    val target = PlaceableTree
+      .find(tree, original)
+      .getOrElse(
+        throw new IllegalArgumentException(
+          s"Could not find '${original.syntax}' in '${tree.syntax}'"
+        )
+      )
+
+    val transformer = new Transformer {
+      override protected def apply(t: Tree): Tree = if (t eq target) replacement else super.apply(t)
+    }
+
+    transformer.transform(tree) match {
+      case t: Term => t
+      case t       =>
+        throw new IllegalArgumentException(
+          s"Replacing '${original.syntax}' with '${replacement.syntax}' in '${tree.syntax}' did not produce a Term, but a ${t.getClass.getSimpleName}"
+        )
+    }
+  }
+}
+
+object PlaceableTree {
+
+  /** Depth-first search for `original` within `tree`, by reference identity first and position plus structure second (a
+    * matcher may hand back a re-created, but equivalent, term).
+    */
+  private def find(tree: Tree, original: Term): Option[Tree] =
+    if ((tree eq original) || (tree.pos == original.pos && tree.structure == original.structure)) Some(tree)
+    else tree.children.iterator.map(find(_, original)).collectFirst { case Some(found) => found }
 }

--- a/modules/mutatorApi/src/main/scala/stryker4s/mutatorapi/PlaceableTree.scala
+++ b/modules/mutatorApi/src/main/scala/stryker4s/mutatorapi/PlaceableTree.scala
@@ -1,4 +1,4 @@
-package stryker4s.model
+package stryker4s.mutatorapi
 
 import scala.meta.Tree
 

--- a/modules/mutatorApi/src/main/scala/stryker4s/mutatorapi/package.scala
+++ b/modules/mutatorApi/src/main/scala/stryker4s/mutatorapi/package.scala
@@ -1,0 +1,26 @@
+package stryker4s
+
+import cats.data.NonEmptyVector
+
+import scala.meta.Tree
+
+package object mutatorapi {
+
+  /** All mutations found for a single [[PlaceableTree]].
+    */
+  type Mutations = NonEmptyVector[MutatedCode]
+
+  /** A mutation that was found, but excluded (e.g. by user configuration or a `@SuppressWarnings` annotation).
+    */
+  type IgnoredMutation = (MutatedCode, IgnoredMutationReason)
+
+  type IgnoredMutations = NonEmptyVector[IgnoredMutation]
+
+  /** A `PartialFunction` that can match on a ScalaMeta `Tree` and, for a given [[PlaceableTree]], return either the
+    * mutations found (`Right`) or the reason they were ignored (`Left`).
+    *
+    * This is the type both Stryker4s's built-in mutators and third-party [[CustomMutator]]s implement.
+    */
+  type MutationMatcher = PartialFunction[Tree, PlaceableTree => Either[IgnoredMutations, Mutations]]
+
+}

--- a/modules/mutatorApi/src/test/scala/stryker4s/mutatorapi/CustomMutatorTest.scala
+++ b/modules/mutatorApi/src/test/scala/stryker4s/mutatorapi/CustomMutatorTest.scala
@@ -1,0 +1,40 @@
+package stryker4s.mutatorapi
+
+import stryker4s.testkit.Stryker4sSuite
+
+import cats.data.NonEmptyVector
+import scala.meta.*
+
+class CustomMutatorTest extends Stryker4sSuite {
+
+  /** A minimal example custom mutator, as a third-party implementation would write one: matching on `Term.Name("<")`
+    * and mutating it to `Term.Name(">")`.
+    */
+  private class SwapLessThanMutator extends CustomMutator {
+    def matcher: MutationMatcher = { case orig @ Term.Name("<") =>
+      placeableTree =>
+        val mutatedStatement = placeableTree.tree.asInstanceOf[Term]
+        val metadata = MutantMetadata(orig.value, ">", "SwapLessThan", orig.pos, None)
+        Right(NonEmptyVector.one(MutatedCode(mutatedStatement, metadata)))
+    }
+  }
+
+  test("a CustomMutator's matcher should be invocable like a built-in matcher") {
+    val mutator = new SwapLessThanMutator
+    val tree = Term.Name("<")
+
+    assert(mutator.matcher.isDefinedAt(tree))
+
+    val result = mutator.matcher(tree)(PlaceableTree(tree))
+
+    val mutations = result.value
+    assertEquals(mutations.head.metadata.mutatorName, "SwapLessThan")
+    assertEquals(mutations.head.metadata.replacement, ">")
+  }
+
+  test("a CustomMutator's matcher should not match unrelated trees") {
+    val mutator = new SwapLessThanMutator
+
+    assert(!mutator.matcher.isDefinedAt(Term.Name(">")))
+  }
+}

--- a/modules/mutatorApi/src/test/scala/stryker4s/mutatorapi/CustomMutatorTest.scala
+++ b/modules/mutatorApi/src/test/scala/stryker4s/mutatorapi/CustomMutatorTest.scala
@@ -7,15 +7,16 @@ import scala.meta.*
 
 class CustomMutatorTest extends Stryker4sSuite {
 
-  /** A minimal example custom mutator, as a third-party implementation would write one: matching on `Term.Name("<")`
-    * and mutating it to `Term.Name(">")`.
+  /** A minimal example custom mutator, written the way a third-party implementation should be: matching a sub-term
+    * (here `Term.Name("<")`) and building the mutated statement with `PlaceableTree.substitute`, so the mutation is
+    * applied in place and the surrounding statement is preserved.
     */
   private class SwapLessThanMutator extends CustomMutator {
     def matcher: MutationMatcher = { case orig @ Term.Name("<") =>
       placeableTree =>
-        val mutatedStatement = placeableTree.tree.asInstanceOf[Term]
+        val replacement = Term.Name(">")
         val metadata = MutantMetadata(orig.value, ">", "SwapLessThan", orig.pos, None)
-        Right(NonEmptyVector.one(MutatedCode(mutatedStatement, metadata)))
+        Right(NonEmptyVector.one(MutatedCode(placeableTree.substitute(orig, replacement), metadata)))
     }
   }
 
@@ -30,6 +31,16 @@ class CustomMutatorTest extends Stryker4sSuite {
     val mutations = result.value
     assertEquals(mutations.head.metadata.mutatorName, "SwapLessThan")
     assertEquals(mutations.head.metadata.replacement, ">")
+  }
+
+  test("a CustomMutator's matcher should keep the statement surrounding the matched sub-term") {
+    val mutator = new SwapLessThanMutator
+    val statement = "a < b".parseTerm
+    val op = statement.collect { case t @ Term.Name("<") => t }.head
+
+    val mutations = mutator.matcher(op)(PlaceableTree(statement)).value
+
+    assertEquals(mutations.head.mutatedStatement.syntax, "a > b")
   }
 
   test("a CustomMutator's matcher should not match unrelated trees") {

--- a/modules/mutatorApi/src/test/scala/stryker4s/mutatorapi/IgnoredMutationReasonTest.scala
+++ b/modules/mutatorApi/src/test/scala/stryker4s/mutatorapi/IgnoredMutationReasonTest.scala
@@ -1,0 +1,22 @@
+package stryker4s.mutatorapi
+
+import stryker4s.testkit.Stryker4sSuite
+
+class IgnoredMutationReasonTest extends Stryker4sSuite {
+  test("MutationExcluded should explain it was excluded by user configuration") {
+    assertEquals(MutationExcluded.explanation, "Mutation was excluded by user configuration")
+  }
+
+  test("RegexParseError should include the pattern and message in its explanation") {
+    val reason = RegexParseError("[a-z", "unclosed character class")
+
+    assert(reason.explanation.contains("[a-z"))
+    assert(reason.explanation.contains("unclosed character class"))
+  }
+
+  test("NoRegexMutationsFound should include the pattern in its explanation") {
+    val reason = NoRegexMutationsFound("[a-z]+")
+
+    assert(reason.explanation.contains("[a-z]+"))
+  }
+}

--- a/modules/mutatorApi/src/test/scala/stryker4s/mutatorapi/MutantMetadataTest.scala
+++ b/modules/mutatorApi/src/test/scala/stryker4s/mutatorapi/MutantMetadataTest.scala
@@ -1,6 +1,6 @@
 package stryker4s.mutatorapi
 
-import mutationtesting.{Location, Position => MTPosition}
+import mutationtesting.{Location, Position as MTPosition}
 import stryker4s.testkit.Stryker4sSuite
 
 class MutantMetadataTest extends Stryker4sSuite {

--- a/modules/mutatorApi/src/test/scala/stryker4s/mutatorapi/MutantMetadataTest.scala
+++ b/modules/mutatorApi/src/test/scala/stryker4s/mutatorapi/MutantMetadataTest.scala
@@ -1,0 +1,32 @@
+package stryker4s.mutatorapi
+
+import mutationtesting.{Location, Position => MTPosition}
+import stryker4s.testkit.Stryker4sSuite
+
+class MutantMetadataTest extends Stryker4sSuite {
+  test("apply(Position) should convert a scalameta Position to a Location") {
+    val tree = "x > 5".parseTerm
+    val position = tree.pos
+
+    val metadata = MutantMetadata("x > 5", "x <= 5", "GreaterThan", position, None)
+
+    val expectedLocation = Location(
+      start = MTPosition(line = position.startLine + 1, column = position.startColumn + 1),
+      end = MTPosition(line = position.endLine + 1, column = position.endColumn + 1)
+    )
+    assertEquals(metadata.location, expectedLocation)
+    assertEquals(metadata.original, "x > 5")
+    assertEquals(metadata.replacement, "x <= 5")
+    assertEquals(metadata.mutatorName, "GreaterThan")
+    assertEquals(metadata.description, None)
+  }
+
+  test("apply(Location) should keep the given Location as-is") {
+    val location = Location(MTPosition(1, 1), MTPosition(1, 5))
+
+    val metadata = MutantMetadata("a", "b", "SomeMutator", location, Some("a description"))
+
+    assertEquals(metadata.location, location)
+    assertEquals(metadata.description, Some("a description"))
+  }
+}

--- a/modules/mutatorApi/src/test/scala/stryker4s/mutatorapi/PlaceableTreeSubstituteTest.scala
+++ b/modules/mutatorApi/src/test/scala/stryker4s/mutatorapi/PlaceableTreeSubstituteTest.scala
@@ -1,0 +1,69 @@
+package stryker4s.mutatorapi
+
+import stryker4s.testkit.Stryker4sSuite
+
+import scala.meta.*
+
+class PlaceableTreeSubstituteTest extends Stryker4sSuite {
+
+  /** Re-parsing a snippet loses the position it had inside the enclosing tree, so tests that need a positioned sub-term
+    * look it up in the real tree by syntax instead of parsing it separately.
+    */
+  private def subTerm(within: Tree, syntax: String): Term =
+    within.collect { case sub: Term if sub.syntax == syntax => sub }.head
+
+  test("substitute should replace the whole tree when it is itself the original") {
+    val tree = "a.orElse(b)".parseTerm
+
+    val result = PlaceableTree(tree).substitute(tree, "a".parseTerm)
+
+    assertEquals(result.syntax, "a")
+  }
+
+  test("substitute should keep the surrounding context of a nested original") {
+    val tree = "IO.sleep(d).as(q).timeout(l)".parseTerm
+    val original = subTerm(tree, "IO.sleep(d)")
+
+    val result = PlaceableTree(tree).substitute(original, "IO.unit".parseTerm)
+
+    assertEquals(result.syntax, "IO.unit.as(q).timeout(l)")
+  }
+
+  test("substitute should replace a deeply nested original") {
+    val tree = "xs.map(x => f(x) + 1)".parseTerm
+    val original = subTerm(tree, "f(x)")
+
+    val result = PlaceableTree(tree).substitute(original, "g(x)".parseTerm)
+
+    assertEquals(result.syntax, "xs.map(x => g(x) + 1)")
+  }
+
+  test("substitute should replace only the occurrence at the original's position") {
+    val tree = "f(a) + f(a)".parseTerm
+    val original = tree.collect { case t: Term.Apply => t }.head
+
+    val result = PlaceableTree(tree).substitute(original, "b".parseTerm)
+
+    assertEquals(result.syntax, "b + f(a)")
+  }
+
+  test("substitute should find the original by reference identity") {
+    val tree = "wrap(inner)".parseTerm
+    val original = tree.collect { case t @ Term.Name("inner") => t }.head
+
+    val result = PlaceableTree(tree).substitute(original, "replaced".parseTerm)
+
+    assertEquals(result.syntax, "wrap(replaced)")
+  }
+
+  test("substitute should fail with a helpful message when the original is not in the tree") {
+    val tree = "a.orElse(b)".parseTerm
+
+    val thrown = intercept[IllegalArgumentException] {
+      PlaceableTree(tree).substitute("somethingElse".parseTerm, "a".parseTerm)
+    }
+
+    assert(thrown.getMessage.contains("somethingElse"), thrown.getMessage)
+    assert(thrown.getMessage.contains("a.orElse(b)"), thrown.getMessage)
+  }
+}

--- a/modules/mutatorApi/src/test/scala/stryker4s/mutatorapi/PlaceableTreeTest.scala
+++ b/modules/mutatorApi/src/test/scala/stryker4s/mutatorapi/PlaceableTreeTest.scala
@@ -1,0 +1,12 @@
+package stryker4s.mutatorapi
+
+import stryker4s.testkit.Stryker4sSuite
+
+class PlaceableTreeTest extends Stryker4sSuite {
+  test("toString should delegate to the wrapped tree's toString") {
+    val tree = "x > 5".parseTerm
+    val placeableTree = PlaceableTree(tree)
+
+    assertEquals(placeableTree.toString(), tree.toString())
+  }
+}

--- a/modules/sbt/src/main/scala/stryker4s/sbt/SbtConfigSource.scala
+++ b/modules/sbt/src/main/scala/stryker4s/sbt/SbtConfigSource.scala
@@ -65,6 +65,11 @@ object SbtConfigSource {
         strykerExcludedMutations.key.label
       ).as[Seq[ExcludedMutation]]
 
+      override def customMutators: ConfigValue[F, Seq[String]] = sbtSetting(
+        strykerCustomMutators.?.value,
+        strykerCustomMutators.key.label
+      )
+
       override def thresholdsHigh: ConfigValue[F, Int] = sbtSetting(
         strykerThresholdsHigh.?.value,
         strykerThresholdsHigh.key.label

--- a/modules/sbt/src/main/scala/stryker4s/sbt/Stryker4sPlugin.scala
+++ b/modules/sbt/src/main/scala/stryker4s/sbt/Stryker4sPlugin.scala
@@ -40,6 +40,10 @@ object Stryker4sPlugin extends AutoPlugin {
     val strykerReporters = settingKey[Seq[String]]("Reporter(s) to use")
     val strykerFiles = settingKey[Seq[String]]("Pattern(s) of files to include in mutation testing")
     val strykerExcludedMutations = settingKey[Seq[String]]("Mutations to exclude from mutation testing")
+    val strykerCustomMutators =
+      settingKey[Seq[String]](
+        "Fully-qualified class names of custom mutators to load, in addition to the built-in mutators"
+      )
     val strykerThresholdsHigh = settingKey[Int]("Threshold for high mutation score")
     val strykerThresholdsLow = settingKey[Int]("Threshold for low mutation score")
     val strykerThresholdsBreak = settingKey[Int]("Threshold score for breaking the build")

--- a/modules/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
+++ b/modules/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
@@ -231,11 +231,25 @@ class Stryker4sSbtRunner(
       InstrumenterOptions.testRunner
     }
 
-  override def customMutatorClassLoader: ClassLoader =
-    PluginCompat.runTask(ctx.targetProject / Test / testLoader, ctx.state) match {
-      case Some(Right(loader)) => loader
+  /** Loads the target project's `Test` classpath into a `URLClassLoader` whose **parent is Stryker4s's own
+    * classloader** (rather than the project's isolated `testLoader`). This ensures that
+    * `stryker4s.mutatorapi.CustomMutator` (and its dependencies) always resolve to the same `Class` instance that
+    * Stryker4s itself uses, so `isAssignableFrom` checks in `CustomMutatorLoader` succeed even though the project may
+    * also have `stryker4s-mutator-api` on its own compile classpath (e.g. to compile against the `CustomMutator`
+    * trait).
+    */
+  override def customMutatorClassLoader: ClassLoader = {
+    val classpath =
+      PluginCompat.toNioPaths(extractTaskValue(ctx.targetProject / Test / fullClasspath, ctx.state))
+    val urls = classpath.map(_.toUri.toURL).toArray
+    new java.net.URLClassLoader(urls, getClass.getClassLoader)
+  }
+
+  private def extractTaskValue[T](task: TaskKey[T], state: State): T =
+    PluginCompat.runTask(task, state) match {
+      case Some(Right(result)) => result
       case other               =>
-        log.debug(s"Expected task '${(Test / testLoader).key.label}' to succeed, but got: $other")
-        throw TestSetupException((Test / testLoader).key.label)
+        log.debug(s"Expected task '${task.key.label}' to succeed, but got: $other")
+        throw TestSetupException(task.key.label)
     }
 }

--- a/modules/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
+++ b/modules/sbt/src/main/scala/stryker4s/sbt/Stryker4sSbtRunner.scala
@@ -230,4 +230,12 @@ class Stryker4sSbtRunner(
     } else {
       InstrumenterOptions.testRunner
     }
+
+  override def customMutatorClassLoader: ClassLoader =
+    PluginCompat.runTask(ctx.targetProject / Test / testLoader, ctx.state) match {
+      case Some(Right(loader)) => loader
+      case other               =>
+        log.debug(s"Expected task '${(Test / testLoader).key.label}' to succeed, but got: $other")
+        throw TestSetupException((Test / testLoader).key.label)
+    }
 }

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/README.md
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/README.md
@@ -1,0 +1,9 @@
+# SBT plugin custom mutator test project
+
+This is a scripted test project for Stryker4s's custom mutator support
+(`strykerCustomMutators`). It registers `example.ArithmeticOperatorMutator`, a small
+example custom mutator that swaps `+` for `-` (and vice versa) on `Int` arithmetic,
+and asserts that the generated `report.json` contains at least one killed mutant
+produced by that custom mutator (`mutatorName == "ArithmeticOperator"`).
+
+To run it, run `sbt scripted` in the root of the Stryker4s project.

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/build.sbt
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/build.sbt
@@ -9,7 +9,13 @@ libraryDependencies ++= Seq(
 
 strykerDebugLogTestRunnerStdout := true
 stryker / logLevel := Level.Debug
-strykerCustomMutators := Seq("example.ArithmeticOperatorMutator")
+
+strykerCustomMutators := Seq(
+  "example.ArithmeticOperatorMutator",
+  "example.NumericLiteralMutator",
+  "example.CollectionLiteralMutator"
+)
+
 strykerMutate := Seq("src/main/scala/example/Calculator.scala")
 strykerReporters := Seq("json")
 strykerThresholdsBreak := 50

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/build.sbt
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/build.sbt
@@ -22,7 +22,12 @@ strykerCustomMutators := Seq(
   "example.FallbackInversionMutator",
   "example.SequencingSwapMutator",
   "example.SequencingRemovalMutator",
-  "example.TimeoutRemovalMutator"
+  "example.TimeoutRemovalMutator",
+  "example.GetOrElseMutator",
+  "example.ParallelSequentialSwapMutator",
+  "example.ResourceFinalizerMutator",
+  "example.RefUpdateMutator",
+  "example.SleepRemovalMutator"
 )
 
 strykerMutate := Seq("src/main/scala/example/Calculator.scala")

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/build.sbt
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/build.sbt
@@ -17,7 +17,9 @@ strykerCustomMutators := Seq(
   "example.NumericLiteralMutator",
   "example.CollectionLiteralMutator",
   "example.ErrorHandlingMutator",
-  "example.ConditionalEffectMutator"
+  "example.ConditionalEffectMutator",
+  "example.FallbackRemovalMutator",
+  "example.FallbackInversionMutator"
 )
 
 strykerMutate := Seq("src/main/scala/example/Calculator.scala")

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/build.sbt
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/build.sbt
@@ -1,0 +1,15 @@
+ThisBuild / scalaVersion := "3.3.8"
+
+libraryDependencies ++= Seq(
+  "org.scalameta" %% "munit" % "1.3.5" % Test,
+  "io.stryker-mutator" %% "stryker4s-mutator-api" % sys.props("plugin.version") % Provided,
+  "org.scalameta" %% "scalameta" % "4.17.3" % Provided,
+  "org.typelevel" %% "cats-core" % "2.13.0" % Provided
+)
+
+strykerDebugLogTestRunnerStdout := true
+stryker / logLevel := Level.Debug
+strykerCustomMutators := Seq("example.ArithmeticOperatorMutator")
+strykerMutate := Seq("src/main/scala/example/Calculator.scala")
+strykerReporters := Seq("json")
+strykerThresholdsBreak := 50

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/build.sbt
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/build.sbt
@@ -27,7 +27,10 @@ strykerCustomMutators := Seq(
   "example.ParallelSequentialSwapMutator",
   "example.ResourceFinalizerMutator",
   "example.RefUpdateMutator",
-  "example.SleepRemovalMutator"
+  "example.SleepRemovalMutator",
+  "example.CollectionOrderMutator",
+  "example.StringNormalizationMutator",
+  "example.HeadLastSwapMutator"
 )
 
 strykerMutate := Seq("src/main/scala/example/Calculator.scala")

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/build.sbt
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/build.sbt
@@ -2,9 +2,11 @@ ThisBuild / scalaVersion := "3.3.8"
 
 libraryDependencies ++= Seq(
   "org.scalameta" %% "munit" % "1.3.5" % Test,
+  "org.typelevel" %% "munit-cats-effect" % "2.1.0" % Test,
   "io.stryker-mutator" %% "stryker4s-mutator-api" % sys.props("plugin.version") % Provided,
   "org.scalameta" %% "scalameta" % "4.17.3" % Provided,
-  "org.typelevel" %% "cats-core" % "2.13.0" % Provided
+  "org.typelevel" %% "cats-core" % "2.13.0" % Provided,
+  "org.typelevel" %% "cats-effect" % "3.7.0"
 )
 
 strykerDebugLogTestRunnerStdout := true
@@ -13,7 +15,8 @@ stryker / logLevel := Level.Debug
 strykerCustomMutators := Seq(
   "example.ArithmeticOperatorMutator",
   "example.NumericLiteralMutator",
-  "example.CollectionLiteralMutator"
+  "example.CollectionLiteralMutator",
+  "example.ErrorHandlingMutator"
 )
 
 strykerMutate := Seq("src/main/scala/example/Calculator.scala")

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/build.sbt
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/build.sbt
@@ -19,7 +19,9 @@ strykerCustomMutators := Seq(
   "example.ErrorHandlingMutator",
   "example.ConditionalEffectMutator",
   "example.FallbackRemovalMutator",
-  "example.FallbackInversionMutator"
+  "example.FallbackInversionMutator",
+  "example.SequencingSwapMutator",
+  "example.SequencingRemovalMutator"
 )
 
 strykerMutate := Seq("src/main/scala/example/Calculator.scala")

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/build.sbt
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/build.sbt
@@ -16,7 +16,8 @@ strykerCustomMutators := Seq(
   "example.ArithmeticOperatorMutator",
   "example.NumericLiteralMutator",
   "example.CollectionLiteralMutator",
-  "example.ErrorHandlingMutator"
+  "example.ErrorHandlingMutator",
+  "example.ConditionalEffectMutator"
 )
 
 strykerMutate := Seq("src/main/scala/example/Calculator.scala")

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/build.sbt
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/build.sbt
@@ -21,7 +21,8 @@ strykerCustomMutators := Seq(
   "example.FallbackRemovalMutator",
   "example.FallbackInversionMutator",
   "example.SequencingSwapMutator",
-  "example.SequencingRemovalMutator"
+  "example.SequencingRemovalMutator",
+  "example.TimeoutRemovalMutator"
 )
 
 strykerMutate := Seq("src/main/scala/example/Calculator.scala")

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/check-report.sh
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/check-report.sh
@@ -10,11 +10,11 @@ if [ -z "$report" ]; then
   exit 1
 fi
 
-for mutator in ArithmeticOperator NumericLiteral CollectionLiteral; do
+for mutator in ArithmeticOperator NumericLiteral CollectionLiteral ErrorHandling; do
   if ! grep -q "$mutator" "$report"; then
     echo "report.json does not contain any $mutator mutants: $report" >&2
     exit 1
   fi
 done
 
-echo "Found ArithmeticOperator, NumericLiteral, and CollectionLiteral mutant(s) in $report"
+echo "Found ArithmeticOperator, NumericLiteral, CollectionLiteral, and ErrorHandling mutant(s) in $report"

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/check-report.sh
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/check-report.sh
@@ -1,20 +1,34 @@
 #!/usr/bin/env bash
 # Asserts that the generated mutation report contains at least one mutant produced by each of the
-# custom mutators registered via `strykerCustomMutators` in build.sbt.
+# custom mutators registered via `strykerCustomMutators` in build.sbt, and that every mutant in the
+# fixture was killed.
 set -euo pipefail
 
-report=$(find target/stryker4s-report -name report.json | head -n1)
+# Reports are written to a timestamped directory, so pick the newest rather than an arbitrary one.
+report=$(find target/stryker4s-report -name report.json -printf "%T@ %p\n" | sort -rn | head -n1 | cut -d" " -f2-)
 
 if [ -z "$report" ]; then
   echo "No report.json found under target/stryker4s-report" >&2
   exit 1
 fi
 
-for mutator in ArithmeticOperator NumericLiteral CollectionLiteral ErrorHandling ConditionalEffect FallbackRemoval FallbackInversion SequencingSwap SequencingRemoval TimeoutRemoval; do
+for mutator in ArithmeticOperator NumericLiteral CollectionLiteral ErrorHandling ConditionalEffect FallbackRemoval FallbackInversion SequencingSwap SequencingRemoval TimeoutRemoval GetOrElse ParallelSequentialSwap ResourceFinalizer RefUpdate SleepRemoval; do
   if ! grep -q "$mutator" "$report"; then
     echo "report.json does not contain any $mutator mutants: $report" >&2
     exit 1
   fi
 done
 
-echo "Found ArithmeticOperator, NumericLiteral, CollectionLiteral, ErrorHandling, ConditionalEffect, FallbackRemoval, FallbackInversion, SequencingSwap, SequencingRemoval, and TimeoutRemoval mutant(s) in $report"
+# A CompileError means a mutator produced a replacement that does not type-check in context — most
+# often by returning the bare replacement instead of the whole placeable statement (see
+# `PlaceableTree.substitute`), or by matching both an applied call and its inner selection so that
+# the second mutant leaves the argument list dangling. A Survived mutant in this fixture means an
+# example mutator is no longer covered by a test, or that an equivalent mutant crept in.
+for status in CompileError Survived; do
+  if grep -q "\"$status\"" "$report"; then
+    echo "report.json contains $status mutants, expected every mutant to be Killed: $report" >&2
+    exit 1
+  fi
+done
+
+echo "Found a mutant for every registered custom mutator, and all mutants were killed, in $report"

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/check-report.sh
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/check-report.sh
@@ -10,11 +10,11 @@ if [ -z "$report" ]; then
   exit 1
 fi
 
-for mutator in ArithmeticOperator NumericLiteral CollectionLiteral ErrorHandling ConditionalEffect; do
+for mutator in ArithmeticOperator NumericLiteral CollectionLiteral ErrorHandling ConditionalEffect FallbackRemoval FallbackInversion; do
   if ! grep -q "$mutator" "$report"; then
     echo "report.json does not contain any $mutator mutants: $report" >&2
     exit 1
   fi
 done
 
-echo "Found ArithmeticOperator, NumericLiteral, CollectionLiteral, ErrorHandling, and ConditionalEffect mutant(s) in $report"
+echo "Found ArithmeticOperator, NumericLiteral, CollectionLiteral, ErrorHandling, ConditionalEffect, FallbackRemoval, and FallbackInversion mutant(s) in $report"

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/check-report.sh
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/check-report.sh
@@ -10,11 +10,11 @@ if [ -z "$report" ]; then
   exit 1
 fi
 
-for mutator in ArithmeticOperator NumericLiteral CollectionLiteral ErrorHandling ConditionalEffect FallbackRemoval FallbackInversion; do
+for mutator in ArithmeticOperator NumericLiteral CollectionLiteral ErrorHandling ConditionalEffect FallbackRemoval FallbackInversion SequencingSwap SequencingRemoval; do
   if ! grep -q "$mutator" "$report"; then
     echo "report.json does not contain any $mutator mutants: $report" >&2
     exit 1
   fi
 done
 
-echo "Found ArithmeticOperator, NumericLiteral, CollectionLiteral, ErrorHandling, ConditionalEffect, FallbackRemoval, and FallbackInversion mutant(s) in $report"
+echo "Found ArithmeticOperator, NumericLiteral, CollectionLiteral, ErrorHandling, ConditionalEffect, FallbackRemoval, FallbackInversion, SequencingSwap, and SequencingRemoval mutant(s) in $report"

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/check-report.sh
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/check-report.sh
@@ -10,11 +10,11 @@ if [ -z "$report" ]; then
   exit 1
 fi
 
-for mutator in ArithmeticOperator NumericLiteral CollectionLiteral ErrorHandling ConditionalEffect FallbackRemoval FallbackInversion SequencingSwap SequencingRemoval; do
+for mutator in ArithmeticOperator NumericLiteral CollectionLiteral ErrorHandling ConditionalEffect FallbackRemoval FallbackInversion SequencingSwap SequencingRemoval TimeoutRemoval; do
   if ! grep -q "$mutator" "$report"; then
     echo "report.json does not contain any $mutator mutants: $report" >&2
     exit 1
   fi
 done
 
-echo "Found ArithmeticOperator, NumericLiteral, CollectionLiteral, ErrorHandling, ConditionalEffect, FallbackRemoval, FallbackInversion, SequencingSwap, and SequencingRemoval mutant(s) in $report"
+echo "Found ArithmeticOperator, NumericLiteral, CollectionLiteral, ErrorHandling, ConditionalEffect, FallbackRemoval, FallbackInversion, SequencingSwap, SequencingRemoval, and TimeoutRemoval mutant(s) in $report"

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/check-report.sh
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/check-report.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Asserts that the generated mutation report contains at least one mutant produced by the
-# custom ArithmeticOperatorMutator registered via `strykerCustomMutators` in build.sbt.
+# Asserts that the generated mutation report contains at least one mutant produced by each of the
+# three custom mutators registered via `strykerCustomMutators` in build.sbt.
 set -euo pipefail
 
 report=$(find target/stryker4s-report -name report.json | head -n1)
@@ -10,9 +10,11 @@ if [ -z "$report" ]; then
   exit 1
 fi
 
-if ! grep -q "ArithmeticOperator" "$report"; then
-  echo "report.json does not contain any ArithmeticOperator mutants: $report" >&2
-  exit 1
-fi
+for mutator in ArithmeticOperator NumericLiteral CollectionLiteral; do
+  if ! grep -q "$mutator" "$report"; then
+    echo "report.json does not contain any $mutator mutants: $report" >&2
+    exit 1
+  fi
+done
 
-echo "Found ArithmeticOperator mutant(s) in $report"
+echo "Found ArithmeticOperator, NumericLiteral, and CollectionLiteral mutant(s) in $report"

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/check-report.sh
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/check-report.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Asserts that the generated mutation report contains at least one mutant produced by each of the
-# three custom mutators registered via `strykerCustomMutators` in build.sbt.
+# custom mutators registered via `strykerCustomMutators` in build.sbt.
 set -euo pipefail
 
 report=$(find target/stryker4s-report -name report.json | head -n1)
@@ -10,11 +10,11 @@ if [ -z "$report" ]; then
   exit 1
 fi
 
-for mutator in ArithmeticOperator NumericLiteral CollectionLiteral ErrorHandling; do
+for mutator in ArithmeticOperator NumericLiteral CollectionLiteral ErrorHandling ConditionalEffect; do
   if ! grep -q "$mutator" "$report"; then
     echo "report.json does not contain any $mutator mutants: $report" >&2
     exit 1
   fi
 done
 
-echo "Found ArithmeticOperator, NumericLiteral, CollectionLiteral, and ErrorHandling mutant(s) in $report"
+echo "Found ArithmeticOperator, NumericLiteral, CollectionLiteral, ErrorHandling, and ConditionalEffect mutant(s) in $report"

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/check-report.sh
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/check-report.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Asserts that the generated mutation report contains at least one mutant produced by the
+# custom ArithmeticOperatorMutator registered via `strykerCustomMutators` in build.sbt.
+set -euo pipefail
+
+report=$(find target/stryker4s-report -name report.json | head -n1)
+
+if [ -z "$report" ]; then
+  echo "No report.json found under target/stryker4s-report" >&2
+  exit 1
+fi
+
+if ! grep -q "ArithmeticOperator" "$report"; then
+  echo "report.json does not contain any ArithmeticOperator mutants: $report" >&2
+  exit 1
+fi
+
+echo "Found ArithmeticOperator mutant(s) in $report"

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/check-report.sh
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/check-report.sh
@@ -12,7 +12,7 @@ if [ -z "$report" ]; then
   exit 1
 fi
 
-for mutator in ArithmeticOperator NumericLiteral CollectionLiteral ErrorHandling ConditionalEffect FallbackRemoval FallbackInversion SequencingSwap SequencingRemoval TimeoutRemoval GetOrElse ParallelSequentialSwap ResourceFinalizer RefUpdate SleepRemoval; do
+for mutator in ArithmeticOperator NumericLiteral CollectionLiteral ErrorHandling ConditionalEffect FallbackRemoval FallbackInversion SequencingSwap SequencingRemoval TimeoutRemoval GetOrElse ParallelSequentialSwap ResourceFinalizer RefUpdate SleepRemoval CollectionOrder StringNormalization HeadLastSwap; do
   if ! grep -q "$mutator" "$report"; then
     echo "report.json does not contain any $mutator mutants: $report" >&2
     exit 1

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/project/plugins.sbt
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("io.stryker-mutator" % "sbt-stryker4s" % x)
+  case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                               |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/ArithmeticOperatorMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/ArithmeticOperatorMutator.scala
@@ -24,6 +24,6 @@ class ArithmeticOperatorMutator extends CustomMutator {
     val from = term.op.value
     val mutated = term.copyWithComments(op = term.op.copyWithComments(value = to))
     val metadata = MutantMetadata(from, to, "ArithmeticOperator", term.pos, None)
-    Right(NonEmptyVector.one(MutatedCode(mutated, metadata)))
+    Right(NonEmptyVector.one(MutatedCode(placeableTree.substitute(term, mutated), metadata)))
   }
 }

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/ArithmeticOperatorMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/ArithmeticOperatorMutator.scala
@@ -1,0 +1,29 @@
+package example
+
+import cats.data.NonEmptyVector
+import stryker4s.mutatorapi.*
+
+import scala.meta.*
+
+/** Example custom mutator: swaps `+` for `-` (and vice versa) in `Int` arithmetic expressions.
+  *
+  * This demonstrates the "Arithmetic Operator" mutator category that Stryker4s does not ship
+  * built-in, registered here via the `strykerCustomMutators` sbt setting.
+  */
+class ArithmeticOperatorMutator extends CustomMutator {
+  def matcher: MutationMatcher = {
+    case term @ Term.ApplyInfix.After_4_6_0(_, Term.Name("+"), Type.ArgClause(Nil), _) =>
+      mutate(term, "-")
+    case term @ Term.ApplyInfix.After_4_6_0(_, Term.Name("-"), Type.ArgClause(Nil), _) =>
+      mutate(term, "+")
+  }
+
+  private def mutate(term: Term.ApplyInfix, to: String)(
+      placeableTree: PlaceableTree
+  ): Either[IgnoredMutations, Mutations] = {
+    val from = term.op.value
+    val mutated = term.copyWithComments(op = term.op.copyWithComments(value = to))
+    val metadata = MutantMetadata(from, to, "ArithmeticOperator", term.pos, None)
+    Right(NonEmptyVector.one(MutatedCode(mutated, metadata)))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/Calculator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/Calculator.scala
@@ -16,4 +16,12 @@ object Calculator {
   // recovery, causing the ArithmeticException to propagate instead of being recovered to 0).
   def safeDivide(a: Int, b: Int): IO[Int] =
     IO(a / b).handleErrorWith(_ => IO.pure(0))
+
+  // Exercises ConditionalEffectMutator (flipping IO.whenA to IO.unlessA inverts the guard).
+  def rejectOversizedOrder(quantity: Int): IO[Unit] =
+    IO.whenA(quantity > 100)(IO.raiseError(new IllegalArgumentException("oversized order")))
+
+  // Exercises ConditionalEffectMutator (flipping IO.raiseUnless to IO.raiseWhen inverts the guard).
+  def requirePositive(value: Int): IO[Int] =
+    IO.raiseUnless(value > 0)(new IllegalArgumentException("non-positive")).as(value)
 }

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/Calculator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/Calculator.scala
@@ -1,6 +1,7 @@
 package example
 
 import cats.effect.IO
+import cats.syntax.all.*
 
 object Calculator {
   def add(a: Int, b: Int): Int = a + b
@@ -30,4 +31,10 @@ object Calculator {
     (if (primaryAvailable) IO.pure(7)
      else IO.raiseError(new IllegalStateException("primary unavailable")))
       .orElse(IO.pure(42))
+
+  // Exercises SequencingSwapMutator and SequencingRemovalMutator.
+  def auditedOrderTotal: IO[Int] =
+    IO.ref(0).flatMap { auditCount =>
+      auditCount.update(_ + 1).as(1) *> auditCount.get.map(_ + 10)
+    }
 }

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/Calculator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/Calculator.scala
@@ -1,5 +1,7 @@
 package example
 
+import cats.effect.IO
+
 object Calculator {
   def add(a: Int, b: Int): Int = a + b
   def subtract(a: Int, b: Int): Int = a - b
@@ -9,4 +11,9 @@ object Calculator {
 
   // Exercises CollectionLiteralMutator (a non-empty List literal).
   def defaultDiscounts: List[Int] = List(5, 10, 15)
+
+  // Exercises ErrorHandlingMutator (dropping .handleErrorWith removes the division-by-zero
+  // recovery, causing the ArithmeticException to propagate instead of being recovered to 0).
+  def safeDivide(a: Int, b: Int): IO[Int] =
+    IO(a / b).handleErrorWith(_ => IO.pure(0))
 }

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/Calculator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/Calculator.scala
@@ -1,0 +1,6 @@
+package example
+
+object Calculator {
+  def add(a: Int, b: Int): Int = a + b
+  def subtract(a: Int, b: Int): Int = a - b
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/Calculator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/Calculator.scala
@@ -37,4 +37,14 @@ object Calculator {
     IO.ref(0).flatMap { auditCount =>
       auditCount.update(_ + 1).as(1) *> auditCount.get.map(_ + 10)
     }
+
+  // Exercises TimeoutRemovalMutator (removing .timeout lets the slow work finish, so the
+  // quantity is returned instead of the -1 sentinel produced by the timeout recovery).
+  def strictOrderTotal(quantity: Int): IO[Int] =
+    IO.sleep(Deadlines.slowWork).as(quantity).timeout(Deadlines.limit).handleError(_ => -1)
+
+  // Exercises TimeoutRemovalMutator (removing .timeoutTo discards the fallback effect, so the
+  // quantity is returned instead of the -2 sentinel).
+  def orderTotalWithDeadline(quantity: Int): IO[Int] =
+    IO.sleep(Deadlines.slowWork).as(quantity).timeoutTo(Deadlines.limit, IO.pure(-2))
 }

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/Calculator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/Calculator.scala
@@ -68,4 +68,21 @@ object Calculator {
         .use(IO.pure)
         .flatMap(used => releases.get.map(_ + used))
     }
+
+  // Exercises CollectionOrderMutator three times over: dropping any one of .distinct, .sorted or
+  // .reverse leaves a list that differs from the expected one.
+  def descendingDiscounts(discounts: List[Int]): List[Int] =
+    discounts.distinct.sorted.reverse
+
+  // Exercises StringNormalizationMutator three times over (.trim, .toUpperCase, .stripPrefix).
+  def normalizeCode(code: String): String =
+    code.trim.toUpperCase.stripPrefix("SKU-")
+
+  // Exercises HeadLastSwapMutator (.headOption swapped for .lastOption).
+  def firstDiscount(discounts: List[Int]): Option[Int] =
+    discounts.headOption
+
+  // Exercises HeadLastSwapMutator (.tail swapped for .init).
+  def remainingDiscounts(discounts: List[Int]): List[Int] =
+    discounts.tail
 }

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/Calculator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/Calculator.scala
@@ -24,4 +24,10 @@ object Calculator {
   // Exercises ConditionalEffectMutator (flipping IO.raiseUnless to IO.raiseWhen inverts the guard).
   def requirePositive(value: Int): IO[Int] =
     IO.raiseUnless(value > 0)(new IllegalArgumentException("non-positive")).as(value)
+
+  // Exercises FallbackRemovalMutator and FallbackInversionMutator.
+  def orderTotalWithFallback(primaryAvailable: Boolean): IO[Int] =
+    (if (primaryAvailable) IO.pure(7)
+     else IO.raiseError(new IllegalStateException("primary unavailable")))
+      .orElse(IO.pure(42))
 }

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/Calculator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/Calculator.scala
@@ -1,6 +1,7 @@
 package example
 
 import cats.effect.IO
+import cats.effect.Resource
 import cats.syntax.all.*
 
 object Calculator {
@@ -29,13 +30,13 @@ object Calculator {
   // Exercises FallbackRemovalMutator and FallbackInversionMutator.
   def orderTotalWithFallback(primaryAvailable: Boolean): IO[Int] =
     (if (primaryAvailable) IO.pure(7)
-     else IO.raiseError(new IllegalStateException("primary unavailable")))
+     else IO.raiseError(new IllegalStateException(Sentinels.primaryUnavailable)))
       .orElse(IO.pure(42))
 
   // Exercises SequencingSwapMutator and SequencingRemovalMutator.
   def auditedOrderTotal: IO[Int] =
     IO.ref(0).flatMap { auditCount =>
-      auditCount.update(_ + 1).as(1) *> auditCount.get.map(_ + 10)
+      auditCount.update(_ + 1).as(Sentinels.discardedAudit) *> auditCount.get.map(_ + 10)
     }
 
   // Exercises TimeoutRemovalMutator (removing .timeout lets the slow work finish, so the
@@ -47,4 +48,24 @@ object Calculator {
   // quantity is returned instead of the -2 sentinel).
   def orderTotalWithDeadline(quantity: Int): IO[Int] =
     IO.sleep(Deadlines.slowWork).as(quantity).timeoutTo(Deadlines.limit, IO.pure(-2))
+
+  // Exercises GetOrElseMutator (forcing the default discards the supplied quantity).
+  def quantityOrDefault(maybeQuantity: Option[Int]): Int =
+    maybeQuantity.getOrElse(1)
+
+  // Exercises ParallelSequentialSwapMutator. `traverse` over Either short-circuits at the first
+  // Left, whereas `parTraverse` goes through Validated and accumulates every Left, so swapping
+  // the two is observable without depending on timing or thread scheduling.
+  def validateAll(values: List[Int]): Either[List[Int], List[Int]] =
+    values.traverse(value => Either.cond(value > 0, value, value :: Nil))
+
+  // Exercises ResourceFinalizerMutator (dropping the release leaves the counter at zero) and
+  // RefUpdateMutator (neutralising the update does the same).
+  def trackedResource: IO[Int] =
+    IO.ref(0).flatMap { releases =>
+      Resource
+        .make(IO.pure(7))(_ => releases.update(_ + 1))
+        .use(IO.pure)
+        .flatMap(used => releases.get.map(_ + used))
+    }
 }

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/Calculator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/Calculator.scala
@@ -3,4 +3,10 @@ package example
 object Calculator {
   def add(a: Int, b: Int): Int = a + b
   def subtract(a: Int, b: Int): Int = a - b
+
+  // Exercises NumericLiteralMutator (10 is a numeric literal threshold).
+  def isLargeOrder(quantity: Int): Boolean = quantity > 10
+
+  // Exercises CollectionLiteralMutator (a non-empty List literal).
+  def defaultDiscounts: List[Int] = List(5, 10, 15)
 }

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/CollectionLiteralMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/CollectionLiteralMutator.scala
@@ -29,6 +29,6 @@ class CollectionLiteralMutator extends CustomMutator {
   ): Either[IgnoredMutations, Mutations] = {
     val mutated = Term.Select(Term.Name(collectionName), Term.Name("empty"))
     val metadata = MutantMetadata(term.reprint(), mutated.reprint(), "CollectionLiteral", term.pos, None)
-    Right(NonEmptyVector.one(MutatedCode(mutated, metadata)))
+    Right(NonEmptyVector.one(MutatedCode(placeableTree.substitute(term, mutated), metadata)))
   }
 }

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/CollectionLiteralMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/CollectionLiteralMutator.scala
@@ -6,13 +6,13 @@ import stryker4s.mutatorapi.*
 import scala.meta.*
 import scala.meta.prettyprinters.XtensionReprint
 
-/** Example custom mutator: replaces non-empty `List(...)`/`Seq(...)`/`Vector(...)` literal construction with the
-  * type's `.empty` collection.
+/** Example custom mutator: replaces non-empty `List(...)`/`Seq(...)`/`Vector(...)` literal construction with the type's
+  * `.empty` collection.
   *
-  * Demonstrates the "Array/Collection Literal" mutator category that Stryker4s does not ship built-in, registered
-  * here via the `strykerCustomMutators` sbt setting. Restricted to a small, explicit allow-list of collection
-  * factory names to avoid false-positive matches on user-defined `apply` methods with the same name (this codebase
-  * has no type information available at match time, so this syntactic restriction is the safest we can do).
+  * Demonstrates the "Array/Collection Literal" mutator category that Stryker4s does not ship built-in, registered here
+  * via the `strykerCustomMutators` sbt setting. Restricted to a small, explicit allow-list of collection factory names
+  * to avoid false-positive matches on user-defined `apply` methods with the same name (this codebase has no type
+  * information available at match time, so this syntactic restriction is the safest we can do).
   */
 class CollectionLiteralMutator extends CustomMutator {
   private def isCollectionName(name: String): Boolean =

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/CollectionLiteralMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/CollectionLiteralMutator.scala
@@ -1,0 +1,34 @@
+package example
+
+import cats.data.NonEmptyVector
+import stryker4s.mutatorapi.*
+
+import scala.meta.*
+import scala.meta.prettyprinters.XtensionReprint
+
+/** Example custom mutator: replaces non-empty `List(...)`/`Seq(...)`/`Vector(...)` literal construction with the
+  * type's `.empty` collection.
+  *
+  * Demonstrates the "Array/Collection Literal" mutator category that Stryker4s does not ship built-in, registered
+  * here via the `strykerCustomMutators` sbt setting. Restricted to a small, explicit allow-list of collection
+  * factory names to avoid false-positive matches on user-defined `apply` methods with the same name (this codebase
+  * has no type information available at match time, so this syntactic restriction is the safest we can do).
+  */
+class CollectionLiteralMutator extends CustomMutator {
+  private def isCollectionName(name: String): Boolean =
+    name == "List" || name == "Seq" || name == "Vector"
+
+  def matcher: MutationMatcher = {
+    case term @ Term.Apply.After_4_6_0(Term.Name(name), Term.ArgClause(args, _))
+        if isCollectionName(name) && args.nonEmpty =>
+      mutate(term, name)
+  }
+
+  private def mutate(term: Term.Apply, collectionName: String)(
+      placeableTree: PlaceableTree
+  ): Either[IgnoredMutations, Mutations] = {
+    val mutated = Term.Select(Term.Name(collectionName), Term.Name("empty"))
+    val metadata = MutantMetadata(term.reprint(), mutated.reprint(), "CollectionLiteral", term.pos, None)
+    Right(NonEmptyVector.one(MutatedCode(mutated, metadata)))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/CollectionOrderMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/CollectionOrderMutator.scala
@@ -7,9 +7,9 @@ import scala.meta.*
 
 /** Example custom mutator: removes collection ordering and de-duplication.
   *
-  * `discounts.sorted`, `discounts.reverse`, `discounts.distinct`, `discounts.sortBy(f)`,
-  * `discounts.sortWith(f)` and `discounts.distinctBy(f)` all become just `discounts`. The collection is still there;
-  * only the guarantee about its order or uniqueness is gone.
+  * `discounts.sorted`, `discounts.reverse`, `discounts.distinct`, `discounts.sortBy(f)`, `discounts.sortWith(f)` and
+  * `discounts.distinctBy(f)` all become just `discounts`. The collection is still there; only the guarantee about its
+  * order or uniqueness is gone.
   *
   * This targets a bug class that is easy to under-test because the input often happens to be sorted or duplicate-free
   * already. A test that builds its fixture in the order it expects back cannot tell whether the sort runs, and neither

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/CollectionOrderMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/CollectionOrderMutator.scala
@@ -1,0 +1,51 @@
+package example
+
+import cats.data.NonEmptyVector
+import stryker4s.mutatorapi.*
+
+import scala.meta.*
+
+/** Example custom mutator: removes collection ordering and de-duplication.
+  *
+  * `discounts.sorted`, `discounts.reverse`, `discounts.distinct`, `discounts.sortBy(f)`,
+  * `discounts.sortWith(f)` and `discounts.distinctBy(f)` all become just `discounts`. The collection is still there;
+  * only the guarantee about its order or uniqueness is gone.
+  *
+  * This targets a bug class that is easy to under-test because the input often happens to be sorted or duplicate-free
+  * already. A test that builds its fixture in the order it expects back cannot tell whether the sort runs, and neither
+  * can a test that never supplies a duplicate. Surviving mutants here point at exactly those tests.
+  *
+  * Note the asymmetry with [[HeadLastSwapMutator]]: this mutator *drops* a selection, so it must not match the function
+  * of an enclosing `Term.Apply`. Dropping the selection of `discounts.sorted(ordering)` would leave
+  * `discounts(ordering)`, which cannot compile. A mutator that only *renames* a selection has no such constraint.
+  */
+class CollectionOrderMutator extends CustomMutator {
+  private def isAppliedCombinator(name: String): Boolean =
+    name == "sortBy" || name == "sortWith" || name == "distinctBy"
+
+  private def isNoArgCombinator(name: String): Boolean =
+    name == "sorted" || name == "reverse" || name == "distinct"
+
+  def matcher: MutationMatcher = {
+    case term @ Term.Apply.After_4_6_0(Term.Select(receiver, Term.Name(name)), _) if isAppliedCombinator(name) =>
+      mutate(term, receiver, name)
+    case term @ Term.Select(receiver, Term.Name(name)) if isNoArgCombinator(name) && !isAppliedTo(term) =>
+      mutate(term, receiver, name)
+  }
+
+  /** True when this term is the function of an enclosing call, as `discounts.sorted` is in `discounts.sorted(ordering)`
+    * — in which case dropping it would strand the argument list.
+    */
+  private def isAppliedTo(term: Term): Boolean =
+    term.parent.exists {
+      case Term.Apply.After_4_6_0(fun, _) => fun eq term
+      case _                              => false
+    }
+
+  private def mutate(term: Term, receiver: Term, removed: String)(
+      placeableTree: PlaceableTree
+  ): Either[IgnoredMutations, Mutations] = {
+    val metadata = MutantMetadata(removed, "unordered", "CollectionOrder", term.pos, None)
+    Right(NonEmptyVector.one(MutatedCode(placeableTree.substitute(term, receiver), metadata)))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/ConditionalEffectMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/ConditionalEffectMutator.scala
@@ -8,13 +8,13 @@ import scala.meta.*
 /** Example custom mutator: flips cats-effect conditional effect helpers (`IO.whenA`/`IO.unlessA`,
   * `IO.raiseWhen`/`IO.raiseUnless`).
   *
-  * These helpers encode side-effecting boolean guards, so flipping the guard helper tests whether
-  * the suite distinguishes "run this effect when the condition is true" from "run this effect when
-  * the condition is false". This is a cats-effect-specific equivalent of a conditional-boundary
-  * mutator, but targeted at pure-FP effect construction rather than imperative `if` statements.
+  * These helpers encode side-effecting boolean guards, so flipping the guard helper tests whether the suite
+  * distinguishes "run this effect when the condition is true" from "run this effect when the condition is false". This
+  * is a cats-effect-specific equivalent of a conditional-boundary mutator, but targeted at pure-FP effect construction
+  * rather than imperative `if` statements.
   *
-  * Purely syntactic: only matches two-argument-list calls on an `IO` receiver, such as
-  * `IO.whenA(flag)(effect)` or `cats.effect.IO.raiseUnless(flag)(error)`.
+  * Purely syntactic: only matches two-argument-list calls on an `IO` receiver, such as `IO.whenA(flag)(effect)` or
+  * `cats.effect.IO.raiseUnless(flag)(error)`.
   */
 class ConditionalEffectMutator extends CustomMutator {
   def matcher: MutationMatcher = {
@@ -32,16 +32,16 @@ class ConditionalEffectMutator extends CustomMutator {
 
   private def isIoReceiver(receiver: Term): Boolean =
     receiver match {
-      case Term.Name("IO") => true
+      case Term.Name("IO")                 => true
       case Term.Select(_, Term.Name("IO")) => true
-      case _ => false
+      case _                               => false
     }
 
   private def flippedName(name: String): String =
     name match {
-      case "whenA" => "unlessA"
-      case "unlessA" => "whenA"
-      case "raiseWhen" => "raiseUnless"
+      case "whenA"       => "unlessA"
+      case "unlessA"     => "whenA"
+      case "raiseWhen"   => "raiseUnless"
       case "raiseUnless" => "raiseWhen"
     }
 

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/ConditionalEffectMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/ConditionalEffectMutator.scala
@@ -53,6 +53,6 @@ class ConditionalEffectMutator extends CustomMutator {
   ): Either[IgnoredMutations, Mutations] = {
     val metadata =
       MutantMetadata(s".$originalName", s".$replacementName", "ConditionalEffect", term.pos, None)
-    Right(NonEmptyVector.one(MutatedCode(replacement, metadata)))
+    Right(NonEmptyVector.one(MutatedCode(placeableTree.substitute(term, replacement), metadata)))
   }
 }

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/ConditionalEffectMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/ConditionalEffectMutator.scala
@@ -1,0 +1,58 @@
+package example
+
+import cats.data.NonEmptyVector
+import stryker4s.mutatorapi.*
+
+import scala.meta.*
+
+/** Example custom mutator: flips cats-effect conditional effect helpers (`IO.whenA`/`IO.unlessA`,
+  * `IO.raiseWhen`/`IO.raiseUnless`).
+  *
+  * These helpers encode side-effecting boolean guards, so flipping the guard helper tests whether
+  * the suite distinguishes "run this effect when the condition is true" from "run this effect when
+  * the condition is false". This is a cats-effect-specific equivalent of a conditional-boundary
+  * mutator, but targeted at pure-FP effect construction rather than imperative `if` statements.
+  *
+  * Purely syntactic: only matches two-argument-list calls on an `IO` receiver, such as
+  * `IO.whenA(flag)(effect)` or `cats.effect.IO.raiseUnless(flag)(error)`.
+  */
+class ConditionalEffectMutator extends CustomMutator {
+  def matcher: MutationMatcher = {
+    case term @ Term.Apply.After_4_6_0(
+          Term.Apply.After_4_6_0(Term.Select(receiver, Term.Name(name)), conditionArgs),
+          effectArgs
+        ) if isIoReceiver(receiver) && isConditionalEffectHelper(name) =>
+      val replacementName = flippedName(name)
+      val replacement = Term.Apply(
+        Term.Apply(Term.Select(receiver, Term.Name(replacementName)), conditionArgs),
+        effectArgs
+      )
+      mutate(term, replacement, name, replacementName)
+  }
+
+  private def isIoReceiver(receiver: Term): Boolean =
+    receiver match {
+      case Term.Name("IO") => true
+      case Term.Select(_, Term.Name("IO")) => true
+      case _ => false
+    }
+
+  private def flippedName(name: String): String =
+    name match {
+      case "whenA" => "unlessA"
+      case "unlessA" => "whenA"
+      case "raiseWhen" => "raiseUnless"
+      case "raiseUnless" => "raiseWhen"
+    }
+
+  private def isConditionalEffectHelper(name: String): Boolean =
+    name == "whenA" || name == "unlessA" || name == "raiseWhen" || name == "raiseUnless"
+
+  private def mutate(term: Term, replacement: Term, originalName: String, replacementName: String)(
+      placeableTree: PlaceableTree
+  ): Either[IgnoredMutations, Mutations] = {
+    val metadata =
+      MutantMetadata(s".$originalName", s".$replacementName", "ConditionalEffect", term.pos, None)
+    Right(NonEmptyVector.one(MutatedCode(replacement, metadata)))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/Deadlines.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/Deadlines.scala
@@ -1,0 +1,17 @@
+package example
+
+import scala.concurrent.duration.*
+
+/** Deadlines used by [[Calculator]].
+  *
+  * These live outside `Calculator.scala` on purpose: only that file is listed in `strykerMutate`,
+  * so keeping the durations here stops `NumericLiteralMutator` from producing equivalent mutants
+  * (nudging a 200ms sleep to 201ms changes nothing observable) that would otherwise survive and
+  * depress the mutation score for no useful reason.
+  */
+object Deadlines {
+  /** Comfortably longer than [[limit]], so the deadline always fires. */
+  val slowWork: FiniteDuration = 200.millis
+
+  val limit: FiniteDuration = 10.millis
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/Deadlines.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/Deadlines.scala
@@ -4,12 +4,12 @@ import scala.concurrent.duration.*
 
 /** Deadlines used by [[Calculator]].
   *
-  * These live outside `Calculator.scala` on purpose: only that file is listed in `strykerMutate`,
-  * so keeping the durations here stops `NumericLiteralMutator` from producing equivalent mutants
-  * (nudging a 200ms sleep to 201ms changes nothing observable) that would otherwise survive and
-  * depress the mutation score for no useful reason.
+  * These live outside `Calculator.scala` on purpose: only that file is listed in `strykerMutate`, so keeping the
+  * durations here stops `NumericLiteralMutator` from producing equivalent mutants (nudging a 200ms sleep to 201ms
+  * changes nothing observable) that would otherwise survive and depress the mutation score for no useful reason.
   */
 object Deadlines {
+
   /** Comfortably longer than [[limit]], so the deadline always fires. */
   val slowWork: FiniteDuration = 200.millis
 

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/ErrorHandlingMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/ErrorHandlingMutator.scala
@@ -1,0 +1,46 @@
+package example
+
+import cats.data.NonEmptyVector
+import stryker4s.mutatorapi.*
+
+import scala.meta.*
+
+/** Example custom mutator: drops cats-effect/cats `MonadThrow`/`ApplicativeError` error-handling
+  * combinators (`.attempt`, `.handleErrorWith`, `.handleError`, `.recover`, `.recoverWith`,
+  * `.rethrow`), replacing `effect.combinator(...)` (or bare `effect.rethrow`/`effect.attempt`) with
+  * just `effect`.
+  *
+  * Demonstrates a mutator category not covered by any of Stryker4s's built-in mutators nor by the
+  * generic imperative-language categories (Arithmetic/Numeric/Collection Literal) added earlier:
+  * FP error-handling paths. Dropping the combinator either removes error recovery entirely (so a
+  * failure that should have been recovered now propagates) or removes error capture (so a failure
+  * that should have been turned into a value now propagates) — both are realistic, high-value
+  * mutants that specifically test whether error-handling logic is exercised by tests.
+  *
+  * Purely syntactic: matches on the method name in a `Term.Select`/`Term.Apply` and produces a
+  * mutant that is just the receiver expression, dropping the wrapper — the same shape as
+  * `CollectionLiteralMutator`, with no dependency on type information (so it can't distinguish a
+  * real `IO`/`F[_]` receiver from an unrelated type that happens to define a same-named method;
+  * acceptable here since these method names are effectively reserved vocabulary in the
+  * cats/cats-effect ecosystem).
+  */
+class ErrorHandlingMutator extends CustomMutator {
+  private def isErrorHandlingCombinator(name: String): Boolean =
+    name == "attempt" || name == "handleErrorWith" || name == "handleError" ||
+      name == "recover" || name == "recoverWith" || name == "rethrow"
+
+  def matcher: MutationMatcher = {
+    case term @ Term.Apply.After_4_6_0(Term.Select(receiver, Term.Name(name)), _)
+        if isErrorHandlingCombinator(name) =>
+      mutate(term, receiver, name)
+    case term @ Term.Select(receiver, Term.Name(name)) if isErrorHandlingCombinator(name) =>
+      mutate(term, receiver, name)
+  }
+
+  private def mutate(term: Term, receiver: Term, combinatorName: String)(
+      placeableTree: PlaceableTree
+  ): Either[IgnoredMutations, Mutations] = {
+    val metadata = MutantMetadata(s".$combinatorName", "", "ErrorHandling", term.pos, None)
+    Right(NonEmptyVector.one(MutatedCode(receiver, metadata)))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/ErrorHandlingMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/ErrorHandlingMutator.scala
@@ -20,16 +20,23 @@ import scala.meta.*
   * information (so it can't distinguish a real `IO`/`F[_]` receiver from an unrelated type that happens to define a
   * same-named method; acceptable here since these method names are effectively reserved vocabulary in the
   * cats/cats-effect ecosystem).
+  *
+  * The applied combinators (`handleErrorWith` and friends) and the no-argument ones (`attempt`, `rethrow`) are kept in
+  * disjoint sets on purpose. Stryker4s walks every node of the tree, so matching both `effect.recover(f)` and its inner
+  * `effect.recover` selection would emit two mutants for one combinator — and the second would drop only the selection
+  * and leave the argument list behind, as in `IO(a / b)(_ => IO.pure(0))`, which cannot compile.
   */
 class ErrorHandlingMutator extends CustomMutator {
-  private def isErrorHandlingCombinator(name: String): Boolean =
-    name == "attempt" || name == "handleErrorWith" || name == "handleError" ||
-      name == "recover" || name == "recoverWith" || name == "rethrow"
+  private def isAppliedCombinator(name: String): Boolean =
+    name == "handleErrorWith" || name == "handleError" || name == "recover" || name == "recoverWith"
+
+  private def isNoArgCombinator(name: String): Boolean =
+    name == "attempt" || name == "rethrow"
 
   def matcher: MutationMatcher = {
-    case term @ Term.Apply.After_4_6_0(Term.Select(receiver, Term.Name(name)), _) if isErrorHandlingCombinator(name) =>
+    case term @ Term.Apply.After_4_6_0(Term.Select(receiver, Term.Name(name)), _) if isAppliedCombinator(name) =>
       mutate(term, receiver, name)
-    case term @ Term.Select(receiver, Term.Name(name)) if isErrorHandlingCombinator(name) =>
+    case term @ Term.Select(receiver, Term.Name(name)) if isNoArgCombinator(name) =>
       mutate(term, receiver, name)
   }
 
@@ -37,6 +44,6 @@ class ErrorHandlingMutator extends CustomMutator {
       placeableTree: PlaceableTree
   ): Either[IgnoredMutations, Mutations] = {
     val metadata = MutantMetadata(s".$combinatorName", "", "ErrorHandling", term.pos, None)
-    Right(NonEmptyVector.one(MutatedCode(receiver, metadata)))
+    Right(NonEmptyVector.one(MutatedCode(placeableTree.substitute(term, receiver), metadata)))
   }
 }

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/ErrorHandlingMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/ErrorHandlingMutator.scala
@@ -5,23 +5,20 @@ import stryker4s.mutatorapi.*
 
 import scala.meta.*
 
-/** Example custom mutator: drops cats-effect/cats `MonadThrow`/`ApplicativeError` error-handling
-  * combinators (`.attempt`, `.handleErrorWith`, `.handleError`, `.recover`, `.recoverWith`,
-  * `.rethrow`), replacing `effect.combinator(...)` (or bare `effect.rethrow`/`effect.attempt`) with
-  * just `effect`.
+/** Example custom mutator: drops cats-effect/cats `MonadThrow`/`ApplicativeError` error-handling combinators
+  * (`.attempt`, `.handleErrorWith`, `.handleError`, `.recover`, `.recoverWith`, `.rethrow`), replacing
+  * `effect.combinator(...)` (or bare `effect.rethrow`/`effect.attempt`) with just `effect`.
   *
-  * Demonstrates a mutator category not covered by any of Stryker4s's built-in mutators nor by the
-  * generic imperative-language categories (Arithmetic/Numeric/Collection Literal) added earlier:
-  * FP error-handling paths. Dropping the combinator either removes error recovery entirely (so a
-  * failure that should have been recovered now propagates) or removes error capture (so a failure
-  * that should have been turned into a value now propagates) — both are realistic, high-value
-  * mutants that specifically test whether error-handling logic is exercised by tests.
+  * Demonstrates a mutator category not covered by any of Stryker4s's built-in mutators nor by the generic
+  * imperative-language categories (Arithmetic/Numeric/Collection Literal) added earlier: FP error-handling paths.
+  * Dropping the combinator either removes error recovery entirely (so a failure that should have been recovered now
+  * propagates) or removes error capture (so a failure that should have been turned into a value now propagates) — both
+  * are realistic, high-value mutants that specifically test whether error-handling logic is exercised by tests.
   *
-  * Purely syntactic: matches on the method name in a `Term.Select`/`Term.Apply` and produces a
-  * mutant that is just the receiver expression, dropping the wrapper — the same shape as
-  * `CollectionLiteralMutator`, with no dependency on type information (so it can't distinguish a
-  * real `IO`/`F[_]` receiver from an unrelated type that happens to define a same-named method;
-  * acceptable here since these method names are effectively reserved vocabulary in the
+  * Purely syntactic: matches on the method name in a `Term.Select`/`Term.Apply` and produces a mutant that is just the
+  * receiver expression, dropping the wrapper — the same shape as `CollectionLiteralMutator`, with no dependency on type
+  * information (so it can't distinguish a real `IO`/`F[_]` receiver from an unrelated type that happens to define a
+  * same-named method; acceptable here since these method names are effectively reserved vocabulary in the
   * cats/cats-effect ecosystem).
   */
 class ErrorHandlingMutator extends CustomMutator {
@@ -30,8 +27,7 @@ class ErrorHandlingMutator extends CustomMutator {
       name == "recover" || name == "recoverWith" || name == "rethrow"
 
   def matcher: MutationMatcher = {
-    case term @ Term.Apply.After_4_6_0(Term.Select(receiver, Term.Name(name)), _)
-        if isErrorHandlingCombinator(name) =>
+    case term @ Term.Apply.After_4_6_0(Term.Select(receiver, Term.Name(name)), _) if isErrorHandlingCombinator(name) =>
       mutate(term, receiver, name)
     case term @ Term.Select(receiver, Term.Name(name)) if isErrorHandlingCombinator(name) =>
       mutate(term, receiver, name)

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/FallbackMutators.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/FallbackMutators.scala
@@ -1,0 +1,55 @@
+package example
+
+import cats.data.NonEmptyVector
+import stryker4s.mutatorapi.*
+
+import scala.meta.*
+
+/** Example custom mutator: removes cats-effect fallback behavior by replacing
+  * `primary.orElse(fallback)` with just `primary`.
+  */
+class FallbackRemovalMutator extends CustomMutator {
+  def matcher: MutationMatcher = {
+    case term @ Term.Apply.After_4_6_0(
+          Term.Select(primary, Term.Name("orElse")),
+          Term.ArgClause(args, _)
+        ) if args.size == 1 =>
+      mutate(term, primary, ".orElse", "", "FallbackRemoval")
+  }
+
+  private def mutate(
+      term: Term,
+      replacement: Term,
+      original: String,
+      replacementDescription: String,
+      mutatorName: String
+  )(placeableTree: PlaceableTree): Either[IgnoredMutations, Mutations] = {
+    val metadata = MutantMetadata(original, replacementDescription, mutatorName, term.pos, None)
+    Right(NonEmptyVector.one(MutatedCode(replacement, metadata)))
+  }
+}
+
+/** Example custom mutator: inverts cats-effect fallback behavior by replacing
+  * `primary.orElse(fallback)` with just `fallback`.
+  */
+class FallbackInversionMutator extends CustomMutator {
+  def matcher: MutationMatcher = {
+    case term @ Term.Apply.After_4_6_0(
+          Term.Select(_, Term.Name("orElse")),
+          Term.ArgClause(args, _)
+        ) if args.size == 1 =>
+      val fallback = args.head
+      mutate(term, fallback, ".orElse", "fallback", "FallbackInversion")
+  }
+
+  private def mutate(
+      term: Term,
+      replacement: Term,
+      original: String,
+      replacementDescription: String,
+      mutatorName: String
+  )(placeableTree: PlaceableTree): Either[IgnoredMutations, Mutations] = {
+    val metadata = MutantMetadata(original, replacementDescription, mutatorName, term.pos, None)
+    Right(NonEmptyVector.one(MutatedCode(replacement, metadata)))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/FallbackMutators.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/FallbackMutators.scala
@@ -25,7 +25,7 @@ class FallbackRemovalMutator extends CustomMutator {
       mutatorName: String
   )(placeableTree: PlaceableTree): Either[IgnoredMutations, Mutations] = {
     val metadata = MutantMetadata(original, replacementDescription, mutatorName, term.pos, None)
-    Right(NonEmptyVector.one(MutatedCode(replacement, metadata)))
+    Right(NonEmptyVector.one(MutatedCode(placeableTree.substitute(term, replacement), metadata)))
   }
 }
 
@@ -50,6 +50,6 @@ class FallbackInversionMutator extends CustomMutator {
       mutatorName: String
   )(placeableTree: PlaceableTree): Either[IgnoredMutations, Mutations] = {
     val metadata = MutantMetadata(original, replacementDescription, mutatorName, term.pos, None)
-    Right(NonEmptyVector.one(MutatedCode(replacement, metadata)))
+    Right(NonEmptyVector.one(MutatedCode(placeableTree.substitute(term, replacement), metadata)))
   }
 }

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/FallbackMutators.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/FallbackMutators.scala
@@ -5,8 +5,8 @@ import stryker4s.mutatorapi.*
 
 import scala.meta.*
 
-/** Example custom mutator: removes cats-effect fallback behavior by replacing
-  * `primary.orElse(fallback)` with just `primary`.
+/** Example custom mutator: removes cats-effect fallback behavior by replacing `primary.orElse(fallback)` with just
+  * `primary`.
   */
 class FallbackRemovalMutator extends CustomMutator {
   def matcher: MutationMatcher = {
@@ -29,8 +29,8 @@ class FallbackRemovalMutator extends CustomMutator {
   }
 }
 
-/** Example custom mutator: inverts cats-effect fallback behavior by replacing
-  * `primary.orElse(fallback)` with just `fallback`.
+/** Example custom mutator: inverts cats-effect fallback behavior by replacing `primary.orElse(fallback)` with just
+  * `fallback`.
   */
 class FallbackInversionMutator extends CustomMutator {
   def matcher: MutationMatcher = {

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/GetOrElseMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/GetOrElseMutator.scala
@@ -7,13 +7,12 @@ import scala.meta.*
 
 /** Example custom mutator: forces the default branch of `getOrElse`.
   *
-  * `maybeQuantity.getOrElse(0)` becomes `0`, so the value carried by a `Some`/`Right` is never
-  * used. This tests whether a suite covers the present case at all, or only ever exercises the
-  * empty case where the default is returned anyway.
+  * `maybeQuantity.getOrElse(0)` becomes `0`, so the value carried by a `Some`/`Right` is never used. This tests whether
+  * a suite covers the present case at all, or only ever exercises the empty case where the default is returned anyway.
   *
-  * Both the one-argument form (`Option`, `Either`, `IO`-like) and the two-argument `Map` form
-  * (`map.getOrElse(key, default)`) are handled by always taking the last argument, which is the
-  * default in both. `getOrElseF` is covered as well, since cats uses it for the effectful variant.
+  * Both the one-argument form (`Option`, `Either`, `IO`-like) and the two-argument `Map` form (`map.getOrElse(key,
+  * default)`) are handled by always taking the last argument, which is the default in both. `getOrElseF` is covered as
+  * well, since cats uses it for the effectful variant.
   */
 class GetOrElseMutator extends CustomMutator {
   def matcher: MutationMatcher = {

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/GetOrElseMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/GetOrElseMutator.scala
@@ -1,0 +1,44 @@
+package example
+
+import cats.data.NonEmptyVector
+import stryker4s.mutatorapi.*
+
+import scala.meta.*
+
+/** Example custom mutator: forces the default branch of `getOrElse`.
+  *
+  * `maybeQuantity.getOrElse(0)` becomes `0`, so the value carried by a `Some`/`Right` is never
+  * used. This tests whether a suite covers the present case at all, or only ever exercises the
+  * empty case where the default is returned anyway.
+  *
+  * Both the one-argument form (`Option`, `Either`, `IO`-like) and the two-argument `Map` form
+  * (`map.getOrElse(key, default)`) are handled by always taking the last argument, which is the
+  * default in both. `getOrElseF` is covered as well, since cats uses it for the effectful variant.
+  */
+class GetOrElseMutator extends CustomMutator {
+  def matcher: MutationMatcher = {
+    case term @ Term.Apply.After_4_6_0(Term.Select(_, Term.Name(name)), args)
+        if isGetOrElse(name) && hasDefaultArgument(args) =>
+      mutate(term, defaultArgument(args), name)
+    case term @ Term.ApplyInfix.After_4_6_0(_, Term.Name(name), Type.ArgClause(Nil), args)
+        if isGetOrElse(name) && hasDefaultArgument(args) =>
+      mutate(term, defaultArgument(args), name)
+  }
+
+  private def isGetOrElse(name: String): Boolean =
+    name == "getOrElse" || name == "getOrElseF"
+
+  /** One argument for `Option`/`Either`, two for `Map` (`key` then `default`). */
+  private def hasDefaultArgument(args: Term.ArgClause): Boolean =
+    args.values.size == 1 || args.values.size == 2
+
+  private def defaultArgument(args: Term.ArgClause): Term =
+    args.values.last
+
+  private def mutate(term: Term, replacement: Term, removed: String)(
+      placeableTree: PlaceableTree
+  ): Either[IgnoredMutations, Mutations] = {
+    val metadata = MutantMetadata(removed, "default", "GetOrElse", term.pos, None)
+    Right(NonEmptyVector.one(MutatedCode(placeableTree.substitute(term, replacement), metadata)))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/HeadLastSwapMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/HeadLastSwapMutator.scala
@@ -1,0 +1,40 @@
+package example
+
+import cats.data.NonEmptyVector
+import stryker4s.mutatorapi.*
+
+import scala.meta.*
+
+/** Example custom mutator: swaps collection endpoints.
+  *
+  * `.head` becomes `.last`, `.headOption` becomes `.lastOption`, `.init` becomes `.tail`, and each swap also applies in
+  * reverse.
+  *
+  * Off-by-one-at-the-end is a classic bug, and it is invisible to a test whose fixture happens to be a singleton or a
+  * list of identical elements — which is what most fixtures are. Killing these mutants forces a fixture whose first and
+  * last elements actually differ.
+  *
+  * Unlike [[CollectionOrderMutator]] and [[StringNormalizationMutator]], this mutator *renames* a selection rather than
+  * dropping it, so it needs no guard against being the function of an enclosing `Term.Apply`: `xs.last(i)` compiles
+  * just as `xs.head(i)` does.
+  */
+class HeadLastSwapMutator extends CustomMutator {
+  private def swapped(name: String): String =
+    if (name == "head") "last"
+    else if (name == "last") "head"
+    else if (name == "headOption") "lastOption"
+    else if (name == "lastOption") "headOption"
+    else if (name == "init") "tail"
+    else if (name == "tail") "init"
+    else ""
+
+  def matcher: MutationMatcher = {
+    case term @ Term.Select(receiver, Term.Name(name)) if swapped(name).nonEmpty =>
+      placeableTree => {
+        val replacementName = swapped(name)
+        val replacement = Term.Select(receiver, Term.Name(replacementName))
+        val metadata = MutantMetadata(name, replacementName, "HeadLastSwap", term.pos, None)
+        Right(NonEmptyVector.one(MutatedCode(placeableTree.substitute(term, replacement), metadata)))
+      }
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/NumericLiteralMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/NumericLiteralMutator.scala
@@ -7,12 +7,12 @@ import scala.meta.*
 
 /** Example custom mutator: increments integer literals by 1 (e.g. `10` -> `11`).
   *
-  * Demonstrates the "Numeric Literal" mutator category that Stryker4s does not ship built-in, registered here via
-  * the `strykerCustomMutators` sbt setting. Purely syntactic (operates on `Lit.Int` nodes), with no dependency on
-  * type information — matching the same style as Stryker4s's built-in `StringLiteral`/`BooleanLiteral` mutators.
-  * Only produces a single (+1) mutant per literal, since scalameta trees created reflectively across a
-  * classloader boundary can't safely use varargs-based collection construction (e.g. `NonEmptyVector.of`,
-  * `Vector(...)`) — see the classloader-identity notes in `docs/configuration.md`.
+  * Demonstrates the "Numeric Literal" mutator category that Stryker4s does not ship built-in, registered here via the
+  * `strykerCustomMutators` sbt setting. Purely syntactic (operates on `Lit.Int` nodes), with no dependency on type
+  * information — matching the same style as Stryker4s's built-in `StringLiteral`/`BooleanLiteral` mutators. Only
+  * produces a single (+1) mutant per literal, since scalameta trees created reflectively across a classloader boundary
+  * can't safely use varargs-based collection construction (e.g. `NonEmptyVector.of`, `Vector(...)`) — see the
+  * classloader-identity notes in `docs/configuration.md`.
   */
 class NumericLiteralMutator extends CustomMutator {
   def matcher: MutationMatcher = { case lit @ Lit.Int(value) =>

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/NumericLiteralMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/NumericLiteralMutator.scala
@@ -1,0 +1,29 @@
+package example
+
+import cats.data.NonEmptyVector
+import stryker4s.mutatorapi.*
+
+import scala.meta.*
+
+/** Example custom mutator: increments integer literals by 1 (e.g. `10` -> `11`).
+  *
+  * Demonstrates the "Numeric Literal" mutator category that Stryker4s does not ship built-in, registered here via
+  * the `strykerCustomMutators` sbt setting. Purely syntactic (operates on `Lit.Int` nodes), with no dependency on
+  * type information — matching the same style as Stryker4s's built-in `StringLiteral`/`BooleanLiteral` mutators.
+  * Only produces a single (+1) mutant per literal, since scalameta trees created reflectively across a
+  * classloader boundary can't safely use varargs-based collection construction (e.g. `NonEmptyVector.of`,
+  * `Vector(...)`) — see the classloader-identity notes in `docs/configuration.md`.
+  */
+class NumericLiteralMutator extends CustomMutator {
+  def matcher: MutationMatcher = { case lit @ Lit.Int(value) =>
+    mutate(lit, value + 1)
+  }
+
+  private def mutate(lit: Lit.Int, incremented: Int)(
+      placeableTree: PlaceableTree
+  ): Either[IgnoredMutations, Mutations] = {
+    val from = lit.value.toString
+    val metadata = MutantMetadata(from, incremented.toString, "NumericLiteral", lit.pos, None)
+    Right(NonEmptyVector.one(MutatedCode(Lit.Int(incremented), metadata)))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/NumericLiteralMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/NumericLiteralMutator.scala
@@ -24,6 +24,6 @@ class NumericLiteralMutator extends CustomMutator {
   ): Either[IgnoredMutations, Mutations] = {
     val from = lit.value.toString
     val metadata = MutantMetadata(from, incremented.toString, "NumericLiteral", lit.pos, None)
-    Right(NonEmptyVector.one(MutatedCode(Lit.Int(incremented), metadata)))
+    Right(NonEmptyVector.one(MutatedCode(placeableTree.substitute(lit, Lit.Int(incremented)), metadata)))
   }
 }

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/ParallelSequentialSwapMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/ParallelSequentialSwapMutator.scala
@@ -7,22 +7,20 @@ import scala.meta.*
 
 /** Example custom mutator: swaps sequential and parallel cats combinators.
   *
-  * `orders.traverse(f)` becomes `orders.parTraverse(f)` and vice versa, likewise for `traverse_`,
-  * `flatTraverse`, `sequence`, `sequence_` and `mapN`.
+  * `orders.traverse(f)` becomes `orders.parTraverse(f)` and vice versa, likewise for `traverse_`, `flatTraverse`,
+  * `sequence`, `sequence_` and `mapN`.
   *
-  * Making sequential code parallel is the more interesting direction: it survives only if nothing
-  * depends on the effects running in order, so a killed mutant is evidence that ordering is
-  * actually asserted somewhere. The reverse direction catches code that is parallel by habit
-  * rather than by need.
+  * Making sequential code parallel is the more interesting direction: it survives only if nothing depends on the
+  * effects running in order, so a killed mutant is evidence that ordering is actually asserted somewhere. The reverse
+  * direction catches code that is parallel by habit rather than by need.
   *
-  * Note that `parTraverse` and friends require a `Parallel` instance, so the sequential-to-parallel
-  * direction can produce compile errors for effect types that have none (`Either`, `Try`, plain
-  * `Option`). Those surface as `CompileError` mutants, which Stryker4s reports but excludes from
-  * the mutation score.
+  * Note that `parTraverse` and friends require a `Parallel` instance, so the sequential-to-parallel direction can
+  * produce compile errors for effect types that have none (`Either`, `Try`, plain `Option`). Those surface as
+  * `CompileError` mutants, which Stryker4s reports but excludes from the mutation score.
   *
-  * The applied combinators (`traverse`) and the no-argument ones (`sequence`) are kept in separate
-  * groups on purpose: matching a bare `Term.Select` for an applied combinator would emit a second,
-  * duplicate mutant for the inner selection of `xs.traverse(f)`.
+  * The applied combinators (`traverse`) and the no-argument ones (`sequence`) are kept in separate groups on purpose:
+  * matching a bare `Term.Select` for an applied combinator would emit a second, duplicate mutant for the inner
+  * selection of `xs.traverse(f)`.
   */
 class ParallelSequentialSwapMutator extends CustomMutator {
   def matcher: MutationMatcher = {

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/ParallelSequentialSwapMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/ParallelSequentialSwapMutator.scala
@@ -1,0 +1,68 @@
+package example
+
+import cats.data.NonEmptyVector
+import stryker4s.mutatorapi.*
+
+import scala.meta.*
+
+/** Example custom mutator: swaps sequential and parallel cats combinators.
+  *
+  * `orders.traverse(f)` becomes `orders.parTraverse(f)` and vice versa, likewise for `traverse_`,
+  * `flatTraverse`, `sequence`, `sequence_` and `mapN`.
+  *
+  * Making sequential code parallel is the more interesting direction: it survives only if nothing
+  * depends on the effects running in order, so a killed mutant is evidence that ordering is
+  * actually asserted somewhere. The reverse direction catches code that is parallel by habit
+  * rather than by need.
+  *
+  * Note that `parTraverse` and friends require a `Parallel` instance, so the sequential-to-parallel
+  * direction can produce compile errors for effect types that have none (`Either`, `Try`, plain
+  * `Option`). Those surface as `CompileError` mutants, which Stryker4s reports but excludes from
+  * the mutation score.
+  *
+  * The applied combinators (`traverse`) and the no-argument ones (`sequence`) are kept in separate
+  * groups on purpose: matching a bare `Term.Select` for an applied combinator would emit a second,
+  * duplicate mutant for the inner selection of `xs.traverse(f)`.
+  */
+class ParallelSequentialSwapMutator extends CustomMutator {
+  def matcher: MutationMatcher = {
+    case term @ Term.Apply.After_4_6_0(select @ Term.Select(_, name @ Term.Name(method)), _)
+        if isAppliedCombinator(method) =>
+      val swapped = swap(method)
+      val replacement =
+        term.copyWithComments(fun = select.copyWithComments(name = name.copyWithComments(value = swapped)))
+      mutate(term, replacement, method, swapped)
+
+    case term @ Term.Select(_, name @ Term.Name(method)) if isNoArgCombinator(method) =>
+      val swapped = swap(method)
+      mutate(term, term.copyWithComments(name = name.copyWithComments(value = swapped)), method, swapped)
+  }
+
+  private def isAppliedCombinator(name: String): Boolean =
+    name == "traverse" || name == "parTraverse" ||
+      name == "traverse_" || name == "parTraverse_" ||
+      name == "flatTraverse" || name == "parFlatTraverse" ||
+      name == "mapN" || name == "parMapN"
+
+  private def isNoArgCombinator(name: String): Boolean =
+    name == "sequence" || name == "parSequence" ||
+      name == "sequence_" || name == "parSequence_"
+
+  /** `traverse` <-> `parTraverse`, driven purely by the `par` prefix. */
+  private def swap(name: String): String =
+    if (name.startsWith("par") && name.length > 3) decapitalize(name.substring(3))
+    else "par" + capitalize(name)
+
+  private def capitalize(name: String): String =
+    name.substring(0, 1).toUpperCase + name.substring(1)
+
+  private def decapitalize(name: String): String =
+    name.substring(0, 1).toLowerCase + name.substring(1)
+
+  private def mutate(term: Term, replacement: Term, from: String, to: String)(
+      placeableTree: PlaceableTree
+  ): Either[IgnoredMutations, Mutations] = {
+    val metadata = MutantMetadata(from, to, "ParallelSequentialSwap", term.pos, None)
+    Right(NonEmptyVector.one(MutatedCode(placeableTree.substitute(term, replacement), metadata)))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/RefUpdateMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/RefUpdateMutator.scala
@@ -7,19 +7,17 @@ import scala.meta.*
 
 /** Example custom mutator: neutralises a `Ref` update by replacing its function with `identity`.
   *
-  * `counter.update(_ + 1)` becomes `counter.update(identity)`, so the effect still runs, still has
-  * the same type, and still touches the same `Ref` — but leaves the state unchanged. A surviving
-  * mutant means nothing ever reads back the updated state, which is the usual shape of an untested
-  * accumulator, cache or metric counter.
+  * `counter.update(_ + 1)` becomes `counter.update(identity)`, so the effect still runs, still has the same type, and
+  * still touches the same `Ref` — but leaves the state unchanged. A surviving mutant means nothing ever reads back the
+  * updated state, which is the usual shape of an untested accumulator, cache or metric counter.
   *
-  * Unlike the other examples this one rewrites an *argument* rather than the method name or the
-  * enclosing call, which keeps the mutant type-correct without needing to know the effect type.
-  * `identity` is used because it is always in scope via `Predef`, so the replacement never needs a
-  * new import.
+  * Unlike the other examples this one rewrites an *argument* rather than the method name or the enclosing call, which
+  * keeps the mutant type-correct without needing to know the effect type. `identity` is used because it is always in
+  * scope via `Predef`, so the replacement never needs a new import.
   *
-  * `modify` is deliberately not handled: its function returns a `(state, result)` pair, so there is
-  * no total identity-shaped replacement. An update that is already `identity` is skipped, since
-  * that mutant would be equivalent to the original.
+  * `modify` is deliberately not handled: its function returns a `(state, result)` pair, so there is no total
+  * identity-shaped replacement. An update that is already `identity` is skipped, since that mutant would be equivalent
+  * to the original.
   */
 class RefUpdateMutator extends CustomMutator {
   def matcher: MutationMatcher = {

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/RefUpdateMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/RefUpdateMutator.scala
@@ -1,0 +1,46 @@
+package example
+
+import cats.data.NonEmptyVector
+import stryker4s.mutatorapi.*
+
+import scala.meta.*
+
+/** Example custom mutator: neutralises a `Ref` update by replacing its function with `identity`.
+  *
+  * `counter.update(_ + 1)` becomes `counter.update(identity)`, so the effect still runs, still has
+  * the same type, and still touches the same `Ref` — but leaves the state unchanged. A surviving
+  * mutant means nothing ever reads back the updated state, which is the usual shape of an untested
+  * accumulator, cache or metric counter.
+  *
+  * Unlike the other examples this one rewrites an *argument* rather than the method name or the
+  * enclosing call, which keeps the mutant type-correct without needing to know the effect type.
+  * `identity` is used because it is always in scope via `Predef`, so the replacement never needs a
+  * new import.
+  *
+  * `modify` is deliberately not handled: its function returns a `(state, result)` pair, so there is
+  * no total identity-shaped replacement. An update that is already `identity` is skipped, since
+  * that mutant would be equivalent to the original.
+  */
+class RefUpdateMutator extends CustomMutator {
+  def matcher: MutationMatcher = {
+    case term @ Term.Apply.After_4_6_0(Term.Select(_, Term.Name(method)), args)
+        if isUpdate(method) && args.values.size == 1 && !isIdentity(args.values.head) =>
+      mutate(term, term.copyWithComments(args = Term.ArgClause(Term.Name("identity") :: Nil)), method)
+  }
+
+  private def isUpdate(name: String): Boolean =
+    name == "update" || name == "updateAndGet" || name == "getAndUpdate"
+
+  private def isIdentity(arg: Term): Boolean =
+    arg match {
+      case Term.Name("identity") => true
+      case _                     => false
+    }
+
+  private def mutate(term: Term, replacement: Term, method: String)(
+      placeableTree: PlaceableTree
+  ): Either[IgnoredMutations, Mutations] = {
+    val metadata = MutantMetadata(method, "identity", "RefUpdate", term.pos, None)
+    Right(NonEmptyVector.one(MutatedCode(placeableTree.substitute(term, replacement), metadata)))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/ResourceFinalizerMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/ResourceFinalizerMutator.scala
@@ -1,0 +1,69 @@
+package example
+
+import cats.data.NonEmptyVector
+import stryker4s.mutatorapi.*
+
+import scala.meta.*
+
+/** Example custom mutator: removes cats-effect resource finalizers.
+  *
+  *   - `Resource.make(acquire)(release)` becomes `Resource.eval(acquire)`
+  *   - `fa.bracket(use)(release)` becomes `fa.flatMap(use)`
+  *   - `fa.guarantee(cleanup)` (and `guaranteeCase`, `onCancel`) becomes `fa`
+  *
+  * In every case the acquisition and the use of the resource are preserved and only the cleanup is
+  * dropped, so the mutant is behaviourally identical unless a test actually observes the release —
+  * by asserting a connection was returned to the pool, a file handle closed, a lock freed, and so
+  * on. Finalizers are some of the least-tested code in an effectful codebase, so surviving mutants
+  * here are usually genuine coverage gaps rather than noise.
+  *
+  * `Resource.make` is only matched when its qualifier is literally `Resource` (bare or as the last
+  * segment of a qualified path), so unrelated `Foo.make(a)(b)` builders are left alone.
+  */
+class ResourceFinalizerMutator extends CustomMutator {
+  def matcher: MutationMatcher = {
+    // Resource.make(acquire)(release) / Resource.makeCase(acquire)(release)
+    case term @ Term.Apply.After_4_6_0(
+          Term.Apply.After_4_6_0(Term.Select(qualifier, Term.Name(method)), acquire),
+          _
+        ) if isResourceQualifier(qualifier) && isResourceMake(method) && acquire.values.size == 1 =>
+      val replacement = Term.Apply(Term.Select(qualifier, Term.Name("eval")), acquire)
+      mutate(term, replacement, method)
+
+    // fa.bracket(use)(release) / fa.bracketCase(use)(release)
+    case term @ Term.Apply.After_4_6_0(
+          Term.Apply.After_4_6_0(Term.Select(receiver, Term.Name(method)), use),
+          _
+        ) if isBracket(method) && use.values.size == 1 =>
+      val replacement = Term.Apply(Term.Select(receiver, Term.Name("flatMap")), use)
+      mutate(term, replacement, method)
+
+    // fa.guarantee(cleanup) / fa.guaranteeCase(cleanup) / fa.onCancel(cleanup)
+    case term @ Term.Apply.After_4_6_0(Term.Select(receiver, Term.Name(method)), args)
+        if isGuarantee(method) && args.values.size == 1 =>
+      mutate(term, receiver, method)
+  }
+
+  private def isResourceQualifier(qualifier: Term): Boolean =
+    qualifier match {
+      case Term.Name("Resource")              => true
+      case Term.Select(_, Term.Name("Resource")) => true
+      case _                                  => false
+    }
+
+  private def isResourceMake(name: String): Boolean =
+    name == "make" || name == "makeCase"
+
+  private def isBracket(name: String): Boolean =
+    name == "bracket" || name == "bracketCase"
+
+  private def isGuarantee(name: String): Boolean =
+    name == "guarantee" || name == "guaranteeCase" || name == "onCancel"
+
+  private def mutate(term: Term, replacement: Term, removed: String)(
+      placeableTree: PlaceableTree
+  ): Either[IgnoredMutations, Mutations] = {
+    val metadata = MutantMetadata(removed, "no finalizer", "ResourceFinalizer", term.pos, None)
+    Right(NonEmptyVector.one(MutatedCode(placeableTree.substitute(term, replacement), metadata)))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/ResourceFinalizerMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/ResourceFinalizerMutator.scala
@@ -11,14 +11,13 @@ import scala.meta.*
   *   - `fa.bracket(use)(release)` becomes `fa.flatMap(use)`
   *   - `fa.guarantee(cleanup)` (and `guaranteeCase`, `onCancel`) becomes `fa`
   *
-  * In every case the acquisition and the use of the resource are preserved and only the cleanup is
-  * dropped, so the mutant is behaviourally identical unless a test actually observes the release —
-  * by asserting a connection was returned to the pool, a file handle closed, a lock freed, and so
-  * on. Finalizers are some of the least-tested code in an effectful codebase, so surviving mutants
-  * here are usually genuine coverage gaps rather than noise.
+  * In every case the acquisition and the use of the resource are preserved and only the cleanup is dropped, so the
+  * mutant is behaviourally identical unless a test actually observes the release — by asserting a connection was
+  * returned to the pool, a file handle closed, a lock freed, and so on. Finalizers are some of the least-tested code in
+  * an effectful codebase, so surviving mutants here are usually genuine coverage gaps rather than noise.
   *
-  * `Resource.make` is only matched when its qualifier is literally `Resource` (bare or as the last
-  * segment of a qualified path), so unrelated `Foo.make(a)(b)` builders are left alone.
+  * `Resource.make` is only matched when its qualifier is literally `Resource` (bare or as the last segment of a
+  * qualified path), so unrelated `Foo.make(a)(b)` builders are left alone.
   */
 class ResourceFinalizerMutator extends CustomMutator {
   def matcher: MutationMatcher = {
@@ -46,9 +45,9 @@ class ResourceFinalizerMutator extends CustomMutator {
 
   private def isResourceQualifier(qualifier: Term): Boolean =
     qualifier match {
-      case Term.Name("Resource")              => true
+      case Term.Name("Resource")                 => true
       case Term.Select(_, Term.Name("Resource")) => true
-      case _                                  => false
+      case _                                     => false
     }
 
   private def isResourceMake(name: String): Boolean =

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/Sentinels.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/Sentinels.scala
@@ -2,13 +2,12 @@ package example
 
 /** Values that [[Calculator]] uses but never exposes to its callers.
   *
-  * Like [[Deadlines]], these live outside `Calculator.scala` on purpose. Only that file is listed in
-  * `strykerMutate`, and a literal whose value cannot be observed from outside the method produces an *equivalent*
-  * mutant: the source changes but the behaviour does not, so no test can ever kill it and the score is depressed
-  * forever.
+  * Like [[Deadlines]], these live outside `Calculator.scala` on purpose. Only that file is listed in `strykerMutate`,
+  * and a literal whose value cannot be observed from outside the method produces an *equivalent* mutant: the source
+  * changes but the behaviour does not, so no test can ever kill it and the score is depressed forever.
   *
-  * Both values here are unobservable by construction — one is discarded by `*>`, the other is recovered by `.orElse`
-  * — so moving them out is the honest fix. Contrast the exception messages that `Calculator` does surface to callers,
+  * Both values here are unobservable by construction — one is discarded by `*>`, the other is recovered by `.orElse` —
+  * so moving them out is the honest fix. Contrast the exception messages that `Calculator` does surface to callers,
   * which stay inline and are pinned by assertions in `CalculatorTest`.
   */
 object Sentinels {

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/Sentinels.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/Sentinels.scala
@@ -1,0 +1,21 @@
+package example
+
+/** Values that [[Calculator]] uses but never exposes to its callers.
+  *
+  * Like [[Deadlines]], these live outside `Calculator.scala` on purpose. Only that file is listed in
+  * `strykerMutate`, and a literal whose value cannot be observed from outside the method produces an *equivalent*
+  * mutant: the source changes but the behaviour does not, so no test can ever kill it and the score is depressed
+  * forever.
+  *
+  * Both values here are unobservable by construction — one is discarded by `*>`, the other is recovered by `.orElse`
+  * — so moving them out is the honest fix. Contrast the exception messages that `Calculator` does surface to callers,
+  * which stay inline and are pinned by assertions in `CalculatorTest`.
+  */
+object Sentinels {
+
+  /** Discarded by `*>` in `auditedOrderTotal`; only its type matters, so that swapping `*>` for `<*` still compiles. */
+  val discardedAudit: Int = 1
+
+  /** Recovered by `.orElse` in `orderTotalWithFallback`, so it never reaches a caller. */
+  val primaryUnavailable: String = "primary unavailable"
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/SequencingMutators.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/SequencingMutators.scala
@@ -28,7 +28,7 @@ class SequencingSwapMutator extends CustomMutator {
       placeableTree: PlaceableTree
   ): Either[IgnoredMutations, Mutations] = {
     val metadata = MutantMetadata(term.op.value, to, "SequencingSwap", term.pos, None)
-    Right(NonEmptyVector.one(MutatedCode(replacement, metadata)))
+    Right(NonEmptyVector.one(MutatedCode(placeableTree.substitute(term, replacement), metadata)))
   }
 }
 
@@ -51,6 +51,6 @@ class SequencingRemovalMutator extends CustomMutator {
       placeableTree: PlaceableTree
   ): Either[IgnoredMutations, Mutations] = {
     val metadata = MutantMetadata(from, to, "SequencingRemoval", term.pos, None)
-    Right(NonEmptyVector.one(MutatedCode(replacement, metadata)))
+    Right(NonEmptyVector.one(MutatedCode(placeableTree.substitute(term, replacement), metadata)))
   }
 }

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/SequencingMutators.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/SequencingMutators.scala
@@ -1,0 +1,58 @@
+package example
+
+import cats.data.NonEmptyVector
+import stryker4s.mutatorapi.*
+
+import scala.meta.*
+
+/** Example custom mutator: swaps cats-effect sequencing operators `*>` and `<*`.
+  *
+  * Both effects still run, but the returned value changes from the right side to the left side (or
+  * vice versa). This tests whether suites assert the result of sequencing, not only that it
+  * completed.
+  */
+class SequencingSwapMutator extends CustomMutator {
+  def matcher: MutationMatcher = {
+    case term @ Term.ApplyInfix.After_4_6_0(_, Term.Name(op), Type.ArgClause(Nil), args)
+        if isSequencingOperator(op) && hasOneArgument(args) =>
+      val replacement = if (op == "*>") "<*" else "*>"
+      mutate(term, term.copyWithComments(op = term.op.copyWithComments(value = replacement)), replacement)
+  }
+
+  private def isSequencingOperator(op: String): Boolean =
+    op == "*>" || op == "<*"
+
+  private def hasOneArgument(args: Term.ArgClause): Boolean =
+    args.values.size == 1
+
+  private def mutate(term: Term.ApplyInfix, replacement: Term, to: String)(
+      placeableTree: PlaceableTree
+  ): Either[IgnoredMutations, Mutations] = {
+    val metadata = MutantMetadata(term.op.value, to, "SequencingSwap", term.pos, None)
+    Right(NonEmptyVector.one(MutatedCode(replacement, metadata)))
+  }
+}
+
+/** Example custom mutator: removes the effect whose result is discarded by cats-effect sequencing.
+  *
+  * `fa *> fb` becomes `fb`, removing the left effect. `fa <* fb` becomes `fa`, removing the right
+  * effect. This keeps the original result type while testing whether discarded-result effects are
+  * nevertheless behaviorally important.
+  */
+class SequencingRemovalMutator extends CustomMutator {
+  def matcher: MutationMatcher = {
+    case term @ Term.ApplyInfix.After_4_6_0(left, Term.Name("*>"), Type.ArgClause(Nil), args)
+        if args.values.size == 1 =>
+      mutate(term, args.values.head, "*>", "right")
+    case term @ Term.ApplyInfix.After_4_6_0(left, Term.Name("<*"), Type.ArgClause(Nil), args)
+        if args.values.size == 1 =>
+      mutate(term, left, "<*", "left")
+  }
+
+  private def mutate(term: Term.ApplyInfix, replacement: Term, from: String, to: String)(
+      placeableTree: PlaceableTree
+  ): Either[IgnoredMutations, Mutations] = {
+    val metadata = MutantMetadata(from, to, "SequencingRemoval", term.pos, None)
+    Right(NonEmptyVector.one(MutatedCode(replacement, metadata)))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/SequencingMutators.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/SequencingMutators.scala
@@ -7,9 +7,8 @@ import scala.meta.*
 
 /** Example custom mutator: swaps cats-effect sequencing operators `*>` and `<*`.
   *
-  * Both effects still run, but the returned value changes from the right side to the left side (or
-  * vice versa). This tests whether suites assert the result of sequencing, not only that it
-  * completed.
+  * Both effects still run, but the returned value changes from the right side to the left side (or vice versa). This
+  * tests whether suites assert the result of sequencing, not only that it completed.
   */
 class SequencingSwapMutator extends CustomMutator {
   def matcher: MutationMatcher = {
@@ -35,9 +34,8 @@ class SequencingSwapMutator extends CustomMutator {
 
 /** Example custom mutator: removes the effect whose result is discarded by cats-effect sequencing.
   *
-  * `fa *> fb` becomes `fb`, removing the left effect. `fa <* fb` becomes `fa`, removing the right
-  * effect. This keeps the original result type while testing whether discarded-result effects are
-  * nevertheless behaviorally important.
+  * `fa *> fb` becomes `fb`, removing the left effect. `fa <* fb` becomes `fa`, removing the right effect. This keeps
+  * the original result type while testing whether discarded-result effects are nevertheless behaviorally important.
   */
 class SequencingRemovalMutator extends CustomMutator {
   def matcher: MutationMatcher = {

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/SleepRemovalMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/SleepRemovalMutator.scala
@@ -7,16 +7,16 @@ import scala.meta.*
 
 /** Example custom mutator: removes deliberate delays.
   *
-  * `IO.sleep(backoff)` becomes `IO.unit`, and `publish.delayBy(backoff)` / `publish.andWait(backoff)`
-  * become `publish`. The surrounding effect keeps its type and still runs; only the waiting is gone.
+  * `IO.sleep(backoff)` becomes `IO.unit`, and `publish.delayBy(backoff)` / `publish.andWait(backoff)` become `publish`.
+  * The surrounding effect keeps its type and still runs; only the waiting is gone.
   *
-  * This separates load-bearing delays from cargo-culted ones. A sleep that is genuinely part of the
-  * behaviour — a backoff between retries, a rate limit, a debounce window — should have a test that
-  * fails without it. One that survives is either untested or was never needed.
+  * This separates load-bearing delays from cargo-culted ones. A sleep that is genuinely part of the behaviour — a
+  * backoff between retries, a rate limit, a debounce window — should have a test that fails without it. One that
+  * survives is either untested or was never needed.
   *
-  * The qualifier is preserved rather than hardcoded to `IO`, so `Temporal[F].sleep(d)` correctly
-  * becomes `Temporal[F].unit`; `unit` is available on any `Applicative`. `Thread.sleep` is excluded
-  * because `Thread` has no `unit` and the mutant could only ever be a compile error.
+  * The qualifier is preserved rather than hardcoded to `IO`, so `Temporal[F].sleep(d)` correctly becomes
+  * `Temporal[F].unit`; `unit` is available on any `Applicative`. `Thread.sleep` is excluded because `Thread` has no
+  * `unit` and the mutant could only ever be a compile error.
   */
 class SleepRemovalMutator extends CustomMutator {
   def matcher: MutationMatcher = {
@@ -34,9 +34,9 @@ class SleepRemovalMutator extends CustomMutator {
 
   private def isThread(qualifier: Term): Boolean =
     qualifier match {
-      case Term.Name("Thread")              => true
+      case Term.Name("Thread")                 => true
       case Term.Select(_, Term.Name("Thread")) => true
-      case _                                => false
+      case _                                   => false
     }
 
   private def mutate(term: Term, replacement: Term, removed: String)(

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/SleepRemovalMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/SleepRemovalMutator.scala
@@ -1,0 +1,48 @@
+package example
+
+import cats.data.NonEmptyVector
+import stryker4s.mutatorapi.*
+
+import scala.meta.*
+
+/** Example custom mutator: removes deliberate delays.
+  *
+  * `IO.sleep(backoff)` becomes `IO.unit`, and `publish.delayBy(backoff)` / `publish.andWait(backoff)`
+  * become `publish`. The surrounding effect keeps its type and still runs; only the waiting is gone.
+  *
+  * This separates load-bearing delays from cargo-culted ones. A sleep that is genuinely part of the
+  * behaviour — a backoff between retries, a rate limit, a debounce window — should have a test that
+  * fails without it. One that survives is either untested or was never needed.
+  *
+  * The qualifier is preserved rather than hardcoded to `IO`, so `Temporal[F].sleep(d)` correctly
+  * becomes `Temporal[F].unit`; `unit` is available on any `Applicative`. `Thread.sleep` is excluded
+  * because `Thread` has no `unit` and the mutant could only ever be a compile error.
+  */
+class SleepRemovalMutator extends CustomMutator {
+  def matcher: MutationMatcher = {
+    case term @ Term.Apply.After_4_6_0(Term.Select(qualifier, Term.Name("sleep")), args)
+        if args.values.size == 1 && !isThread(qualifier) =>
+      mutate(term, Term.Select(qualifier, Term.Name("unit")), "sleep")
+
+    case term @ Term.Apply.After_4_6_0(Term.Select(receiver, Term.Name(method)), args)
+        if isDelay(method) && args.values.size == 1 =>
+      mutate(term, receiver, method)
+  }
+
+  private def isDelay(name: String): Boolean =
+    name == "delayBy" || name == "andWait"
+
+  private def isThread(qualifier: Term): Boolean =
+    qualifier match {
+      case Term.Name("Thread")              => true
+      case Term.Select(_, Term.Name("Thread")) => true
+      case _                                => false
+    }
+
+  private def mutate(term: Term, replacement: Term, removed: String)(
+      placeableTree: PlaceableTree
+  ): Either[IgnoredMutations, Mutations] = {
+    val metadata = MutantMetadata(removed, "no delay", "SleepRemoval", term.pos, None)
+    Right(NonEmptyVector.one(MutatedCode(placeableTree.substitute(term, replacement), metadata)))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/StringNormalizationMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/StringNormalizationMutator.scala
@@ -1,0 +1,46 @@
+package example
+
+import cats.data.NonEmptyVector
+import stryker4s.mutatorapi.*
+
+import scala.meta.*
+
+/** Example custom mutator: removes string normalization.
+  *
+  * `code.trim`, `code.strip`, `code.toLowerCase`, `code.toUpperCase`, `code.capitalize`, `code.stripPrefix(p)` and
+  * `code.stripSuffix(s)` all become just `code`.
+  *
+  * Normalization is usually defensive: it exists for the inputs a test fixture rarely bothers to produce. A test that
+  * only ever passes `"ABC"` cannot tell whether `toUpperCase` runs, and one that never passes a padded string cannot
+  * tell whether `trim` runs. A surviving mutant here is a direct instruction to add the untidy input.
+  *
+  * Like [[CollectionOrderMutator]] this mutator *drops* a selection, so it must not match the function of an enclosing
+  * `Term.Apply`.
+  */
+class StringNormalizationMutator extends CustomMutator {
+  private def isAppliedCombinator(name: String): Boolean =
+    name == "stripPrefix" || name == "stripSuffix"
+
+  private def isNoArgCombinator(name: String): Boolean =
+    name == "trim" || name == "strip" || name == "toLowerCase" || name == "toUpperCase" || name == "capitalize"
+
+  def matcher: MutationMatcher = {
+    case term @ Term.Apply.After_4_6_0(Term.Select(receiver, Term.Name(name)), _) if isAppliedCombinator(name) =>
+      mutate(term, receiver, name)
+    case term @ Term.Select(receiver, Term.Name(name)) if isNoArgCombinator(name) && !isAppliedTo(term) =>
+      mutate(term, receiver, name)
+  }
+
+  private def isAppliedTo(term: Term): Boolean =
+    term.parent.exists {
+      case Term.Apply.After_4_6_0(fun, _) => fun eq term
+      case _                              => false
+    }
+
+  private def mutate(term: Term, receiver: Term, removed: String)(
+      placeableTree: PlaceableTree
+  ): Either[IgnoredMutations, Mutations] = {
+    val metadata = MutantMetadata(removed, "unnormalized", "StringNormalization", term.pos, None)
+    Right(NonEmptyVector.one(MutatedCode(placeableTree.substitute(term, receiver), metadata)))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/TimeoutMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/TimeoutMutator.scala
@@ -1,0 +1,36 @@
+package example
+
+import cats.data.NonEmptyVector
+import stryker4s.mutatorapi.*
+
+import scala.meta.*
+
+/** Example custom mutator: removes cats-effect timeout combinators.
+  *
+  * `fa.timeout(d)`, `fa.timeoutTo(d, fallback)` and `fa.timeoutAndForget(d)` all become `fa`, so
+  * the effect is allowed to run to completion instead of being cancelled at the deadline. This
+  * tests whether a suite actually asserts the timeout behaviour, rather than only exercising the
+  * happy path where the deadline is never reached.
+  *
+  * Note that a surviving mutant here means no test distinguishes "completed in time" from
+  * "cancelled at the deadline". A killed mutant will usually fail on the result value; if a suite
+  * has no such assertion the mutant may instead be detected by Stryker4s's own test-run timeout.
+  */
+class TimeoutRemovalMutator extends CustomMutator {
+  def matcher: MutationMatcher = {
+    case term @ Term.Apply.After_4_6_0(Term.Select(receiver, Term.Name(name)), args)
+        if isTimeoutCombinator(name, args.values.size) =>
+      mutate(term, receiver, name)
+  }
+
+  private def isTimeoutCombinator(name: String, arity: Int): Boolean =
+    ((name == "timeout" || name == "timeoutAndForget") && arity == 1) ||
+      (name == "timeoutTo" && arity == 2)
+
+  private def mutate(term: Term.Apply, replacement: Term, removed: String)(
+      placeableTree: PlaceableTree
+  ): Either[IgnoredMutations, Mutations] = {
+    val metadata = MutantMetadata(removed, "removed", "TimeoutRemoval", term.pos, None)
+    Right(NonEmptyVector.one(MutatedCode(replacement, metadata)))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/TimeoutMutator.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/main/scala/example/TimeoutMutator.scala
@@ -7,14 +7,13 @@ import scala.meta.*
 
 /** Example custom mutator: removes cats-effect timeout combinators.
   *
-  * `fa.timeout(d)`, `fa.timeoutTo(d, fallback)` and `fa.timeoutAndForget(d)` all become `fa`, so
-  * the effect is allowed to run to completion instead of being cancelled at the deadline. This
-  * tests whether a suite actually asserts the timeout behaviour, rather than only exercising the
-  * happy path where the deadline is never reached.
+  * `fa.timeout(d)`, `fa.timeoutTo(d, fallback)` and `fa.timeoutAndForget(d)` all become `fa`, so the effect is allowed
+  * to run to completion instead of being cancelled at the deadline. This tests whether a suite actually asserts the
+  * timeout behaviour, rather than only exercising the happy path where the deadline is never reached.
   *
-  * Note that a surviving mutant here means no test distinguishes "completed in time" from
-  * "cancelled at the deadline". A killed mutant will usually fail on the result value; if a suite
-  * has no such assertion the mutant may instead be detected by Stryker4s's own test-run timeout.
+  * Note that a surviving mutant here means no test distinguishes "completed in time" from "cancelled at the deadline".
+  * A killed mutant will usually fail on the result value; if a suite has no such assertion the mutant may instead be
+  * detected by Stryker4s's own test-run timeout.
   */
 class TimeoutRemovalMutator extends CustomMutator {
   def matcher: MutationMatcher = {
@@ -31,6 +30,6 @@ class TimeoutRemovalMutator extends CustomMutator {
       placeableTree: PlaceableTree
   ): Either[IgnoredMutations, Mutations] = {
     val metadata = MutantMetadata(removed, "removed", "TimeoutRemoval", term.pos, None)
-    Right(NonEmptyVector.one(MutatedCode(replacement, metadata)))
+    Right(NonEmptyVector.one(MutatedCode(placeableTree.substitute(term, replacement), metadata)))
   }
 }

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/CalculatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/CalculatorTest.scala
@@ -28,4 +28,20 @@ class CalculatorTest extends munit.CatsEffectSuite {
   test("safeDivide passes through a successful division") {
     Calculator.safeDivide(10, 2).map(result => assertEquals(result, 5))
   }
+
+  test("rejectOversizedOrder fails for quantities above the limit") {
+    Calculator.rejectOversizedOrder(101).attempt.map(result => assert(result.isLeft))
+  }
+
+  test("rejectOversizedOrder accepts quantities at the limit") {
+    Calculator.rejectOversizedOrder(100)
+  }
+
+  test("requirePositive accepts positive values") {
+    Calculator.requirePositive(1).map(result => assertEquals(result, 1))
+  }
+
+  test("requirePositive rejects non-positive values") {
+    Calculator.requirePositive(0).attempt.map(result => assert(result.isLeft))
+  }
 }

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/CalculatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/CalculatorTest.scala
@@ -92,4 +92,32 @@ class CalculatorTest extends munit.CatsEffectSuite {
   test("trackedResource releases the resource exactly once") {
     Calculator.trackedResource.map(result => assertEquals(result, 8))
   }
+
+  test("descendingDiscounts orders the discounts from largest to smallest") {
+    assertEquals(Calculator.descendingDiscounts(List(5, 15, 10)), List(15, 10, 5))
+  }
+
+  test("descendingDiscounts collapses repeated discounts") {
+    assertEquals(Calculator.descendingDiscounts(List(10, 5, 10)), List(10, 5))
+  }
+
+  test("normalizeCode trims, upper-cases and strips the prefix from a code") {
+    assertEquals(Calculator.normalizeCode("  sku-ab "), "AB")
+  }
+
+  test("normalizeCode leaves a code that does not carry the prefix intact") {
+    assertEquals(Calculator.normalizeCode("ab"), "AB")
+  }
+
+  test("firstDiscount reads the discount at the front of the list") {
+    assertEquals(Calculator.firstDiscount(List(5, 10, 15)), Some(5))
+  }
+
+  test("firstDiscount has no discount to read for an empty list") {
+    assertEquals(Calculator.firstDiscount(Nil), None)
+  }
+
+  test("remainingDiscounts drops the discount at the front of the list") {
+    assertEquals(Calculator.remainingDiscounts(List(5, 10, 15)), List(10, 15))
+  }
 }

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/CalculatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/CalculatorTest.scala
@@ -44,4 +44,12 @@ class CalculatorTest extends munit.CatsEffectSuite {
   test("requirePositive rejects non-positive values") {
     Calculator.requirePositive(0).attempt.map(result => assert(result.isLeft))
   }
+
+  test("orderTotalWithFallback uses the primary result when it is available") {
+    Calculator.orderTotalWithFallback(primaryAvailable = true).map(result => assertEquals(result, 7))
+  }
+
+  test("orderTotalWithFallback uses the fallback result when the primary fails") {
+    Calculator.orderTotalWithFallback(primaryAvailable = false).map(result => assertEquals(result, 42))
+  }
 }

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/CalculatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/CalculatorTest.scala
@@ -1,6 +1,6 @@
 package example
 
-class CalculatorTest extends munit.FunSuite {
+class CalculatorTest extends munit.CatsEffectSuite {
   test("add sums two numbers") {
     assertEquals(Calculator.add(2, 3), 5)
     assertEquals(Calculator.add(-1, 1), 0)
@@ -19,5 +19,13 @@ class CalculatorTest extends munit.FunSuite {
 
   test("defaultDiscounts has exactly the expected three tiers") {
     assertEquals(Calculator.defaultDiscounts, List(5, 10, 15))
+  }
+
+  test("safeDivide recovers from division-by-zero errors back to a default of 0") {
+    Calculator.safeDivide(10, 0).map(result => assertEquals(result, 0))
+  }
+
+  test("safeDivide passes through a successful division") {
+    Calculator.safeDivide(10, 2).map(result => assertEquals(result, 5))
   }
 }

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/CalculatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/CalculatorTest.scala
@@ -1,0 +1,13 @@
+package example
+
+class CalculatorTest extends munit.FunSuite {
+  test("add sums two numbers") {
+    assertEquals(Calculator.add(2, 3), 5)
+    assertEquals(Calculator.add(-1, 1), 0)
+  }
+
+  test("subtract subtracts two numbers") {
+    assertEquals(Calculator.subtract(5, 3), 2)
+    assertEquals(Calculator.subtract(1, 1), 0)
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/CalculatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/CalculatorTest.scala
@@ -30,7 +30,9 @@ class CalculatorTest extends munit.CatsEffectSuite {
   }
 
   test("rejectOversizedOrder fails for quantities above the limit") {
-    Calculator.rejectOversizedOrder(101).attempt.map(result => assert(result.isLeft))
+    Calculator.rejectOversizedOrder(101).attempt.map { result =>
+      assertEquals(result.left.toOption.map(_.getMessage), Some("oversized order"))
+    }
   }
 
   test("rejectOversizedOrder accepts quantities at the limit") {
@@ -42,7 +44,9 @@ class CalculatorTest extends munit.CatsEffectSuite {
   }
 
   test("requirePositive rejects non-positive values") {
-    Calculator.requirePositive(0).attempt.map(result => assert(result.isLeft))
+    Calculator.requirePositive(0).attempt.map { result =>
+      assertEquals(result.left.toOption.map(_.getMessage), Some("non-positive"))
+    }
   }
 
   test("orderTotalWithFallback uses the primary result when it is available") {
@@ -63,5 +67,29 @@ class CalculatorTest extends munit.CatsEffectSuite {
 
   test("orderTotalWithDeadline substitutes the fallback effect at the deadline") {
     Calculator.orderTotalWithDeadline(5).map(result => assertEquals(result, -2))
+  }
+
+  test("quantityOrDefault uses the supplied quantity when one is present") {
+    assertEquals(Calculator.quantityOrDefault(Some(9)), 9)
+  }
+
+  test("quantityOrDefault falls back to a single unit when no quantity is present") {
+    assertEquals(Calculator.quantityOrDefault(None), 1)
+  }
+
+  test("validateAll short-circuits at the first invalid value") {
+    assertEquals(Calculator.validateAll(List(1, -1, -2)), Left(List(-1)))
+  }
+
+  test("validateAll returns every value when all of them are valid") {
+    assertEquals(Calculator.validateAll(List(1, 2)), Right(List(1, 2)))
+  }
+
+  test("validateAll rejects zero, which is the boundary of the validity check") {
+    assertEquals(Calculator.validateAll(List(0)), Left(List(0)))
+  }
+
+  test("trackedResource releases the resource exactly once") {
+    Calculator.trackedResource.map(result => assertEquals(result, 8))
   }
 }

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/CalculatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/CalculatorTest.scala
@@ -52,4 +52,8 @@ class CalculatorTest extends munit.CatsEffectSuite {
   test("orderTotalWithFallback uses the fallback result when the primary fails") {
     Calculator.orderTotalWithFallback(primaryAvailable = false).map(result => assertEquals(result, 42))
   }
+
+  test("auditedOrderTotal runs the audit effect before computing the result") {
+    Calculator.auditedOrderTotal.map(result => assertEquals(result, 11))
+  }
 }

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/CalculatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/CalculatorTest.scala
@@ -56,4 +56,12 @@ class CalculatorTest extends munit.CatsEffectSuite {
   test("auditedOrderTotal runs the audit effect before computing the result") {
     Calculator.auditedOrderTotal.map(result => assertEquals(result, 11))
   }
+
+  test("strictOrderTotal recovers to a sentinel when the work exceeds its deadline") {
+    Calculator.strictOrderTotal(5).map(result => assertEquals(result, -1))
+  }
+
+  test("orderTotalWithDeadline substitutes the fallback effect at the deadline") {
+    Calculator.orderTotalWithDeadline(5).map(result => assertEquals(result, -2))
+  }
 }

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/CalculatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/CalculatorTest.scala
@@ -10,4 +10,14 @@ class CalculatorTest extends munit.FunSuite {
     assertEquals(Calculator.subtract(5, 3), 2)
     assertEquals(Calculator.subtract(1, 1), 0)
   }
+
+  test("isLargeOrder detects quantities above the threshold") {
+    assert(Calculator.isLargeOrder(11))
+    assert(!Calculator.isLargeOrder(10))
+    assert(!Calculator.isLargeOrder(0))
+  }
+
+  test("defaultDiscounts has exactly the expected three tiers") {
+    assertEquals(Calculator.defaultDiscounts, List(5, 10, 15))
+  }
 }

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/CollectionOrderMutatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/CollectionOrderMutatorTest.scala
@@ -1,0 +1,76 @@
+package example
+
+import scala.meta.*
+
+/** Unit tests for [[CollectionOrderMutator]]'s matcher logic, written first (TDD) before the mutator implementation.
+  */
+class CollectionOrderMutatorTest extends munit.FunSuite {
+  private val mutator = new CollectionOrderMutator
+
+  private def parseTerm(code: String): Term =
+    code.parse[Term].get
+
+  private def mutate(code: String): String = {
+    val term = parseTerm(code)
+    val Right(mutations) = mutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(term)): @unchecked
+    assertEquals(mutations.length, 1)
+    assertEquals(mutations.head.metadata.mutatorName, "CollectionOrder")
+    mutations.head.mutatedStatement.syntax
+  }
+
+  test("drops .sorted, leaving the receiver in its original order") {
+    assertEquals(mutate("discounts.sorted"), "discounts")
+  }
+
+  test("drops .reverse") {
+    assertEquals(mutate("discounts.reverse"), "discounts")
+  }
+
+  test("drops .distinct") {
+    assertEquals(mutate("discounts.distinct"), "discounts")
+  }
+
+  test("drops .sortBy(f)") {
+    assertEquals(mutate("discounts.sortBy(magnitude)"), "discounts")
+  }
+
+  test("drops .sortWith(f)") {
+    assertEquals(mutate("discounts.sortWith(byRank)"), "discounts")
+  }
+
+  test("drops .distinctBy(f)") {
+    assertEquals(mutate("discounts.distinctBy(code)"), "discounts")
+  }
+
+  test("keeps the statement surrounding the matched sub-term") {
+    val statement = parseTerm("discounts.sorted.headOption")
+    val term = statement.collect { case t: Term if t.syntax == "discounts.sorted" => t }.head
+
+    val Right(mutations) = mutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(statement)): @unchecked
+    assertEquals(mutations.head.mutatedStatement.syntax, "discounts.headOption")
+  }
+
+  test("does not match the selection an ordering combinator is applied to") {
+    // `discounts.sortBy` on its own would drop the selection and leave `discounts(magnitude)`.
+    val statement = parseTerm("discounts.sortBy(magnitude)")
+    val select = statement.collect { case t: Term.Select => t }.head
+
+    assert(!mutator.matcher.isDefinedAt(select))
+  }
+
+  test("does not match a no-argument combinator that is being applied") {
+    // `sorted` takes no arguments, so `discounts.sorted(ordering)` is passing an implicit
+    // explicitly; dropping the selection would leave `discounts(ordering)`.
+    val statement = parseTerm("discounts.sorted(ordering)")
+    val select = statement.collect { case t: Term.Select => t }.head
+
+    assert(!mutator.matcher.isDefinedAt(select))
+    assert(!mutator.matcher.isDefinedAt(statement))
+  }
+
+  test("does not match unrelated combinators") {
+    assert(!mutator.matcher.isDefinedAt(parseTerm("discounts.map(process)")))
+    assert(!mutator.matcher.isDefinedAt(parseTerm("discounts.sortedness")))
+    assert(!mutator.matcher.isDefinedAt(parseTerm("discounts")))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/ConditionalEffectMutatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/ConditionalEffectMutatorTest.scala
@@ -2,9 +2,8 @@ package example
 
 import scala.meta.*
 
-/** Unit tests for [[ConditionalEffectMutator]]'s matcher logic, written first (TDD) before the
-  * mutator implementation. These cover cats-effect conditional-effect helpers that encode
-  * side-effecting boolean guards.
+/** Unit tests for [[ConditionalEffectMutator]]'s matcher logic, written first (TDD) before the mutator implementation.
+  * These cover cats-effect conditional-effect helpers that encode side-effecting boolean guards.
   */
 class ConditionalEffectMutatorTest extends munit.FunSuite {
   private val mutator = new ConditionalEffectMutator

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/ConditionalEffectMutatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/ConditionalEffectMutatorTest.scala
@@ -1,0 +1,57 @@
+package example
+
+import scala.meta.*
+
+/** Unit tests for [[ConditionalEffectMutator]]'s matcher logic, written first (TDD) before the
+  * mutator implementation. These cover cats-effect conditional-effect helpers that encode
+  * side-effecting boolean guards.
+  */
+class ConditionalEffectMutatorTest extends munit.FunSuite {
+  private val mutator = new ConditionalEffectMutator
+
+  private def parseTerm(code: String): Term =
+    code.parse[Term].get
+
+  private def mutatedSyntax(code: String): String = {
+    val term = parseTerm(code)
+
+    assert(mutator.matcher.isDefinedAt(term))
+
+    val Right(mutations) = mutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(term)): @unchecked
+    assertEquals(mutations.length, 1)
+    assertEquals(mutations.head.metadata.mutatorName, "ConditionalEffect")
+    mutations.head.mutatedStatement.syntax
+  }
+
+  test("flips IO.whenA(cond)(effect) to IO.unlessA(cond)(effect)") {
+    assertEquals(mutatedSyntax("IO.whenA(flag)(publish)"), "IO.unlessA(flag)(publish)")
+  }
+
+  test("flips IO.unlessA(cond)(effect) to IO.whenA(cond)(effect)") {
+    assertEquals(mutatedSyntax("IO.unlessA(flag)(publish)"), "IO.whenA(flag)(publish)")
+  }
+
+  test("flips IO.raiseWhen(cond)(error) to IO.raiseUnless(cond)(error)") {
+    assertEquals(mutatedSyntax("IO.raiseWhen(flag)(error)"), "IO.raiseUnless(flag)(error)")
+  }
+
+  test("flips IO.raiseUnless(cond)(error) to IO.raiseWhen(cond)(error)") {
+    assertEquals(mutatedSyntax("IO.raiseUnless(flag)(error)"), "IO.raiseWhen(flag)(error)")
+  }
+
+  test("preserves complex receiver and argument expressions") {
+    assertEquals(
+      mutatedSyntax("cats.effect.IO.whenA(quantity > 10)(publish(quantity))"),
+      "cats.effect.IO.unlessA(quantity > 10)(publish(quantity))"
+    )
+  }
+
+  test("does not match unrelated method calls") {
+    assert(!mutator.matcher.isDefinedAt(parseTerm("IO.delay(publish)")))
+    assert(!mutator.matcher.isDefinedAt(parseTerm("someEffect.whenA(flag)")))
+  }
+
+  test("does not match a single-argument conditional helper call") {
+    assert(!mutator.matcher.isDefinedAt(parseTerm("IO.whenA(flag)")))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/ErrorHandlingMutatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/ErrorHandlingMutatorTest.scala
@@ -77,4 +77,30 @@ class ErrorHandlingMutatorTest extends munit.FunSuite {
   test("does not match a bare identifier") {
     assert(!mutator.matcher.isDefinedAt(parseTerm("someEffect")))
   }
+
+  test("does not match the bare selection of an applied combinator") {
+    // Guards against emitting a duplicate mutant for the inner Select of `effect.handleErrorWith(f)`.
+    // That mutant would drop only the selection and leave the argument list dangling, as in
+    // `IO(a / b)(_ => IO.pure(0))`, which cannot compile.
+    assert(!mutator.matcher.isDefinedAt(parseTerm("someEffect.handleErrorWith")))
+    assert(!mutator.matcher.isDefinedAt(parseTerm("someEffect.handleError")))
+    assert(!mutator.matcher.isDefinedAt(parseTerm("someEffect.recover")))
+    assert(!mutator.matcher.isDefinedAt(parseTerm("someEffect.recoverWith")))
+  }
+
+  test("does not match an applied no-argument combinator") {
+    // `attempt` and `rethrow` take no arguments, so an applied one is something else entirely.
+    assert(!mutator.matcher.isDefinedAt(parseTerm("someEffect.attempt(arg)")))
+    assert(!mutator.matcher.isDefinedAt(parseTerm("someEffect.rethrow(arg)")))
+  }
+
+  test("produces exactly one mutant for a whole applied combinator, keeping surrounding context") {
+    val statement = parseTerm("IO(a / b).handleErrorWith(_ => IO.pure(0)).map(double)")
+    val term = statement.collect { case t: Term if t.syntax == "IO(a / b).handleErrorWith(_ => IO.pure(0))" => t }.head
+
+    val Right(mutations) =
+      mutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(statement)): @unchecked
+    assertEquals(mutations.length, 1)
+    assertEquals(mutations.head.mutatedStatement.syntax, "IO(a / b).map(double)")
+  }
 }

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/ErrorHandlingMutatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/ErrorHandlingMutatorTest.scala
@@ -1,0 +1,81 @@
+package example
+
+import scala.meta.*
+
+/** Unit tests for [[ErrorHandlingMutator]]'s matcher logic, written first (TDD) before the mutator
+  * implementation. These test the `MutationMatcher` in isolation (parsing small snippets with
+  * scalameta, invoking the matcher directly) rather than running a full mutation-testing pass,
+  * mirroring the style of `stryker4s.mutatorapi.CustomMutatorTest`.
+  */
+class ErrorHandlingMutatorTest extends munit.FunSuite {
+  private val mutator = new ErrorHandlingMutator
+
+  private def parseTerm(code: String): Term =
+    code.parse[Term].get
+
+  test("matches .attempt and drops it, leaving the receiver expression") {
+    val term = parseTerm("someEffect.attempt")
+
+    assert(mutator.matcher.isDefinedAt(term))
+
+    val Right(mutations) = mutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(term)): @unchecked
+    assertEquals(mutations.length, 1)
+    assertEquals(mutations.head.metadata.mutatorName, "ErrorHandling")
+    assertEquals(mutations.head.mutatedStatement.syntax, "someEffect")
+  }
+
+  test("matches .handleErrorWith(f) and drops it, leaving the receiver expression") {
+    val term = parseTerm("someEffect.handleErrorWith(recover)")
+
+    assert(mutator.matcher.isDefinedAt(term))
+
+    val Right(mutations) = mutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(term)): @unchecked
+    assertEquals(mutations.length, 1)
+    assertEquals(mutations.head.mutatedStatement.syntax, "someEffect")
+  }
+
+  test("matches .handleError(f) and drops it, leaving the receiver expression") {
+    val term = parseTerm("someEffect.handleError(recover)")
+
+    assert(mutator.matcher.isDefinedAt(term))
+
+    val Right(mutations) = mutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(term)): @unchecked
+    assertEquals(mutations.head.mutatedStatement.syntax, "someEffect")
+  }
+
+  test("matches .recover(pf) and drops it, leaving the receiver expression") {
+    val term = parseTerm("someEffect.recover(pf)")
+
+    assert(mutator.matcher.isDefinedAt(term))
+
+    val Right(mutations) = mutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(term)): @unchecked
+    assertEquals(mutations.head.mutatedStatement.syntax, "someEffect")
+  }
+
+  test("matches .recoverWith(pf) and drops it, leaving the receiver expression") {
+    val term = parseTerm("someEffect.recoverWith(pf)")
+
+    assert(mutator.matcher.isDefinedAt(term))
+
+    val Right(mutations) = mutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(term)): @unchecked
+    assertEquals(mutations.head.mutatedStatement.syntax, "someEffect")
+  }
+
+  test("matches .rethrow and drops it, leaving the receiver expression") {
+    val term = parseTerm("someEffect.rethrow")
+
+    assert(mutator.matcher.isDefinedAt(term))
+
+    val Right(mutations) = mutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(term)): @unchecked
+    assertEquals(mutations.head.mutatedStatement.syntax, "someEffect")
+  }
+
+  test("does not match unrelated method calls") {
+    assert(!mutator.matcher.isDefinedAt(parseTerm("someEffect.map(f)")))
+    assert(!mutator.matcher.isDefinedAt(parseTerm("someEffect.flatMap(f)")))
+  }
+
+  test("does not match a bare identifier") {
+    assert(!mutator.matcher.isDefinedAt(parseTerm("someEffect")))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/ErrorHandlingMutatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/ErrorHandlingMutatorTest.scala
@@ -2,10 +2,9 @@ package example
 
 import scala.meta.*
 
-/** Unit tests for [[ErrorHandlingMutator]]'s matcher logic, written first (TDD) before the mutator
-  * implementation. These test the `MutationMatcher` in isolation (parsing small snippets with
-  * scalameta, invoking the matcher directly) rather than running a full mutation-testing pass,
-  * mirroring the style of `stryker4s.mutatorapi.CustomMutatorTest`.
+/** Unit tests for [[ErrorHandlingMutator]]'s matcher logic, written first (TDD) before the mutator implementation.
+  * These test the `MutationMatcher` in isolation (parsing small snippets with scalameta, invoking the matcher directly)
+  * rather than running a full mutation-testing pass, mirroring the style of `stryker4s.mutatorapi.CustomMutatorTest`.
   */
 class ErrorHandlingMutatorTest extends munit.FunSuite {
   private val mutator = new ErrorHandlingMutator

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/FallbackMutatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/FallbackMutatorTest.scala
@@ -1,0 +1,60 @@
+package example
+
+import scala.meta.*
+
+/** Unit tests for fallback-path mutators, written first (TDD) before the mutator implementations.
+  * These cover the high-feasibility cats-effect fallback shape `primary.orElse(fallback)`.
+  */
+class FallbackMutatorTest extends munit.FunSuite {
+  private val removalMutator = new FallbackRemovalMutator
+  private val inversionMutator = new FallbackInversionMutator
+
+  private def parseTerm(code: String): Term =
+    code.parse[Term].get
+
+  test("FallbackRemovalMutator drops .orElse(fallback), leaving the primary effect") {
+    val term = parseTerm("primary.orElse(fallback)")
+
+    assert(removalMutator.matcher.isDefinedAt(term))
+
+    val Right(mutations) =
+      removalMutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(term)): @unchecked
+    assertEquals(mutations.length, 1)
+    assertEquals(mutations.head.metadata.mutatorName, "FallbackRemoval")
+    assertEquals(mutations.head.mutatedStatement.syntax, "primary")
+  }
+
+  test("FallbackInversionMutator replaces primary.orElse(fallback) with fallback") {
+    val term = parseTerm("primary.orElse(fallback)")
+
+    assert(inversionMutator.matcher.isDefinedAt(term))
+
+    val Right(mutations) =
+      inversionMutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(term)): @unchecked
+    assertEquals(mutations.length, 1)
+    assertEquals(mutations.head.metadata.mutatorName, "FallbackInversion")
+    assertEquals(mutations.head.mutatedStatement.syntax, "fallback")
+  }
+
+  test("fallback mutators preserve complex receiver and fallback expressions") {
+    val term = parseTerm("primary.flatMap(next).orElse(makeFallback(value))")
+
+    val Right(removalMutations) =
+      removalMutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(term)): @unchecked
+    val Right(inversionMutations) =
+      inversionMutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(term)): @unchecked
+
+    assertEquals(removalMutations.head.mutatedStatement.syntax, "primary.flatMap(next)")
+    assertEquals(inversionMutations.head.mutatedStatement.syntax, "makeFallback(value)")
+  }
+
+  test("fallback mutators do not match unrelated method calls") {
+    assert(!removalMutator.matcher.isDefinedAt(parseTerm("primary.handleErrorWith(fallback)")))
+    assert(!inversionMutator.matcher.isDefinedAt(parseTerm("primary.map(f)")))
+  }
+
+  test("fallback mutators do not match .orElse without exactly one fallback argument") {
+    assert(!removalMutator.matcher.isDefinedAt(parseTerm("primary.orElse")))
+    assert(!inversionMutator.matcher.isDefinedAt(parseTerm("primary.orElse")))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/FallbackMutatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/FallbackMutatorTest.scala
@@ -2,8 +2,8 @@ package example
 
 import scala.meta.*
 
-/** Unit tests for fallback-path mutators, written first (TDD) before the mutator implementations.
-  * These cover the high-feasibility cats-effect fallback shape `primary.orElse(fallback)`.
+/** Unit tests for fallback-path mutators, written first (TDD) before the mutator implementations. These cover the
+  * high-feasibility cats-effect fallback shape `primary.orElse(fallback)`.
   */
 class FallbackMutatorTest extends munit.FunSuite {
   private val removalMutator = new FallbackRemovalMutator

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/GetOrElseMutatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/GetOrElseMutatorTest.scala
@@ -1,0 +1,68 @@
+package example
+
+import scala.meta.*
+
+/** Unit tests for [[GetOrElseMutator]], written first (TDD) before the mutator implementation. */
+class GetOrElseMutatorTest extends munit.FunSuite {
+  private val mutator = new GetOrElseMutator
+
+  private def parseTerm(code: String): Term =
+    code.parse[Term].get
+
+  private def mutate(code: String) = {
+    val term = parseTerm(code)
+    assert(mutator.matcher.isDefinedAt(term), s"expected matcher to be defined at: $code")
+    val Right(mutations) =
+      mutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(term)): @unchecked
+    mutations
+  }
+
+  test("GetOrElseMutator forces the default of a one-argument getOrElse") {
+    val mutations = mutate("maybeQuantity.getOrElse(0)")
+
+    assertEquals(mutations.length, 1)
+    assertEquals(mutations.head.metadata.mutatorName, "GetOrElse")
+    assertEquals(mutations.head.mutatedStatement.syntax, "0")
+  }
+
+  test("GetOrElseMutator forces the default of a two-argument Map getOrElse") {
+    val mutations = mutate("quantities.getOrElse(key, 0)")
+
+    assertEquals(mutations.head.mutatedStatement.syntax, "0")
+  }
+
+  test("GetOrElseMutator preserves a complex default expression") {
+    val mutations = mutate("lookup(id).getOrElse(fallbackFor(id))")
+
+    assertEquals(mutations.head.mutatedStatement.syntax, "fallbackFor(id)")
+  }
+
+  test("GetOrElseMutator handles the infix form") {
+    val mutations = mutate("maybeQuantity getOrElse 0")
+
+    assertEquals(mutations.head.mutatedStatement.syntax, "0")
+  }
+
+  test("GetOrElseMutator also covers getOrElseF") {
+    val mutations = mutate("maybeQuantity.getOrElseF(IO.pure(0))")
+
+    assertEquals(mutations.head.mutatedStatement.syntax, "IO.pure(0)")
+  }
+
+  test("GetOrElseMutator records the receiver-less default in its metadata") {
+    val mutations = mutate("maybeQuantity.getOrElse(0)")
+
+    assertEquals(mutations.head.metadata.original, "getOrElse")
+    assertEquals(mutations.head.metadata.replacement, "default")
+  }
+
+  test("GetOrElseMutator does not match unrelated combinators") {
+    assert(!mutator.matcher.isDefinedAt(parseTerm("maybeQuantity.orElse(other)")))
+    assert(!mutator.matcher.isDefinedAt(parseTerm("maybeQuantity.map(identity)")))
+  }
+
+  test("GetOrElseMutator does not match getOrElse with unexpected arity") {
+    assert(!mutator.matcher.isDefinedAt(parseTerm("quantities.getOrElse()")))
+    assert(!mutator.matcher.isDefinedAt(parseTerm("quantities.getOrElse(a, b, c)")))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/HeadLastSwapMutatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/HeadLastSwapMutatorTest.scala
@@ -1,0 +1,66 @@
+package example
+
+import scala.meta.*
+
+/** Unit tests for [[HeadLastSwapMutator]]'s matcher logic, written first (TDD) before the mutator implementation.
+  */
+class HeadLastSwapMutatorTest extends munit.FunSuite {
+  private val mutator = new HeadLastSwapMutator
+
+  private def parseTerm(code: String): Term =
+    code.parse[Term].get
+
+  private def mutate(code: String): String = {
+    val term = parseTerm(code)
+    val Right(mutations) = mutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(term)): @unchecked
+    assertEquals(mutations.length, 1)
+    assertEquals(mutations.head.metadata.mutatorName, "HeadLastSwap")
+    mutations.head.mutatedStatement.syntax
+  }
+
+  test("swaps .head for .last") {
+    assertEquals(mutate("discounts.head"), "discounts.last")
+  }
+
+  test("swaps .last for .head") {
+    assertEquals(mutate("discounts.last"), "discounts.head")
+  }
+
+  test("swaps .headOption for .lastOption") {
+    assertEquals(mutate("discounts.headOption"), "discounts.lastOption")
+  }
+
+  test("swaps .lastOption for .headOption") {
+    assertEquals(mutate("discounts.lastOption"), "discounts.headOption")
+  }
+
+  test("swaps .init for .tail") {
+    assertEquals(mutate("discounts.init"), "discounts.tail")
+  }
+
+  test("swaps .tail for .init") {
+    assertEquals(mutate("discounts.tail"), "discounts.init")
+  }
+
+  test("records the endpoint it swapped in the mutant metadata") {
+    val term = parseTerm("discounts.head")
+    val Right(mutations) = mutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(term)): @unchecked
+
+    assertEquals(mutations.head.metadata.original, "head")
+    assertEquals(mutations.head.metadata.replacement, "last")
+  }
+
+  test("keeps the statement surrounding the matched sub-term") {
+    val statement = parseTerm("discounts.sorted.head + 1")
+    val term = statement.collect { case t: Term if t.syntax == "discounts.sorted.head" => t }.head
+
+    val Right(mutations) = mutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(statement)): @unchecked
+    assertEquals(mutations.head.mutatedStatement.syntax, "discounts.sorted.last + 1")
+  }
+
+  test("does not match unrelated selections") {
+    assert(!mutator.matcher.isDefinedAt(parseTerm("discounts.header")))
+    assert(!mutator.matcher.isDefinedAt(parseTerm("discounts.map(process)")))
+    assert(!mutator.matcher.isDefinedAt(parseTerm("discounts")))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/ParallelSequentialSwapMutatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/ParallelSequentialSwapMutatorTest.scala
@@ -2,8 +2,7 @@ package example
 
 import scala.meta.*
 
-/** Unit tests for [[ParallelSequentialSwapMutator]], written first (TDD) before the mutator
-  * implementation.
+/** Unit tests for [[ParallelSequentialSwapMutator]], written first (TDD) before the mutator implementation.
   */
 class ParallelSequentialSwapMutatorTest extends munit.FunSuite {
   private val mutator = new ParallelSequentialSwapMutator

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/ParallelSequentialSwapMutatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/ParallelSequentialSwapMutatorTest.scala
@@ -1,0 +1,79 @@
+package example
+
+import scala.meta.*
+
+/** Unit tests for [[ParallelSequentialSwapMutator]], written first (TDD) before the mutator
+  * implementation.
+  */
+class ParallelSequentialSwapMutatorTest extends munit.FunSuite {
+  private val mutator = new ParallelSequentialSwapMutator
+
+  private def parseTerm(code: String): Term =
+    code.parse[Term].get
+
+  private def mutate(code: String) = {
+    val term = parseTerm(code)
+    assert(mutator.matcher.isDefinedAt(term), s"expected matcher to be defined at: $code")
+    val Right(mutations) =
+      mutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(term)): @unchecked
+    mutations
+  }
+
+  test("ParallelSequentialSwapMutator makes traverse parallel") {
+    val mutations = mutate("orders.traverse(process)")
+
+    assertEquals(mutations.length, 1)
+    assertEquals(mutations.head.metadata.mutatorName, "ParallelSequentialSwap")
+    assertEquals(mutations.head.mutatedStatement.syntax, "orders.parTraverse(process)")
+  }
+
+  test("ParallelSequentialSwapMutator makes parTraverse sequential") {
+    val mutations = mutate("orders.parTraverse(process)")
+
+    assertEquals(mutations.head.mutatedStatement.syntax, "orders.traverse(process)")
+  }
+
+  test("ParallelSequentialSwapMutator swaps the result-discarding variants") {
+    assertEquals(mutate("orders.traverse_(process)").head.mutatedStatement.syntax, "orders.parTraverse_(process)")
+    assertEquals(mutate("orders.parTraverse_(process)").head.mutatedStatement.syntax, "orders.traverse_(process)")
+  }
+
+  test("ParallelSequentialSwapMutator swaps flatTraverse") {
+    assertEquals(
+      mutate("orders.flatTraverse(process)").head.mutatedStatement.syntax,
+      "orders.parFlatTraverse(process)"
+    )
+  }
+
+  test("ParallelSequentialSwapMutator swaps mapN") {
+    assertEquals(mutate("(a, b).mapN(combine)").head.mutatedStatement.syntax, "(a, b).parMapN(combine)")
+    assertEquals(mutate("(a, b).parMapN(combine)").head.mutatedStatement.syntax, "(a, b).mapN(combine)")
+  }
+
+  test("ParallelSequentialSwapMutator swaps the no-argument sequence combinators") {
+    assertEquals(mutate("effects.sequence").head.mutatedStatement.syntax, "effects.parSequence")
+    assertEquals(mutate("effects.parSequence").head.mutatedStatement.syntax, "effects.sequence")
+    assertEquals(mutate("effects.sequence_").head.mutatedStatement.syntax, "effects.parSequence_")
+  }
+
+  test("ParallelSequentialSwapMutator records both directions in its metadata") {
+    val toParallel = mutate("orders.traverse(process)").head.metadata
+    assertEquals(toParallel.original, "traverse")
+    assertEquals(toParallel.replacement, "parTraverse")
+  }
+
+  test("ParallelSequentialSwapMutator does not match an applied sequence combinator") {
+    // `sequence` takes no arguments, so an applied one is something else entirely.
+    assert(!mutator.matcher.isDefinedAt(parseTerm("effects.sequence(arg)")))
+  }
+
+  test("ParallelSequentialSwapMutator does not match a bare traverse selection") {
+    // Guards against emitting a duplicate mutant for the inner Select of `xs.traverse(f)`.
+    assert(!mutator.matcher.isDefinedAt(parseTerm("orders.traverse")))
+  }
+
+  test("ParallelSequentialSwapMutator does not match unrelated combinators") {
+    assert(!mutator.matcher.isDefinedAt(parseTerm("orders.map(process)")))
+    assert(!mutator.matcher.isDefinedAt(parseTerm("orders.parallelism")))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/RefUpdateMutatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/RefUpdateMutatorTest.scala
@@ -1,0 +1,66 @@
+package example
+
+import scala.meta.*
+
+/** Unit tests for [[RefUpdateMutator]], written first (TDD) before the mutator implementation. */
+class RefUpdateMutatorTest extends munit.FunSuite {
+  private val mutator = new RefUpdateMutator
+
+  private def parseTerm(code: String): Term =
+    code.parse[Term].get
+
+  private def mutate(code: String) = {
+    val term = parseTerm(code)
+    assert(mutator.matcher.isDefinedAt(term), s"expected matcher to be defined at: $code")
+    val Right(mutations) =
+      mutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(term)): @unchecked
+    mutations
+  }
+
+  test("RefUpdateMutator neutralises update with identity") {
+    val mutations = mutate("counter.update(_ + 1)")
+
+    assertEquals(mutations.length, 1)
+    assertEquals(mutations.head.metadata.mutatorName, "RefUpdate")
+    assertEquals(mutations.head.mutatedStatement.syntax, "counter.update(identity)")
+  }
+
+  test("RefUpdateMutator neutralises updateAndGet and getAndUpdate") {
+    assertEquals(mutate("counter.updateAndGet(_ + 1)").head.mutatedStatement.syntax, "counter.updateAndGet(identity)")
+    assertEquals(mutate("counter.getAndUpdate(_ + 1)").head.mutatedStatement.syntax, "counter.getAndUpdate(identity)")
+  }
+
+  test("RefUpdateMutator neutralises a named function argument") {
+    val mutations = mutate("counter.update(increment)")
+
+    assertEquals(mutations.head.mutatedStatement.syntax, "counter.update(identity)")
+  }
+
+  test("RefUpdateMutator preserves a complex receiver") {
+    val mutations = mutate("state.counters(key).update(_ + 1)")
+
+    assertEquals(mutations.head.mutatedStatement.syntax, "state.counters(key).update(identity)")
+  }
+
+  test("RefUpdateMutator records the neutralised update in its metadata") {
+    val metadata = mutate("counter.update(_ + 1)").head.metadata
+
+    assertEquals(metadata.original, "update")
+    assertEquals(metadata.replacement, "identity")
+  }
+
+  test("RefUpdateMutator does not match an update that is already identity") {
+    // Would be an equivalent mutant, so it is skipped rather than reported as survived.
+    assert(!mutator.matcher.isDefinedAt(parseTerm("counter.update(identity)")))
+  }
+
+  test("RefUpdateMutator does not match a two-argument update") {
+    // e.g. mutable sequence `xs.update(index, value)`, which has no identity form.
+    assert(!mutator.matcher.isDefinedAt(parseTerm("buffer.update(0, value)")))
+  }
+
+  test("RefUpdateMutator does not match unrelated combinators") {
+    assert(!mutator.matcher.isDefinedAt(parseTerm("counter.modify(_ + 1)")))
+    assert(!mutator.matcher.isDefinedAt(parseTerm("counter.set(1)")))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/ResourceFinalizerMutatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/ResourceFinalizerMutatorTest.scala
@@ -2,8 +2,7 @@ package example
 
 import scala.meta.*
 
-/** Unit tests for [[ResourceFinalizerMutator]], written first (TDD) before the mutator
-  * implementation.
+/** Unit tests for [[ResourceFinalizerMutator]], written first (TDD) before the mutator implementation.
   */
 class ResourceFinalizerMutatorTest extends munit.FunSuite {
   private val mutator = new ResourceFinalizerMutator

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/ResourceFinalizerMutatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/ResourceFinalizerMutatorTest.scala
@@ -1,0 +1,78 @@
+package example
+
+import scala.meta.*
+
+/** Unit tests for [[ResourceFinalizerMutator]], written first (TDD) before the mutator
+  * implementation.
+  */
+class ResourceFinalizerMutatorTest extends munit.FunSuite {
+  private val mutator = new ResourceFinalizerMutator
+
+  private def parseTerm(code: String): Term =
+    code.parse[Term].get
+
+  private def mutate(code: String) = {
+    val term = parseTerm(code)
+    assert(mutator.matcher.isDefinedAt(term), s"expected matcher to be defined at: $code")
+    val Right(mutations) =
+      mutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(term)): @unchecked
+    mutations
+  }
+
+  test("ResourceFinalizerMutator drops the release of Resource.make") {
+    val mutations = mutate("Resource.make(openFile)(closeFile)")
+
+    assertEquals(mutations.length, 1)
+    assertEquals(mutations.head.metadata.mutatorName, "ResourceFinalizer")
+    assertEquals(mutations.head.mutatedStatement.syntax, "Resource.eval(openFile)")
+  }
+
+  test("ResourceFinalizerMutator drops the release of Resource.makeCase") {
+    val mutations = mutate("Resource.makeCase(openFile)((f, _) => closeFile(f))")
+
+    assertEquals(mutations.head.mutatedStatement.syntax, "Resource.eval(openFile)")
+  }
+
+  test("ResourceFinalizerMutator handles a qualified Resource reference") {
+    val mutations = mutate("cats.effect.Resource.make(openFile)(closeFile)")
+
+    assertEquals(mutations.head.mutatedStatement.syntax, "cats.effect.Resource.eval(openFile)")
+  }
+
+  test("ResourceFinalizerMutator turns bracket into a plain flatMap") {
+    val mutations = mutate("openFile.bracket(useFile)(closeFile)")
+
+    assertEquals(mutations.head.mutatedStatement.syntax, "openFile.flatMap(useFile)")
+  }
+
+  test("ResourceFinalizerMutator turns bracketCase into a plain flatMap") {
+    val mutations = mutate("openFile.bracketCase(useFile)((f, _) => closeFile(f))")
+
+    assertEquals(mutations.head.mutatedStatement.syntax, "openFile.flatMap(useFile)")
+  }
+
+  test("ResourceFinalizerMutator removes guarantee, leaving the receiver") {
+    assertEquals(mutate("work.guarantee(cleanup)").head.mutatedStatement.syntax, "work")
+    assertEquals(mutate("work.guaranteeCase(cleanup)").head.mutatedStatement.syntax, "work")
+    assertEquals(mutate("work.onCancel(cleanup)").head.mutatedStatement.syntax, "work")
+  }
+
+  test("ResourceFinalizerMutator records the dropped finalizer in its metadata") {
+    assertEquals(mutate("work.guarantee(cleanup)").head.metadata.original, "guarantee")
+    assertEquals(mutate("Resource.make(openFile)(closeFile)").head.metadata.original, "make")
+  }
+
+  test("ResourceFinalizerMutator does not match a make on an unrelated companion") {
+    assert(!mutator.matcher.isDefinedAt(parseTerm("Widget.make(a)(b)")))
+  }
+
+  test("ResourceFinalizerMutator does not match Resource.eval or Resource.pure") {
+    assert(!mutator.matcher.isDefinedAt(parseTerm("Resource.eval(openFile)")))
+    assert(!mutator.matcher.isDefinedAt(parseTerm("Resource.pure(value)")))
+  }
+
+  test("ResourceFinalizerMutator does not match unrelated combinators") {
+    assert(!mutator.matcher.isDefinedAt(parseTerm("work.flatMap(next)")))
+    assert(!mutator.matcher.isDefinedAt(parseTerm("work.guaranteed")))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/SequencingMutatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/SequencingMutatorTest.scala
@@ -2,8 +2,8 @@ package example
 
 import scala.meta.*
 
-/** Unit tests for cats-effect sequencing mutators, written first (TDD) before the mutator
-  * implementations. These cover the common effect-sequencing operators `*>` and `<*`.
+/** Unit tests for cats-effect sequencing mutators, written first (TDD) before the mutator implementations. These cover
+  * the common effect-sequencing operators `*>` and `<*`.
   */
 class SequencingMutatorTest extends munit.FunSuite {
   private val swapMutator = new SequencingSwapMutator

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/SequencingMutatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/SequencingMutatorTest.scala
@@ -1,0 +1,75 @@
+package example
+
+import scala.meta.*
+
+/** Unit tests for cats-effect sequencing mutators, written first (TDD) before the mutator
+  * implementations. These cover the common effect-sequencing operators `*>` and `<*`.
+  */
+class SequencingMutatorTest extends munit.FunSuite {
+  private val swapMutator = new SequencingSwapMutator
+  private val removalMutator = new SequencingRemovalMutator
+
+  private def parseTerm(code: String): Term =
+    code.parse[Term].get
+
+  test("SequencingSwapMutator flips fa *> fb to fa <* fb") {
+    val term = parseTerm("first *> second")
+
+    assert(swapMutator.matcher.isDefinedAt(term))
+
+    val Right(mutations) =
+      swapMutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(term)): @unchecked
+    assertEquals(mutations.length, 1)
+    assertEquals(mutations.head.metadata.mutatorName, "SequencingSwap")
+    assertEquals(mutations.head.mutatedStatement.syntax, "first <* second")
+  }
+
+  test("SequencingSwapMutator flips fa <* fb to fa *> fb") {
+    val term = parseTerm("first <* second")
+
+    assert(swapMutator.matcher.isDefinedAt(term))
+
+    val Right(mutations) =
+      swapMutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(term)): @unchecked
+    assertEquals(mutations.head.mutatedStatement.syntax, "first *> second")
+  }
+
+  test("SequencingRemovalMutator removes the discarded side from fa *> fb") {
+    val term = parseTerm("first *> second")
+
+    assert(removalMutator.matcher.isDefinedAt(term))
+
+    val Right(mutations) =
+      removalMutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(term)): @unchecked
+    assertEquals(mutations.length, 1)
+    assertEquals(mutations.head.metadata.mutatorName, "SequencingRemoval")
+    assertEquals(mutations.head.mutatedStatement.syntax, "second")
+  }
+
+  test("SequencingRemovalMutator removes the discarded side from fa <* fb") {
+    val term = parseTerm("first <* second")
+
+    assert(removalMutator.matcher.isDefinedAt(term))
+
+    val Right(mutations) =
+      removalMutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(term)): @unchecked
+    assertEquals(mutations.head.mutatedStatement.syntax, "first")
+  }
+
+  test("sequencing mutators preserve complex left and right expressions") {
+    val term = parseTerm("validate(value) *> persist(value)")
+
+    val Right(swapMutations) =
+      swapMutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(term)): @unchecked
+    val Right(removalMutations) =
+      removalMutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(term)): @unchecked
+
+    assertEquals(swapMutations.head.mutatedStatement.syntax, "validate(value) <* persist(value)")
+    assertEquals(removalMutations.head.mutatedStatement.syntax, "persist(value)")
+  }
+
+  test("sequencing mutators do not match unrelated infix operators") {
+    assert(!swapMutator.matcher.isDefinedAt(parseTerm("first + second")))
+    assert(!removalMutator.matcher.isDefinedAt(parseTerm("first orElse second")))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/SleepRemovalMutatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/SleepRemovalMutatorTest.scala
@@ -1,0 +1,60 @@
+package example
+
+import scala.meta.*
+
+/** Unit tests for [[SleepRemovalMutator]], written first (TDD) before the mutator implementation. */
+class SleepRemovalMutatorTest extends munit.FunSuite {
+  private val mutator = new SleepRemovalMutator
+
+  private def parseTerm(code: String): Term =
+    code.parse[Term].get
+
+  private def mutate(code: String) = {
+    val term = parseTerm(code)
+    assert(mutator.matcher.isDefinedAt(term), s"expected matcher to be defined at: $code")
+    val Right(mutations) =
+      mutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(term)): @unchecked
+    mutations
+  }
+
+  test("SleepRemovalMutator turns IO.sleep into IO.unit") {
+    val mutations = mutate("IO.sleep(backoff)")
+
+    assertEquals(mutations.length, 1)
+    assertEquals(mutations.head.metadata.mutatorName, "SleepRemoval")
+    assertEquals(mutations.head.mutatedStatement.syntax, "IO.unit")
+  }
+
+  test("SleepRemovalMutator preserves the effect qualifier") {
+    assertEquals(mutate("Temporal[F].sleep(backoff)").head.mutatedStatement.syntax, "Temporal[F].unit")
+    assertEquals(mutate("cats.effect.IO.sleep(backoff)").head.mutatedStatement.syntax, "cats.effect.IO.unit")
+  }
+
+  test("SleepRemovalMutator removes delayBy, leaving the receiver") {
+    assertEquals(mutate("publish.delayBy(backoff)").head.mutatedStatement.syntax, "publish")
+  }
+
+  test("SleepRemovalMutator removes andWait, leaving the receiver") {
+    assertEquals(mutate("publish.andWait(backoff)").head.mutatedStatement.syntax, "publish")
+  }
+
+  test("SleepRemovalMutator records the removed delay in its metadata") {
+    assertEquals(mutate("IO.sleep(backoff)").head.metadata.original, "sleep")
+    assertEquals(mutate("publish.delayBy(backoff)").head.metadata.original, "delayBy")
+  }
+
+  test("SleepRemovalMutator does not match Thread.sleep") {
+    // Thread has no `unit`, so this would only ever be a compile error.
+    assert(!mutator.matcher.isDefinedAt(parseTerm("Thread.sleep(1000)")))
+  }
+
+  test("SleepRemovalMutator does not match sleep with unexpected arity") {
+    assert(!mutator.matcher.isDefinedAt(parseTerm("IO.sleep()")))
+    assert(!mutator.matcher.isDefinedAt(parseTerm("IO.sleep(a, b)")))
+  }
+
+  test("SleepRemovalMutator does not match unrelated combinators") {
+    assert(!mutator.matcher.isDefinedAt(parseTerm("IO.pure(value)")))
+    assert(!mutator.matcher.isDefinedAt(parseTerm("publish.timeout(backoff)")))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/StringNormalizationMutatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/StringNormalizationMutatorTest.scala
@@ -1,0 +1,80 @@
+package example
+
+import scala.meta.*
+
+/** Unit tests for [[StringNormalizationMutator]]'s matcher logic, written first (TDD) before the mutator
+  * implementation.
+  */
+class StringNormalizationMutatorTest extends munit.FunSuite {
+  private val mutator = new StringNormalizationMutator
+
+  private def parseTerm(code: String): Term =
+    code.parse[Term].get
+
+  private def mutate(code: String): String = {
+    val term = parseTerm(code)
+    val Right(mutations) = mutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(term)): @unchecked
+    assertEquals(mutations.length, 1)
+    assertEquals(mutations.head.metadata.mutatorName, "StringNormalization")
+    mutations.head.mutatedStatement.syntax
+  }
+
+  test("drops .trim, leaving the unnormalized receiver") {
+    assertEquals(mutate("code.trim"), "code")
+  }
+
+  test("drops .strip") {
+    assertEquals(mutate("code.strip"), "code")
+  }
+
+  test("drops .toLowerCase") {
+    assertEquals(mutate("code.toLowerCase"), "code")
+  }
+
+  test("drops .toUpperCase") {
+    assertEquals(mutate("code.toUpperCase"), "code")
+  }
+
+  test("drops .capitalize") {
+    assertEquals(mutate("code.capitalize"), "code")
+  }
+
+  test("drops .stripPrefix(p)") {
+    assertEquals(mutate("code.stripPrefix(prefix)"), "code")
+  }
+
+  test("drops .stripSuffix(s)") {
+    assertEquals(mutate("code.stripSuffix(suffix)"), "code")
+  }
+
+  test("keeps the statement surrounding the matched sub-term") {
+    val statement = parseTerm("code.trim.toUpperCase")
+    val term = statement.collect { case t: Term if t.syntax == "code.trim" => t }.head
+
+    val Right(mutations) = mutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(statement)): @unchecked
+    assertEquals(mutations.head.mutatedStatement.syntax, "code.toUpperCase")
+  }
+
+  test("does not match the selection a stripping combinator is applied to") {
+    val statement = parseTerm("code.stripPrefix(prefix)")
+    val select = statement.collect { case t: Term.Select => t }.head
+
+    assert(!mutator.matcher.isDefinedAt(select))
+  }
+
+  test("does not match a no-argument combinator that is being applied") {
+    // `toLowerCase` also has a `Locale` overload; dropping the selection of `code.toLowerCase(locale)`
+    // would leave `code(locale)`.
+    val statement = parseTerm("code.toLowerCase(locale)")
+    val select = statement.collect { case t: Term.Select => t }.head
+
+    assert(!mutator.matcher.isDefinedAt(select))
+    assert(!mutator.matcher.isDefinedAt(statement))
+  }
+
+  test("does not match unrelated combinators") {
+    assert(!mutator.matcher.isDefinedAt(parseTerm("code.length")))
+    assert(!mutator.matcher.isDefinedAt(parseTerm("code.trimmed")))
+    assert(!mutator.matcher.isDefinedAt(parseTerm("code")))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/TimeoutMutatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/TimeoutMutatorTest.scala
@@ -2,8 +2,8 @@ package example
 
 import scala.meta.*
 
-/** Unit tests for the cats-effect timeout mutator, written first (TDD) before the mutator
-  * implementation. These cover the `timeout`, `timeoutTo` and `timeoutAndForget` combinators.
+/** Unit tests for the cats-effect timeout mutator, written first (TDD) before the mutator implementation. These cover
+  * the `timeout`, `timeoutTo` and `timeoutAndForget` combinators.
   */
 class TimeoutMutatorTest extends munit.FunSuite {
   private val mutator = new TimeoutRemovalMutator

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/TimeoutMutatorTest.scala
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/src/test/scala/example/TimeoutMutatorTest.scala
@@ -1,0 +1,64 @@
+package example
+
+import scala.meta.*
+
+/** Unit tests for the cats-effect timeout mutator, written first (TDD) before the mutator
+  * implementation. These cover the `timeout`, `timeoutTo` and `timeoutAndForget` combinators.
+  */
+class TimeoutMutatorTest extends munit.FunSuite {
+  private val mutator = new TimeoutRemovalMutator
+
+  private def parseTerm(code: String): Term =
+    code.parse[Term].get
+
+  private def mutate(code: String) = {
+    val term = parseTerm(code)
+    assert(mutator.matcher.isDefinedAt(term), s"expected matcher to be defined at: $code")
+    val Right(mutations) =
+      mutator.matcher(term)(stryker4s.mutatorapi.PlaceableTree(term)): @unchecked
+    mutations
+  }
+
+  test("TimeoutRemovalMutator removes .timeout, keeping the receiver") {
+    val mutations = mutate("fetch.timeout(5.seconds)")
+
+    assertEquals(mutations.length, 1)
+    assertEquals(mutations.head.metadata.mutatorName, "TimeoutRemoval")
+    assertEquals(mutations.head.mutatedStatement.syntax, "fetch")
+  }
+
+  test("TimeoutRemovalMutator removes .timeoutTo, discarding the fallback") {
+    val mutations = mutate("fetch.timeoutTo(5.seconds, IO.pure(0))")
+
+    assertEquals(mutations.head.metadata.mutatorName, "TimeoutRemoval")
+    assertEquals(mutations.head.mutatedStatement.syntax, "fetch")
+  }
+
+  test("TimeoutRemovalMutator removes .timeoutAndForget") {
+    val mutations = mutate("fetch.timeoutAndForget(5.seconds)")
+
+    assertEquals(mutations.head.mutatedStatement.syntax, "fetch")
+  }
+
+  test("TimeoutRemovalMutator preserves a complex receiver expression") {
+    val mutations = mutate("client.get(url).flatMap(parse).timeout(5.seconds)")
+
+    assertEquals(mutations.head.mutatedStatement.syntax, "client.get(url).flatMap(parse)")
+  }
+
+  test("TimeoutRemovalMutator records the removed combinator in its metadata") {
+    val mutations = mutate("fetch.timeoutTo(5.seconds, IO.pure(0))")
+
+    assertEquals(mutations.head.metadata.original, "timeoutTo")
+  }
+
+  test("TimeoutRemovalMutator does not match unrelated combinators") {
+    assert(!mutator.matcher.isDefinedAt(parseTerm("fetch.orElse(fallback)")))
+    assert(!mutator.matcher.isDefinedAt(parseTerm("fetch.handleErrorWith(recover)")))
+  }
+
+  test("TimeoutRemovalMutator does not match timeout combinators with unexpected arity") {
+    assert(!mutator.matcher.isDefinedAt(parseTerm("fetch.timeout(5.seconds, extra)")))
+    assert(!mutator.matcher.isDefinedAt(parseTerm("fetch.timeoutTo(5.seconds)")))
+  }
+}

--- a/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/test
+++ b/modules/sbt/src/sbt-test/sbt-stryker4s/test-custom-mutator/test
@@ -1,0 +1,2 @@
+> stryker
+$ exec bash check-report.sh

--- a/project/MillScripted.scala
+++ b/project/MillScripted.scala
@@ -74,6 +74,25 @@ object MillScripted {
       "Expected a threshold-break message when the score is below the configured break threshold"
     )
 
+    // Scenario 3: custom mutators. `bar` registers bar.ArithmeticOperatorMutator via
+    // strykerCustomMutators, and should kill both of its mutants (100% score, since strykerMutate
+    // is scoped to just Calc.scala) and write them to the JSON report.
+    val (exit3, out3) = runMill("bar.stryker")
+    assert(exit3 == 0, s"Expected 'bar.stryker' to succeed, but it exited with $exit3")
+    assert(out3.contains("2 mutant(s) generated"), "Expected the custom mutator's 2 mutants to be generated")
+    val reportDir = mutate / "bar" / "target" / "stryker4s-report"
+    val reportJson = IO.listFiles(reportDir).flatMap(dir => IO.listFiles(dir)).find(_.getName == "report.json")
+    assert(reportJson.isDefined, s"Expected a report.json to be written under $reportDir")
+    val reportContents = IO.read(reportJson.get)
+    assert(
+      reportContents.contains("ArithmeticOperator"),
+      "Expected the JSON report to contain mutants produced by the custom ArithmeticOperatorMutator"
+    )
+    assert(
+      !reportContents.contains("\"status\":\"Survived\""),
+      "Expected both custom mutants to be killed by the test suite"
+    )
+
     log.info("Mill plugin integration test passed")
   }
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -118,6 +118,14 @@ object Settings {
     )
   )
 
+  lazy val mutatorApiSettings: Seq[Setting[?]] = Seq(
+    moduleName := "stryker4s-mutator-api",
+    libraryDependencies ++= Seq(
+      Dependencies.catsCore,
+      Dependencies.scalameta
+    ) ++ Dependencies.mutationTestingMetrics
+  )
+
   lazy val testkitSettings: Seq[Setting[?]] = Seq(
     moduleName := "stryker4s-testkit",
     libraryDependencies ++= Seq(


### PR DESCRIPTION
## Summary

Adds a public extension point for project-defined mutation operators. Users can configure fully qualified `CustomMutator` class names alongside Stryker4s built-ins.

- publishes a lightweight, cross-built `stryker4s-mutator-api` SPI artifact
- loads custom mutators from the target project classpath in sbt, Mill, and Maven
- combines custom matcher results with built-in matcher results rather than short-circuiting either
- supports configuration through CLI, HOCON, sbt, Mill, and Maven
- documents the SPI and configuration, with end-to-end sbt and Mill examples

The examples include generic arithmetic/collection mutations and Cats/Cats Effect cases such as error handling, timeouts, conditional effects, traversal parallelism, finalizers, and sequencing.

## Validation

- `./bin/scalafmt --test`
- `sbt 'compile; ...@scalaBinaryVersion=3/test'` (494 tests)\n\n## Notes\n\nCustom mutators must expose a public no-argument constructor and be compiled against the same Stryker4s release. Build-tool runners use a parent-first classloader so the user mutator can load from the target project while the SPI retains one JVM class identity.